### PR TITLE
[UNI-12] 건물 노드 검색 API

### DIFF
--- a/uniro_backend/build.gradle
+++ b/uniro_backend/build.gradle
@@ -56,6 +56,12 @@ dependencies {
 
 	// issue : https://github.com/spring-projects/spring-data-jpa/issues/3262
 	implementation 'org.antlr:antlr4-runtime:4.10.1'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/CursorPage.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/CursorPage.java
@@ -1,0 +1,12 @@
+package com.softeer5.uniro_backend.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class CursorPage<T> {
+	private final T data;  // 실제 데이터
+	private final Long nextCursor; // 다음 페이지 요청을 위한 커서 ID (마지막 데이터의 ID)
+	private final boolean hasNext; // 다음 페이지가 존재하는지 여부
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/QueryDSLConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/QueryDSLConfig.java
@@ -1,0 +1,20 @@
+package com.softeer5.uniro_backend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(){
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/controller/NodeApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/controller/NodeApi.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.softeer5.uniro_backend.node.dto.GetBuildingResDTO;
+import com.softeer5.uniro_backend.node.dto.SearchBuildingResDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -28,5 +29,17 @@ public interface NodeApi {
 		@RequestParam(value = "left-up-lat") double leftUpLat,
 		@RequestParam(value = "right-down-lng") double rightDownLng,
 		@RequestParam(value = "right-down-lat") double rightDownLat
+	);
+
+	@Operation(summary = "건물 노드 검색")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "건물 노드 검색 성공"),
+		@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
+	})
+	ResponseEntity<SearchBuildingResDTO> searchBuildings(
+		@PathVariable("univId") Long univId,
+		@RequestParam(value = "name", required = false) String name,
+		@RequestParam(value = "cursor-id", required = false) Long cursorId,
+		@RequestParam(value = "page-size", required = false) Integer pageSize
 	);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/controller/NodeController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/controller/NodeController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.softeer5.uniro_backend.node.dto.GetBuildingResDTO;
+import com.softeer5.uniro_backend.node.dto.SearchBuildingResDTO;
 import com.softeer5.uniro_backend.node.service.NodeService;
 
 import lombok.RequiredArgsConstructor;
@@ -28,10 +29,21 @@ public class NodeController implements NodeApi {
 		@RequestParam(value = "right-down-lng") double rightDownLng,
 		@RequestParam(value = "right-down-lat") double rightDownLat
 	) {
-
 		List<GetBuildingResDTO> buildingResDTOS = nodeService.getBuildings(univId, level, leftUpLng, leftUpLat,
 			rightDownLng, rightDownLat);
 		return ResponseEntity.ok().body(buildingResDTOS);
+	}
+
+	@Override
+	@GetMapping("{univId}/nodes/buildings/search")
+	public ResponseEntity<SearchBuildingResDTO> searchBuildings(
+		@PathVariable("univId") Long univId,
+		@RequestParam(value = "name", required = false) String name,
+		@RequestParam(value = "cursor-id", required = false) Long cursorId,
+		@RequestParam(value = "page-size", required = false, defaultValue = "6") Integer pageSize
+	) {
+		SearchBuildingResDTO searchBuildingResDTO = nodeService.searchBuildings(univId, name, cursorId, pageSize);
+		return ResponseEntity.ok().body(searchBuildingResDTO);
 	}
 
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/dto/BuildingNode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/dto/BuildingNode.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.node.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.softeer5.uniro_backend.node.entity.Building;
 import com.softeer5.uniro_backend.node.entity.Node;
 
@@ -10,6 +11,7 @@ public class BuildingNode {
 	private final Building building;
 	private final Node node;
 
+	@QueryProjection
 	public BuildingNode(Building building, Node node) {
 		this.building = building;
 		this.node = node;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/dto/GetBuildingResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/dto/GetBuildingResDTO.java
@@ -14,18 +14,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GetBuildingResDTO {
 
-	@Schema(description = "노드 id", example = "4")
+	@Schema(description = "노드 ID", example = "4")
 	private final Long nodeId;
 
-	@Schema(description = "건물 노드 좌표", example = "{\"lag\": 127.123456, \"lat\": 37.123456}")
+	@Schema(description = "건물 노드 좌표 (위도 및 경도)",
+		example = "{\"lag\": 127.123456, \"lat\": 37.123456}")
 	private final Map<String, Double> node;
 
+	@Schema(description = "건물 이름", example = "공학관")
 	private final String buildingName;
 
+	@Schema(description = "건물 이미지 URL", example = "https://example.com/images/building.jpg")
 	private final String buildingImageUrl;
 
+	@Schema(description = "건물 전화번호",
+		example = "02-123-4567")
 	private final String phoneNumber;
 
+	@Schema(description = "건물 주소",
+		example = "서울특별시 강남구 테헤란로 123")
 	private final String address;
 
 	public static GetBuildingResDTO of(Building building, Node node) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/dto/SearchBuildingResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/dto/SearchBuildingResDTO.java
@@ -1,0 +1,27 @@
+package com.softeer5.uniro_backend.node.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Schema(name = "SearchBuildingResDTO", description = "건물 노드 검색 DTO")
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchBuildingResDTO {
+
+	@Schema(description = "실제 data", example = "")
+	private final List<GetBuildingResDTO> data;
+
+	@Schema(description = "다음 페이지 요청을 위한 커서 ID (마지막 데이터의 ID)", example = "103")
+	private final Long nextCursor;
+
+	@Schema(description = "다음 페이지가 존재하는지 여부", example = "true")
+	private final boolean hasNext;
+
+	public static SearchBuildingResDTO of(List<GetBuildingResDTO> resDTOS, Long nextCursor, boolean hasNext) {
+		return new SearchBuildingResDTO(resDTOS, nextCursor, hasNext);
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/repository/BuildingCustomRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/repository/BuildingCustomRepository.java
@@ -1,0 +1,10 @@
+package com.softeer5.uniro_backend.node.repository;
+
+import java.util.List;
+
+import com.softeer5.uniro_backend.common.CursorPage;
+import com.softeer5.uniro_backend.node.dto.BuildingNode;
+
+public interface BuildingCustomRepository {
+	CursorPage<List<BuildingNode>> searchBuildings(Long univId, String name, Long cursorId, Integer pageSize);
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/repository/BuildingCustomRepositoryImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/repository/BuildingCustomRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.softeer5.uniro_backend.node.repository;
+
+import static com.softeer5.uniro_backend.node.entity.QBuilding.*;
+import static com.softeer5.uniro_backend.node.entity.QNode.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.softeer5.uniro_backend.common.CursorPage;
+import com.softeer5.uniro_backend.node.dto.BuildingNode;
+import com.softeer5.uniro_backend.node.dto.QBuildingNode;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BuildingCustomRepositoryImpl implements BuildingCustomRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public CursorPage<List<BuildingNode>> searchBuildings(Long univId, String name, Long cursorId, Integer pageSize) {
+
+		List<BuildingNode> buildingNodes = queryFactory
+			.select(new QBuildingNode(building, node))
+			.from(building)
+			.innerJoin(node).on(node.id.eq(building.nodeId))
+			.where(
+				building.univId.eq(univId),
+				cursorIdCondition(cursorId),
+				nameCondition(name)
+			)
+			.orderBy(building.nodeId.asc()) // Cursor 기반에서는 정렬이 중요
+			.limit(pageSize + 1) // 다음 페이지 여부를 판단하기 위해 +1로 조회
+			.fetch();
+
+		// nextCursor 및 hasNext 판단
+		boolean hasNext = buildingNodes.size() > pageSize;
+		Long nextCursor = hasNext ? buildingNodes.get(pageSize).getBuilding().getNodeId() : null;
+
+		// 마지막 요소 제거 (다음 페이지 여부 판단용으로 추가된 데이터 제거)
+		if (hasNext) {
+			buildingNodes.remove(buildingNodes.size() - 1);
+		}
+
+		return new CursorPage<>(buildingNodes, nextCursor, hasNext);
+	}
+
+	private BooleanExpression cursorIdCondition(Long cursorId) {
+		return cursorId == null ? null : building.nodeId.gt(cursorId);
+	}
+
+	private BooleanExpression nameCondition(String name) {
+		return name == null || name.isEmpty() ? null : building.name.containsIgnoreCase(name);
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/repository/BuildingRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/repository/BuildingRepository.java
@@ -8,14 +8,14 @@ import org.springframework.data.jpa.repository.Query;
 import com.softeer5.uniro_backend.node.dto.BuildingNode;
 import com.softeer5.uniro_backend.node.entity.Building;
 
-public interface BuildingRepository extends JpaRepository<Building, Long> {
+public interface BuildingRepository extends JpaRepository<Building, Long>, BuildingCustomRepository {
 
 	// 추후에 인덱싱 작업 필요.
 	@Query("""
         SELECT new com.softeer5.uniro_backend.node.dto.BuildingNode(b, n)
         FROM Building b 
         JOIN FETCH Node n ON b.nodeId = n.id
-        AND b.univId = :univId 
+        WHERE b.univId = :univId 
         AND b.level >= :level
         AND ST_Within(n.coordinates, ST_MakeEnvelope(:lux, :luy, :rdx, :rdy, 4326))
     """)

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/service/NodeService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/service/NodeService.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.softeer5.uniro_backend.common.CursorPage;
 import com.softeer5.uniro_backend.node.dto.BuildingNode;
 import com.softeer5.uniro_backend.node.dto.GetBuildingResDTO;
+import com.softeer5.uniro_backend.node.dto.SearchBuildingResDTO;
 import com.softeer5.uniro_backend.node.repository.BuildingRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,17 @@ public class NodeService {
 		return buildingNodes.stream()
 			.map(buildingNode -> GetBuildingResDTO.of(buildingNode.getBuilding(), buildingNode.getNode()))
 			.toList();
+	}
+
+	public SearchBuildingResDTO searchBuildings(Long univId, String name, Long cursorId, Integer pageSize){
+
+		CursorPage<List<BuildingNode>> buildingNodes = buildingRepository.searchBuildings(univId, name, cursorId, pageSize);
+
+		List<GetBuildingResDTO> data = buildingNodes.getData().stream()
+			.map(buildingNode -> GetBuildingResDTO.of(buildingNode.getBuilding(), buildingNode.getNode()))
+			.toList();
+
+		return SearchBuildingResDTO.of(data, buildingNodes.getNextCursor(), buildingNodes.isHasNext());
 	}
 
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/CautionListConverter.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/CautionListConverter.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.resolve;
+package com.softeer5.uniro_backend.resolver;
 
 import java.io.IOException;
 import java.util.Set;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/DangerListConverter.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/DangerListConverter.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.resolve;
+package com.softeer5.uniro_backend.resolver;
 
 import java.io.IOException;
 import java.util.Set;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
@@ -4,8 +4,8 @@ import static jakarta.persistence.FetchType.*;
 
 import java.util.Set;
 
-import com.softeer5.uniro_backend.resolve.CautionListConverter;
-import com.softeer5.uniro_backend.resolve.DangerListConverter;
+import com.softeer5.uniro_backend.resolver.CautionListConverter;
+import com.softeer5.uniro_backend.resolver.DangerListConverter;
 import com.softeer5.uniro_backend.node.entity.Node;
 import org.locationtech.jts.geom.LineString;
 


### PR DESCRIPTION
# 구현 or 수정 사항
### 건물 노드 검색 API
1. 건물 노드를 검색하는 API 를 구현했습니다.
2. 만약 클라이언트의 요청값이 없을경우, where 조건에 제외하는 동적쿼리를 구현했습니다.
3. 페이지네이션 및 동적쿼리를 구현하기 위해 querydsl 를 사용했습니다.

### 커서 기반 페이지네이션
1. offset를 활용한 페이지네이션이 아닌 cursor 기반으로 구현했습니다.
2. 이러한 방식이 성능적이나 기능적으로 더 좋다고 판단해서 그랬는데 다른 의견 있으시면 편하게 말씀주세요!
3. 커서 객체도 따로 정의했습니다!
4. cc. [커서 기반 페이지네이션 관련](https://velog.io/@znftm97/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98Cursor-based-Pagination%EC%9D%B4%EB%9E%80-Querydsl%EB%A1%9C-%EA%B5%AC%ED%98%84%EA%B9%8C%EC%A7%80-so3v8mi2#span-stylecolor0b6e998-cursor%EB%A5%BC-custom%ED%95%B4%EC%84%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0span)

# 테스트 결과
<img width="709" alt="스크린샷 2025-01-28 오후 5 32 59" src="https://github.com/user-attachments/assets/d5469d12-9ba2-4869-9ed3-3cb0ec5f8daa" />

# To Reviewer


