### PR TITLE
[UNI-86] feat : 길 추가 로직 - 4단계 (노드의 z좌표를 Google Map API를 호출하여 가져오기)

### DIFF
--- a/uniro_backend/build.gradle
+++ b/uniro_backend/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//webClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     ROUTE_NOT_FOUND(404, "루트를 찾을 수 없습니다."),
     CAUTION_DANGER_CANT_EXIST_SIMULTANEOUSLY(400, "위험요소와 주의요소는 동시에 존재할 수 없습니다."),
 
+    //길 생성
+    ELEVATION_API_ERROR(500, "구글 해발고도 API에서 오류가 발생했습니다."),
+
     // 건물 노드
     BUILDING_NOT_FOUND(404, "유효한 건물을 찾을 수 없습니다."),
     ;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/ElevationApiException.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/ElevationApiException.java
@@ -1,0 +1,10 @@
+package com.softeer5.uniro_backend.common.exception.custom;
+
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import com.softeer5.uniro_backend.common.exception.CustomException;
+
+public class ElevationApiException extends CustomException {
+    public ElevationApiException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/client/MapClient.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/client/MapClient.java
@@ -1,0 +1,9 @@
+package com.softeer5.uniro_backend.node.client;
+
+import com.softeer5.uniro_backend.node.entity.Node;
+
+import java.util.List;
+
+public interface MapClient {
+    void fetchHeights(List<Node> nodes);
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/client/MapClientImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/client/MapClientImpl.java
@@ -1,0 +1,125 @@
+package com.softeer5.uniro_backend.node.client;
+
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;
+import com.softeer5.uniro_backend.node.entity.Node;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class MapClientImpl implements MapClient{
+    @Value("${map.api.key}")
+    private String apiKey;
+    private final String baseUrl = "https://maps.googleapis.com/maps/api/elevation/json";
+    private final Integer MAX_BATCH_SIZE = 512;
+    private final String SUCCESS_STATUS = "OK";
+    private final WebClient webClient;
+
+    public MapClientImpl() {
+        this.webClient = WebClient.builder().baseUrl(baseUrl).build();
+    }
+
+    @Getter
+    @Setter
+    public static class ElevationResponse {
+        private List<Result> results;
+        private String status;
+
+        @Getter
+        @Setter
+        public static class Result {
+            private double elevation;
+        }
+    }
+
+
+    @Override
+    public void fetchHeights(List<Node> nodes) {
+        List<Node> nodesWithoutHeight = nodes.stream()
+                .filter(node -> node.getId() == null)
+                .toList();
+
+        if(nodesWithoutHeight.isEmpty()) return;
+
+        List<List<Node>> partitions = partitionNodes(nodesWithoutHeight, MAX_BATCH_SIZE);
+
+        List<Mono<Void>> apiCalls = partitions.stream()
+                .map(batch -> fetchElevationAsync(batch)
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .doOnNext(response -> mapElevationToNodes(response, batch))
+                        .then())
+                .toList();
+
+        // 모든 비동기 호출이 완료될 때까지 대기
+        Mono.when(apiCalls).block();
+    }
+
+    // 노드를 512개씩 분할
+    private List<List<Node>> partitionNodes(List<Node> nodes, int batchSize) {
+        List<List<Node>> partitions = new ArrayList<>();
+        for (int i = 0; i < nodes.size(); i += batchSize) {
+            partitions.add(nodes.subList(i, Math.min(i + batchSize, nodes.size())));
+        }
+        return partitions;
+    }
+
+    // 병렬로 Google Map Elevation API 호출
+    private Mono<ElevationResponse> fetchElevationAsync(List<Node> nodes) {
+        StringBuilder coordinateBuilder = convertCoordinatesToStringBuilder(nodes);
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("locations", coordinateBuilder.toString())
+                        .queryParam("key", apiKey)
+                        .build())
+                .retrieve()
+                .bodyToMono(ElevationResponse.class);
+    }
+
+    private StringBuilder convertCoordinatesToStringBuilder(List<Node> nodes) {
+        StringBuilder result =  new StringBuilder();
+        for (Node node : nodes) {
+            result.append(node.getCoordinates().getY())
+                    .append(",")
+                    .append(node.getCoordinates().getX())
+                    .append("|");
+        }
+        result.setLength(result.length() - 1);
+        return result;
+    }
+
+    // 응답결과(해발고도)를 매핑해주는 메서드
+    private void mapElevationToNodes(ElevationResponse response, List<Node> batch) {
+        log.info("Current Thread: {}", Thread.currentThread().getName());
+
+        if (!response.getStatus().equals(SUCCESS_STATUS)) {
+            throw new ElevationApiException("Google Elevation API Fail: " + response.getStatus(), ErrorCode.ELEVATION_API_ERROR);
+        }
+
+        if (response.results.size() != batch.size()) {
+            log.error("The number of responses does not match the number of requests. " +
+                    "request size: {}, response size: {}", batch.size(), response.results.size());
+            throw new ElevationApiException("The number of responses does not match the number of requests. " +
+                    "request size: " + batch.size() + "response size: " + response.results.size(), ErrorCode.ELEVATION_API_ERROR);
+        }
+
+        log.info("Google Elevation API Success. batch size: " + batch.size());
+
+        List<ElevationResponse.Result> results = response.getResults();
+        for (int i = 0; i < results.size(); i++) {
+            batch.get(i).setHeight(results.get(i).getElevation());
+        }
+
+    }
+
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/entity/Node.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/entity/Node.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor//(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
 public class Node {
@@ -40,6 +40,14 @@ public class Node {
 
 	public Map<String, Double> getXY(){
 		return Map.of("lat", coordinates.getY(), "lng", coordinates.getX());
+	}
+
+	public void setHeight(double height) {
+		this.height = height;
+	}
+
+	public void setCoordinates(Point coordinates) {
+		this.coordinates = coordinates;
 	}
 
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/entity/Node.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/entity/Node.java
@@ -3,6 +3,7 @@ package com.softeer5.uniro_backend.node.entity;
 
 import java.util.Map;
 
+import lombok.*;
 import org.locationtech.jts.geom.Point;
 
 import jakarta.persistence.Column;
@@ -11,13 +12,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Entity
-@NoArgsConstructor//(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @ToString
 public class Node {

--- a/uniro_backend/src/main/resources/application-local.yml
+++ b/uniro_backend/src/main/resources/application-local.yml
@@ -21,3 +21,6 @@ spring:
     console:
       enabled: true
       path: /h2-console
+map:
+  api:
+    key: ${google.api.key}

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/node/client/MapClientImplTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/node/client/MapClientImplTest.java
@@ -28,13 +28,13 @@ public class MapClientImplTest {
         Point p2 = geometryFactory.createPoint(new Coordinate(-74.0060, 40.7128));
         Point p3 = geometryFactory.createPoint(new Coordinate(126.9780, 37.5665));
 
-        Node node1 = new Node();
+        Node node1 = Node.builder().build();
         node1.setCoordinates(p1);
 
-        Node node2 = new Node();
+        Node node2 = Node.builder().build();
         node2.setCoordinates(p2);
 
-        Node node3 = new Node();
+        Node node3 = Node.builder().build();
         node3.setCoordinates(p3);
 
         List<Node> nodes = List.of(node1, node2, node3);
@@ -55,13 +55,13 @@ public class MapClientImplTest {
         Point p2 = geometryFactory.createPoint(new Coordinate(-74.0060, 40.7128));
         Point p3 = geometryFactory.createPoint(new Coordinate(126.9780, 37.5665));
 
-        Node node1 = new Node();
+        Node node1 = Node.builder().build();
         node1.setCoordinates(p1);
 
-        Node node2 = new Node();
+        Node node2 = Node.builder().build();
         node2.setCoordinates(p2);
 
-        Node node3 = new Node();
+        Node node3 = Node.builder().build();
         node3.setCoordinates(p3);
 
         List<Node> nodes = List.of(node1, node2, node3);

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/node/client/MapClientImplTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/node/client/MapClientImplTest.java
@@ -1,0 +1,86 @@
+package com.softeer5.uniro_backend.node.client;
+
+import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;
+import com.softeer5.uniro_backend.node.entity.Node;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class MapClientImplTest {
+    @Autowired
+    private MapClientImpl mapClientImpl;
+    private final GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Test
+    @DisplayName("Google Elevation API 테스트")
+    public void testFetchHeights() {
+        Point p1 = geometryFactory.createPoint(new Coordinate(-122.4194, 37.7749));
+        Point p2 = geometryFactory.createPoint(new Coordinate(-74.0060, 40.7128));
+        Point p3 = geometryFactory.createPoint(new Coordinate(126.9780, 37.5665));
+
+        Node node1 = new Node();
+        node1.setCoordinates(p1);
+
+        Node node2 = new Node();
+        node2.setCoordinates(p2);
+
+        Node node3 = new Node();
+        node3.setCoordinates(p3);
+
+        List<Node> nodes = List.of(node1, node2, node3);
+
+        mapClientImpl.fetchHeights(nodes);
+
+        for (Node node : nodes) {
+            assertThat(node.getHeight()).isNotNull();
+            System.out.println("Node coordinates: " + node.getCoordinates() + ", Elevation: " + node.getHeight());
+        }
+    }
+
+
+    @Test
+    @DisplayName("Google Elevation API exception 발생 테스트")
+    public void testFetchHeights2() {
+        Point p1 = geometryFactory.createPoint(new Coordinate(-122.4194, 37.7749));
+        Point p2 = geometryFactory.createPoint(new Coordinate(-74.0060, 40.7128));
+        Point p3 = geometryFactory.createPoint(new Coordinate(126.9780, 37.5665));
+
+        Node node1 = new Node();
+        node1.setCoordinates(p1);
+
+        Node node2 = new Node();
+        node2.setCoordinates(p2);
+
+        Node node3 = new Node();
+        node3.setCoordinates(p3);
+
+        List<Node> nodes = List.of(node1, node2, node3);
+
+        // 강제로 @Value로 가져온 Google API Key를 초기화 할 수 있도록 새로운 객체 생성
+        mapClientImpl = new MapClientImpl();
+        //mapClientImpl.fetchHeights(nodes);
+        try {
+            mapClientImpl.fetchHeights(nodes);
+            Assertions.fail("예외가 발생하지 않았습니다. 예상된 ElevationApiException이 발생해야 합니다.");
+        } catch (ElevationApiException e) {
+            System.out.println("예외 발생 메시지: " + e.getMessage());
+            assertThat(e.getMessage()).contains("Google Elevation API Fail");
+        }
+
+        for (Node node : nodes) {
+            assertThat(node.getHeight()).isNotNull();
+            System.out.println("Node coordinates: " + node.getCoordinates() + ", Elevation: " + node.getHeight());
+        }
+    }
+
+}

--- a/uniro_backend/src/test/resources/application-test.yml
+++ b/uniro_backend/src/test/resources/application-test.yml
@@ -21,3 +21,6 @@ spring:
     console:
       enabled: true
       path: /h2-console
+map:
+  api:
+    key: ${google.api.key}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### Google Elevation API를 통해 새로 추가된 Node의 z좌표를 채우는 로직
- 외부 API를 호출해야하는 로직이므로 MapClient 인터페이스와 MapClientImpl 구현체로 구현하였습니다. 
- 길 추가 로직 1-3단계를 마친 배열에 대한 후처리 로직입니다. Service단에서 호출하여 사용하시면 될 것 같습니다.

플로우는 다음과 같습니다.
1. id가 null인 새로 추가된 Node 객체들을 필터링합니다. 이는 아직 데이터베이스에 저장되지 않은 새로운 POJO를 의미합니다.
2. Google Elevation API는 한 번에 최대 512개의 좌표만 처리할 수 있으므로, 필터링된 Node 객체들을 512개 단위로 파티셔닝합니다.
3. 파티셔닝된 각 배열을 WebClient를 이용해 비동기 병렬로 Google Elevation API에 요청을 보냅니다.
4. API 응답으로 받은 고도 데이터를 각 Node 객체의 z 값(height)에 매핑합니다.
5. 모든 비동기 API 요청이 완료될 때까지 Mono.when()으로 대기한 뒤, block()을 호출하여 동기적으로 결과를 반환합니다.

### 그외
- 길 추가 로직에서 사용될 것으로 예상되어 Node 생성자의 Protected 접근자를 Public으로 변경하였습니다.

### 테스트코드
성공적으로 z좌표를 가져오는 시나리오와, 잘못된 API Key를 넘기는 등 예외가 발생하는 경우 정상적으로 ElevationApiException이 발생하는지 확인하는 테스트코드를 작성하였고, 정상 작동함을 확인하였습니다.

## 💡 To Reviewer
- yml에 ${google.api.key} 환경변수를 추가하였습니다. 저희 구글클라우드 계정에서 백엔드용 API Key를 넣어두셔야 정상적으로 작동할 것 같습니다.

