### PR TITLE
[UNI-38] feat: 초기 지도 컴포넌트 및 훅 생성

### DIFF
--- a/uniro_frontend/package-lock.json
+++ b/uniro_frontend/package-lock.json
@@ -12,6 +12,7 @@
 				"@tailwindcss/vite": "^4.0.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
+				"react-router": "^7.1.3",
 				"tailwindcss": "^4.0.0"
 			},
 			"devDependencies": {
@@ -1562,6 +1563,12 @@
 				"@babel/types": "^7.20.7"
 			}
 		},
+		"node_modules/@types/cookie": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2269,6 +2276,15 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/cookie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -4720,6 +4736,30 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-router": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.3.tgz",
+			"integrity": "sha512-EezYymLY6Guk/zLQ2vRA8WvdUhWFEj5fcE3RfWihhxXBW7+cd1LsIiA3lmx+KCmneAGQuyBv820o44L2+TtkSA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/cookie": "^0.6.0",
+				"cookie": "^1.0.1",
+				"set-cookie-parser": "^2.6.0",
+				"turbo-stream": "2.4.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=18",
+				"react-dom": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/reflect.getprototypeof": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -4938,6 +4978,12 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
+		},
+		"node_modules/set-cookie-parser": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+			"license": "MIT"
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
@@ -5297,6 +5343,12 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
+		},
+		"node_modules/turbo-stream": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+			"integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+			"license": "ISC"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",

--- a/uniro_frontend/package-lock.json
+++ b/uniro_frontend/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "uniro_frontend",
 			"version": "0.0.0",
 			"dependencies": {
+				"@googlemaps/js-api-loader": "^1.16.8",
 				"@tailwindcss/vite": "^4.0.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -15,6 +16,7 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.17.0",
+				"@types/google.maps": "^3.58.1",
 				"@types/react": "^18.3.18",
 				"@types/react-dom": "^18.3.5",
 				"@vitejs/plugin-react": "^4.3.4",
@@ -868,6 +870,12 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
+		"node_modules/@googlemaps/js-api-loader": {
+			"version": "1.16.8",
+			"resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+			"integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1558,6 +1566,13 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/google.maps": {
+			"version": "3.58.1",
+			"resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+			"integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {

--- a/uniro_frontend/package.json
+++ b/uniro_frontend/package.json
@@ -14,6 +14,7 @@
 		"@tailwindcss/vite": "^4.0.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
+		"react-router": "^7.1.3",
 		"tailwindcss": "^4.0.0"
 	},
 	"devDependencies": {

--- a/uniro_frontend/package.json
+++ b/uniro_frontend/package.json
@@ -10,6 +10,7 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
+		"@googlemaps/js-api-loader": "^1.16.8",
 		"@tailwindcss/vite": "^4.0.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
@@ -17,6 +18,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.17.0",
+		"@types/google.maps": "^3.58.1",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",
 		"@vitejs/plugin-react": "^4.3.4",

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -27,7 +27,6 @@ function App() {
 			<div className="h-[500px] w-[500px]">
 				<Map />
 			</div>
-			
 			<p className="read-the-docs">Click on the Vite and React logos to learn more</p>
 		</>
 	);

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
 import "./App.css";
+import Map from "./component/Map";
 
 function App() {
 	const [count, setCount] = useState(0);
@@ -23,6 +24,10 @@ function App() {
 				<p>한글</p>
 				<p>English</p>
 			</div>
+			<div className="h-[500px] w-[500px]">
+				<Map />
+			</div>
+			
 			<p className="read-the-docs">Click on the Vite and React logos to learn more</p>
 		</>
 	);

--- a/uniro_frontend/src/component/Map.tsx
+++ b/uniro_frontend/src/component/Map.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect, useRef } from 'react'
-import useMap from '../hooks/useMap'
+import React, { useEffect, useRef } from "react";
+import useMap from "../hooks/useMap";
 
 const Map = () => {
+	const { mapRef } = useMap();
 
-    const {mapRef} = useMap();
-    
-    return (
-        <div id="map" ref={mapRef} style={{ width: "100%", height: "100%" }}></div>
-    )
-}
+	return <div id="map" ref={mapRef} style={{ width: "100%", height: "100%" }}></div>;
+};
 
-export default Map
+export default Map;

--- a/uniro_frontend/src/component/Map.tsx
+++ b/uniro_frontend/src/component/Map.tsx
@@ -1,0 +1,13 @@
+import React, { useEffect, useRef } from 'react'
+import useMap from '../hooks/useMap'
+
+const Map = () => {
+
+    const {mapRef} = useMap();
+    
+    return (
+        <div id="map" ref={mapRef} style={{ width: "100%", height: "100%" }}></div>
+    )
+}
+
+export default Map

--- a/uniro_frontend/src/constant/bounds.ts
+++ b/uniro_frontend/src/constant/bounds.ts
@@ -1,0 +1,13 @@
+interface Bounds {
+    north: number;
+    south: number;
+    east: number;
+    west: number;
+}
+
+export const HanyangUniversityBounds : Bounds = {
+    north: 37.560645,
+    south: 37.552997,
+    east: 127.051049,
+    west: 127.041110,
+};

--- a/uniro_frontend/src/constant/bounds.ts
+++ b/uniro_frontend/src/constant/bounds.ts
@@ -1,13 +1,13 @@
 interface Bounds {
-    north: number;
-    south: number;
-    east: number;
-    west: number;
+	north: number;
+	south: number;
+	east: number;
+	west: number;
 }
 
-export const HanyangUniversityBounds : Bounds = {
-    north: 37.560645,
-    south: 37.552997,
-    east: 127.051049,
-    west: 127.041110,
+export const HanyangUniversityBounds: Bounds = {
+	north: 37.560645,
+	south: 37.552997,
+	east: 127.051049,
+	west: 127.04111,
 };

--- a/uniro_frontend/src/constant/university.ts
+++ b/uniro_frontend/src/constant/university.ts
@@ -1,0 +1,9 @@
+interface Coordinate {
+    lat: number;
+    lng: number;
+}
+
+export const HanyangUniversity : Coordinate = {
+    lat: 37.558056,
+    lng: 127.045833,
+};

--- a/uniro_frontend/src/constant/university.ts
+++ b/uniro_frontend/src/constant/university.ts
@@ -1,9 +1,9 @@
 interface Coordinate {
-    lat: number;
-    lng: number;
+	lat: number;
+	lng: number;
 }
 
-export const HanyangUniversity : Coordinate = {
-    lat: 37.558056,
-    lng: 127.045833,
+export const HanyangUniversity: Coordinate = {
+	lat: 37.558056,
+	lng: 127.045833,
 };

--- a/uniro_frontend/src/hooks/useMap.tsx
+++ b/uniro_frontend/src/hooks/useMap.tsx
@@ -1,42 +1,40 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { initializeMap } from '../map/initializer/googleMapInitializer';
-
+import React, { useEffect, useRef, useState } from "react";
+import { initializeMap } from "../map/initializer/googleMapInitializer";
 
 const useMap = () => {
+	const mapRef = useRef<HTMLDivElement>(null);
+	const [map, setMap] = useState<google.maps.Map | null>(null);
+	const [overlay, setOverlay] = useState<google.maps.OverlayView | null>(null);
+	const [AdvancedMarker, setAdvancedMarker] = useState<typeof google.maps.marker.AdvancedMarkerElement | null>(null);
+	const [Polyline, setPolyline] = useState<typeof google.maps.Polyline | null>(null);
+	const [mapLoaded, setMapLoaded] = useState<boolean>(false);
 
-    const mapRef = useRef<HTMLDivElement>(null);
-    const [map, setMap] = useState<google.maps.Map | null>(null);
-    const [overlay, setOverlay] = useState<google.maps.OverlayView | null>(null);
-    const [AdvancedMarker, setAdvancedMarker] = useState<typeof google.maps.marker.AdvancedMarkerElement | null>(null);
-    const [Polyline, setPolyline] = useState<typeof google.maps.Polyline | null>(null);
-    const [mapLoaded, setMapLoaded] = useState<boolean>(false);
+	useEffect(() => {
+		if (!mapRef.current) return;
 
-    useEffect(() => {
-        if (!mapRef.current) return;
-    
-        const initMap = async () => {
-          try {
-            const { map, overlay, AdvancedMarkerElement, Polyline  } = await initializeMap(mapRef.current);
-            setMap(map);
-            setOverlay(overlay)
-            setAdvancedMarker(()=>AdvancedMarkerElement);
-            setPolyline(()=>Polyline);
-            setMapLoaded(true);
-          } catch (e) {
-            alert("Error while initializing map: " + e);
-          }
-        };
-    
-        initMap();
-    
-        return () => {
-          if (map) {
-            map.unbindAll();
-          }
-        };
-      }, []);
+		const initMap = async () => {
+			try {
+				const { map, overlay, AdvancedMarkerElement, Polyline } = await initializeMap(mapRef.current);
+				setMap(map);
+				setOverlay(overlay);
+				setAdvancedMarker(() => AdvancedMarkerElement);
+				setPolyline(() => Polyline);
+				setMapLoaded(true);
+			} catch (e) {
+				alert("Error while initializing map: " + e);
+			}
+		};
 
-    return {mapRef, map, overlay, AdvancedMarker, Polyline, mapLoaded};
-}
+		initMap();
+
+		return () => {
+			if (map) {
+				map.unbindAll();
+			}
+		};
+	}, []);
+
+	return { mapRef, map, overlay, AdvancedMarker, Polyline, mapLoaded };
+};
 
 export default useMap;

--- a/uniro_frontend/src/hooks/useMap.tsx
+++ b/uniro_frontend/src/hooks/useMap.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { initializeMap } from '../map/initializer/googleMapInitializer';
+
+
+const useMap = () => {
+
+    const mapRef = useRef<HTMLDivElement>(null);
+    const [map, setMap] = useState<google.maps.Map | null>(null);
+    const [overlay, setOverlay] = useState<google.maps.OverlayView | null>(null);
+    const [AdvancedMarker, setAdvancedMarker] = useState<typeof google.maps.marker.AdvancedMarkerElement | null>(null);
+    const [Polyline, setPolyline] = useState<typeof google.maps.Polyline | null>(null);
+    const [mapLoaded, setMapLoaded] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (!mapRef.current) return;
+    
+        const initMap = async () => {
+          try {
+            const { map, overlay, AdvancedMarkerElement, Polyline  } = await initializeMap(mapRef.current);
+            setMap(map);
+            setOverlay(overlay)
+            setAdvancedMarker(()=>AdvancedMarkerElement);
+            setPolyline(()=>Polyline);
+            setMapLoaded(true);
+          } catch (e) {
+            alert("Error while initializing map: " + e);
+          }
+        };
+    
+        initMap();
+    
+        return () => {
+          if (map) {
+            map.unbindAll();
+          }
+        };
+      }, []);
+
+    return {mapRef, map, overlay, AdvancedMarker, Polyline, mapLoaded};
+}
+
+export default useMap;

--- a/uniro_frontend/src/map/initializer/googleMapInitializer.ts
+++ b/uniro_frontend/src/map/initializer/googleMapInitializer.ts
@@ -4,41 +4,39 @@ import { HanyangUniversityBounds } from "../../constant/bounds";
 import loadGoogleMapsLibraries from "../loader/googleMapLoader";
 
 interface MapWithOverlay {
-    map: google.maps.Map | null;
-    overlay: google.maps.OverlayView | null;
-    AdvancedMarkerElement: typeof google.maps.marker.AdvancedMarkerElement;
-    Polyline: typeof google.maps.Polyline;
+	map: google.maps.Map | null;
+	overlay: google.maps.OverlayView | null;
+	AdvancedMarkerElement: typeof google.maps.marker.AdvancedMarkerElement;
+	Polyline: typeof google.maps.Polyline;
 }
 
 export const initializeMap = async (mapElement: HTMLElement | null): Promise<MapWithOverlay> => {
-    const { Map, OverlayView, AdvancedMarkerElement, Polyline } = await loadGoogleMapsLibraries();
+	const { Map, OverlayView, AdvancedMarkerElement, Polyline } = await loadGoogleMapsLibraries();
 
-    // useMap hook에서 error을 catch 하도록 함.
-    if (!mapElement) {
-        throw new Error("mapElement is null");
-    }
+	// useMap hook에서 error을 catch 하도록 함.
+	if (!mapElement) {
+		throw new Error("mapElement is null");
+	}
 
-    const map = new Map(mapElement, 
-        {
-            center: HanyangUniversity,
-            zoom: 17,
-            draggable: true,
-            scrollwheel: true,
-            disableDoubleClickZoom: false,
-            gestureHandling: "auto",
-            restriction: {
-                latLngBounds: HanyangUniversityBounds,
-                strictBounds: false,
-            },
-            mapId: import.meta.env.VITE_REACT_APP_GOOGLE_MAP_ID,
-    });
+	const map = new Map(mapElement, {
+		center: HanyangUniversity,
+		zoom: 17,
+		draggable: true,
+		scrollwheel: true,
+		disableDoubleClickZoom: false,
+		gestureHandling: "auto",
+		restriction: {
+			latLngBounds: HanyangUniversityBounds,
+			strictBounds: false,
+		},
+		mapId: import.meta.env.VITE_REACT_APP_GOOGLE_MAP_ID,
+	});
 
-    const overlay = new OverlayView();
-    overlay.onAdd = function () { };
-    overlay.draw = function () { };
-    overlay.onRemove = function () { };
-    overlay.setMap(map);
+	const overlay = new OverlayView();
+	overlay.onAdd = function () {};
+	overlay.draw = function () {};
+	overlay.onRemove = function () {};
+	overlay.setMap(map);
 
-    return { map, overlay, AdvancedMarkerElement, Polyline };
-
+	return { map, overlay, AdvancedMarkerElement, Polyline };
 };

--- a/uniro_frontend/src/map/initializer/googleMapInitializer.ts
+++ b/uniro_frontend/src/map/initializer/googleMapInitializer.ts
@@ -1,0 +1,44 @@
+import { HanyangUniversity } from "../../constant/university";
+import { HanyangUniversityBounds } from "../../constant/bounds";
+
+import loadGoogleMapsLibraries from "../loader/googleMapLoader";
+
+interface MapWithOverlay {
+    map: google.maps.Map | null;
+    overlay: google.maps.OverlayView | null;
+    AdvancedMarkerElement: typeof google.maps.marker.AdvancedMarkerElement;
+    Polyline: typeof google.maps.Polyline;
+}
+
+export const initializeMap = async (mapElement: HTMLElement | null): Promise<MapWithOverlay> => {
+    const { Map, OverlayView, AdvancedMarkerElement, Polyline } = await loadGoogleMapsLibraries();
+
+    // useMap hook에서 error을 catch 하도록 함.
+    if (!mapElement) {
+        throw new Error("mapElement is null");
+    }
+
+    const map = new Map(mapElement, 
+        {
+            center: HanyangUniversity,
+            zoom: 17,
+            draggable: true,
+            scrollwheel: true,
+            disableDoubleClickZoom: false,
+            gestureHandling: "auto",
+            restriction: {
+                latLngBounds: HanyangUniversityBounds,
+                strictBounds: false,
+            },
+            mapId: import.meta.env.VITE_REACT_APP_GOOGLE_MAP_ID,
+    });
+
+    const overlay = new OverlayView();
+    overlay.onAdd = function () { };
+    overlay.draw = function () { };
+    overlay.onRemove = function () { };
+    overlay.setMap(map);
+
+    return { map, overlay, AdvancedMarkerElement, Polyline };
+
+};

--- a/uniro_frontend/src/map/loader/googleMapLoader.ts
+++ b/uniro_frontend/src/map/loader/googleMapLoader.ts
@@ -1,17 +1,16 @@
-import { Loader } from '@googlemaps/js-api-loader';
+import { Loader } from "@googlemaps/js-api-loader";
 
 const GoogleMapsLoader = new Loader({
-    apiKey: import.meta.env.VITE_REACT_APP_GOOGLE_MAPS_API_KEY,
-    version: 'weekly',
-    libraries: ['maps','marker'],
-  });
+	apiKey: import.meta.env.VITE_REACT_APP_GOOGLE_MAPS_API_KEY,
+	version: "weekly",
+	libraries: ["maps", "marker"],
+});
 
 const loadGoogleMapsLibraries = async () => {
+	const { Map, OverlayView, Polyline } = await GoogleMapsLoader.importLibrary("maps");
+	const { AdvancedMarkerElement } = await GoogleMapsLoader.importLibrary("marker");
 
-    const { Map, OverlayView, Polyline } = await GoogleMapsLoader.importLibrary('maps');
-    const { AdvancedMarkerElement } = await GoogleMapsLoader.importLibrary('marker');
-
-    return { Map, OverlayView,AdvancedMarkerElement, Polyline };
-}
+	return { Map, OverlayView, AdvancedMarkerElement, Polyline };
+};
 
 export default loadGoogleMapsLibraries;

--- a/uniro_frontend/src/map/loader/googleMapLoader.ts
+++ b/uniro_frontend/src/map/loader/googleMapLoader.ts
@@ -1,0 +1,17 @@
+import { Loader } from '@googlemaps/js-api-loader';
+
+const GoogleMapsLoader = new Loader({
+    apiKey: import.meta.env.VITE_REACT_APP_GOOGLE_MAPS_API_KEY,
+    version: 'weekly',
+    libraries: ['maps','marker'],
+  });
+
+const loadGoogleMapsLibraries = async () => {
+
+    const { Map, OverlayView, Polyline } = await GoogleMapsLoader.importLibrary('maps');
+    const { AdvancedMarkerElement } = await GoogleMapsLoader.importLibrary('marker');
+
+    return { Map, OverlayView,AdvancedMarkerElement, Polyline };
+}
+
+export default loadGoogleMapsLibraries;


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 지도 라이브러리 설치 (Loader, Google Map Type)
2. 초기 지도 컴포넌트 제작
- 우선 테스트 용으로 메인 화면에 500 * 500으로 넣어놨습니다.
3. 지도 관련 hook 생성 useMap
4. React Router 라이브러리 설치
- 미리 의존성이 들어가면 좋을 것 같아 설치했습니다.

### 동작 확인
![스크린샷 2025-01-26 13 12 52](https://github.com/user-attachments/assets/57102e62-98c0-42f1-85b6-b3a97f692fa1)

## 💬 리뷰 요구사항(선택)
> 지도 객체들의 type중에 null이 많이 있는데, 그 부분 괜찮은지 봐주시면 좋을 것 같습니다.
> 지도 Hook을 Provider로 바꿔야할지 고민이긴 한데, 차차 이야기해보면 좋을 것 같습니다.