### PR TITLE
[UNI-62] chore : custom exception handler 정의

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    FASTEST_ROUTE_NOT_FOUND(422, "경로가 없습니다.");
+    // 길찾기
+    FASTEST_ROUTE_NOT_FOUND(422, "경로가 없습니다."),
+    SAME_START_AND_END_POINT(400, "출발지와 도착지가 같습니다.");
 
     final private int httpStatus;
     final private String message;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.softeer5.uniro_backend.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    FASTEST_ROUTE_NOT_FOUND(422, "경로가 없습니다.");
+
+    final private int httpStatus;
+    final private String message;
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorResponse.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.softeer5.uniro_backend.common.error;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ErrorResponse extends Error {
+    private int status;
+    private String message;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.status = errorCode.getHttpStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/CustomException.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.softeer5.uniro_backend.common.exception;
+
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,10 @@
+package com.softeer5.uniro_backend.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,7 @@
 package com.softeer5.uniro_backend.common.exception;
 
 import com.softeer5.uniro_backend.common.error.ErrorResponse;
-import com.softeer5.uniro_backend.common.exception.custom.SameStartAndEndPointException;
-import com.softeer5.uniro_backend.common.exception.custom.UnreachableDestinationException;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,15 +11,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(UnreachableDestinationException.class)
-    public ResponseEntity<ErrorResponse> handleSameStartEndPointException(UnreachableDestinationException ex) {
-        log.error(ex.getMessage());
-        ErrorResponse response = new ErrorResponse(ex.getErrorCode());
-        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getHttpStatus()));
-    }
-
-    @ExceptionHandler(SameStartAndEndPointException.class)
-    public ResponseEntity<ErrorResponse> handleSameStartEndPointException(SameStartAndEndPointException ex) {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
         log.error(ex.getMessage());
         ErrorResponse response = new ErrorResponse(ex.getErrorCode());
         return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getHttpStatus()));

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,28 @@
 package com.softeer5.uniro_backend.common.exception;
 
+import com.softeer5.uniro_backend.common.error.ErrorResponse;
+import com.softeer5.uniro_backend.common.exception.custom.SameStartAndEndPointException;
+import com.softeer5.uniro_backend.common.exception.custom.UnreachableDestinationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(UnreachableDestinationException.class)
+    public ResponseEntity<ErrorResponse> handleSameStartEndPointException(UnreachableDestinationException ex) {
+        log.error(ex.getMessage());
+        ErrorResponse response = new ErrorResponse(ex.getErrorCode());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getHttpStatus()));
+    }
 
+    @ExceptionHandler(SameStartAndEndPointException.class)
+    public ResponseEntity<ErrorResponse> handleSameStartEndPointException(SameStartAndEndPointException ex) {
+        log.error(ex.getMessage());
+        ErrorResponse response = new ErrorResponse(ex.getErrorCode());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getHttpStatus()));
+    }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/SameStartAndEndPointException.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/SameStartAndEndPointException.java
@@ -1,0 +1,16 @@
+package com.softeer5.uniro_backend.common.exception.custom;
+
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class SameStartAndEndPointException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public SameStartAndEndPointException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/SameStartAndEndPointException.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/SameStartAndEndPointException.java
@@ -1,16 +1,12 @@
 package com.softeer5.uniro_backend.common.exception.custom;
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
+import com.softeer5.uniro_backend.common.exception.CustomException;
 import lombok.Getter;
 
 @Getter
-public class SameStartAndEndPointException extends RuntimeException {
-
-    private final ErrorCode errorCode;
-
+public class SameStartAndEndPointException extends CustomException {
     public SameStartAndEndPointException(String message, ErrorCode errorCode) {
-        super(message);
-        this.errorCode = errorCode;
+        super(message, errorCode);
     }
-
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/UnreachableDestinationException.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/UnreachableDestinationException.java
@@ -1,0 +1,17 @@
+package com.softeer5.uniro_backend.common.exception.custom;
+
+
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UnreachableDestinationException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public UnreachableDestinationException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/UnreachableDestinationException.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/UnreachableDestinationException.java
@@ -2,16 +2,12 @@ package com.softeer5.uniro_backend.common.exception.custom;
 
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
+import com.softeer5.uniro_backend.common.exception.CustomException;
 import lombok.Getter;
 
 @Getter
-public class UnreachableDestinationException extends RuntimeException {
-
-    private final ErrorCode errorCode;
-
+public class UnreachableDestinationException extends CustomException {
     public UnreachableDestinationException(String message, ErrorCode errorCode) {
-        super(message);
-        this.errorCode = errorCode;
+        super(message, errorCode);
     }
-
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -1,5 +1,8 @@
 package com.softeer5.uniro_backend.route.service;
 
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import com.softeer5.uniro_backend.common.exception.custom.SameStartAndEndPointException;
+import com.softeer5.uniro_backend.common.exception.custom.UnreachableDestinationException;
 import com.softeer5.uniro_backend.node.entity.Node;
 import com.softeer5.uniro_backend.node.repository.NodeRepository;
 import com.softeer5.uniro_backend.route.entity.DirectionType;
@@ -37,7 +40,7 @@ public class RouteCalculationService {
     public FastestRouteResDTO calculateFastestRoute(Long univId, Long startNodeId, Long endNodeId){
 
         if(startNodeId.equals(endNodeId)){
-            throw new RuntimeException(); // 추후 처리예정
+            throw new SameStartAndEndPointException("Start and end nodes cannot be the same", ErrorCode.SAME_START_AND_END_POINT);
         }
 
         //인접 리스트
@@ -126,7 +129,7 @@ public class RouteCalculationService {
         }
         //길 없는 경우
         if(!costMap.containsKey(endNode.getId())){
-            throw new RuntimeException(); // 추후 처리예정
+            throw new UnreachableDestinationException("Unable to find a valid route", ErrorCode.FASTEST_ROUTE_NOT_FOUND);
         }
 
         return prevRoute;


### PR DESCRIPTION
# 🚀 구현 or 변동 사항
### 1. custom exception handler class & custom errorCode 정의
예외를 추가하고자 할 시 다음과 같이 추가할 수 있습니다.
1. common/exception/custom 패키지 안에 예외 클래스 생성
2. common/exception/GlobalExceptionHandler.java에 ExceptionHandler 등록
3. 필요시 common/error/ErrorCode에 커스텀 에러코드 추가
4. 예외처리가 필요한 로직에서 사용
 **example**
  `throw new UnreachableDestinationException("Unable to find a valid route", ErrorCode.FASTEST_ROUTE_NOT_FOUND);`


### 2. 이전에 예외처리되지 않았던 로직들 예외처리

RouteCalculationService에서 발생하는  예외처리를 추가하였습니다.
- 출발/도착지가 같은 경우 - SameStartAndEndPointException
- 경로를 찾을 수 없는경우 - UnreachableDestinationException 

### 3. 코드리뷰 반영
CustomException 부모 클래스를 다른 exception이 상속받도록 수정하여 코드중복을 피하도록  하였습니다.

# 🧪 테스트
<img width="565" alt="image" src="https://github.com/user-attachments/assets/8f8717c8-3622-4e9a-a788-85397df0cd7a" />
