### PR TITLE
[UNI-11] feat : 대학교 내 모든 루트와 노드를 조회하는 API 개발

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
@@ -1,6 +1,7 @@
 package com.softeer5.uniro_backend.route.controller;
 
 import com.softeer5.uniro_backend.route.dto.FastestRouteResDTO;
+import com.softeer5.uniro_backend.route.dto.GetAllRoutesResDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -13,8 +14,18 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @Tag(name = "간선 및 위험&주의 요소 관련 Api")
 public interface RouteApi {
+
+	@Operation(summary = "모든 지도(노드,루트) 조회")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "모든 지도 조회 성공"),
+			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
+	})
+	public ResponseEntity<List<GetAllRoutesResDTO>> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
+
 	@Operation(summary = "위험&주의 요소 조회")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "위험&주의 요소 조회 성공"),

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
@@ -1,6 +1,7 @@
 package com.softeer5.uniro_backend.route.controller;
 
 import com.softeer5.uniro_backend.route.dto.FastestRouteResDTO;
+import com.softeer5.uniro_backend.route.dto.GetAllRoutesResDTO;
 import com.softeer5.uniro_backend.route.service.RouteCalculationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,12 +14,22 @@ import com.softeer5.uniro_backend.route.service.RouteService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RestController
 public class RouteController implements RouteApi {
 
 	private final RouteService routeService;
 	private final RouteCalculationService routeCalculationService;
+
+	@Override
+	@GetMapping("/{univId}/routes")
+	public ResponseEntity<List<GetAllRoutesResDTO>> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
+		List<GetAllRoutesResDTO> allRoutes = routeService.GetAllRoutes(univId);
+		return ResponseEntity.ok().body(allRoutes);
+	}
+
 	@Override
 	@GetMapping("/{univId}/routes/risks")
 	public ResponseEntity<GetRiskRoutesResDTO> getRiskRoutes(@PathVariable("univId") Long univId) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
@@ -10,9 +10,13 @@ import java.util.Map;
 @Getter
 @Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
 public class GetAllRoutesResDTO {
+    @Schema(description = "코어루트(코어노드-코어노드) id", example = "1")
     private final Long coreRouteId;
+    @Schema(description = "node1(코어노드) id", example = "3")
     private final Long node1Id;
+    @Schema(description = "node2(코어노드) id", example = "4")
     private final Long node2Id;
+    @Schema(description = "길을 이루는 좌표목록", example = "")
     private final List<Map<String, Double>> routes;
 
     private GetAllRoutesResDTO(Long coreRouteId, Long node1Id, Long node2Id, List<Map<String, Double>> routes){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
@@ -1,0 +1,28 @@
+package com.softeer5.uniro_backend.route.dto;
+
+import com.softeer5.uniro_backend.route.entity.CoreRoute;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
+public class GetAllRoutesResDTO {
+    private final Long coreRouteId;
+    private final Long node1Id;
+    private final Long node2Id;
+    private final List<Map<String, Double>> routes;
+
+    private GetAllRoutesResDTO(Long coreRouteId, Long node1Id, Long node2Id, List<Map<String, Double>> routes){
+        this.coreRouteId = coreRouteId;
+        this.node1Id = node1Id;
+        this.node2Id = node2Id;
+        this.routes = routes;
+    }
+
+    public static GetAllRoutesResDTO of(CoreRoute coreRoute){
+        return new GetAllRoutesResDTO(coreRoute.getId(), coreRoute.getNode1Id(), coreRoute.getNode2Id(), coreRoute.getPathAsList());
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/CoreRoute.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/CoreRoute.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.route.entity;
 
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.LineString;
 
 import jakarta.persistence.Column;
@@ -10,6 +11,10 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,4 +31,14 @@ public class CoreRoute {
 	private Long node1Id;
 
 	private Long node2Id;
+
+	private Long univId;
+
+	public List<Map<String, Double>> getPathAsList() {
+		List<Map<String, Double>> coordinatesList = new ArrayList<>();
+		for (Coordinate coordinate : path.getCoordinates()) {
+			coordinatesList.add(Map.of("lat", coordinate.getY(), "lng", coordinate.getX()));
+		}
+		return coordinatesList;
+	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/repository/CoreRouteRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/repository/CoreRouteRepository.java
@@ -1,0 +1,12 @@
+package com.softeer5.uniro_backend.route.repository;
+
+import com.softeer5.uniro_backend.route.entity.CoreRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CoreRouteRepository extends JpaRepository<CoreRoute, Long> {
+    List<CoreRoute> findByUnivId(Long univId);
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -4,7 +4,6 @@ import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.SameStartAndEndPointException;
 import com.softeer5.uniro_backend.common.exception.custom.UnreachableDestinationException;
 import com.softeer5.uniro_backend.node.entity.Node;
-import com.softeer5.uniro_backend.node.repository.NodeRepository;
 import com.softeer5.uniro_backend.route.entity.DirectionType;
 import com.softeer5.uniro_backend.route.entity.Route;
 import com.softeer5.uniro_backend.route.dto.RouteDetailDTO;
@@ -24,7 +23,6 @@ import java.util.*;
 @Transactional(readOnly = true)
 public class RouteCalculationService {
     private final RouteRepository routeRepository;
-    private final NodeRepository nodeRepository;
 
     @AllArgsConstructor
     private class CostToNextNode implements Comparable<CostToNextNode> {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
@@ -2,6 +2,9 @@ package com.softeer5.uniro_backend.route.service;
 
 import java.util.List;
 
+import com.softeer5.uniro_backend.route.dto.GetAllRoutesResDTO;
+import com.softeer5.uniro_backend.route.entity.CoreRoute;
+import com.softeer5.uniro_backend.route.repository.CoreRouteRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,13 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class RouteService {
 	private final RouteRepository routeRepository;
+	private final CoreRouteRepository coreRouteRepository;
+
+
+	public List<GetAllRoutesResDTO> GetAllRoutes(Long univId) {
+		List<CoreRoute> coreRoutes = coreRouteRepository.findByUnivId(univId);
+		return coreRoutes.stream().map(GetAllRoutesResDTO::of).toList();
+	}
 
 	public GetRiskRoutesResDTO getRiskRoutes(Long univId) {
 		List<Route> riskRoutes = routeRepository.findRiskRouteByUnivIdWithNode(univId);


### PR DESCRIPTION
# 🚀 구현 or 변동 사항
### 1. 대학교 내 모든 루트와 노드를 조회하는 API 개발
- 대학교 내 모든 루트와 노드를 조회하는 API를 개발하였습니다.
- 현재 리턴형식은 List형태로, 각각 coreRouteId, node1Id, node2Id, List<좌표> (길을 구성하는 각 노드의 좌표) 로 구성되어있습니다. 이는 추후 프론트엔드와의 의견조율로 변경될 수 있습니다.
- 현재 코어노드의 좌표를 따로 리턴하고있지 않습니다. 그 이유는 제공한 coreRoute의 양 끝이 코어노드이기 떄문에 데이터 중복을 피하기 위해서 입니다.


# 🧪 테스트
<img width="630" alt="image" src="https://github.com/user-attachments/assets/3c5e7449-8ee1-44a8-bf81-0f5b315ad5f2" />


# 🚨 주의사항
1. 현재 CoreRoute 테이블의 Path 컬럼 (LineString 타입)은 node1부터 시작하여 node2까지의 좌표입니다. 즉, 첫번째 좌표는 node1의 좌표이고 두번째 좌표는 node2의 좌표입니다.
   - 만약 node1과 node2가 뒤바뀐 상태라면 로직상 문제가 발생합니다. 이를 검증하기 위한 로직이 **길 추가 API 개발** 에 필요합니다.

2. 과거엔 '코어노드 = 연결된 간선이 3개 이상인 갈림길' 로 정의되어있었습니다. 하지만 [코어노드 관련 논의 스레드](https://hmg5.slack.com/archives/C0874SWD998/p1738051305860579) 이후 '코어노드 = 연결된 간선이 3개 이상이거나 1개인 노드' 로 정의가 바뀌었습니다. 


[UNI-20]: https://uniro.atlassian.net/browse/UNI-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ