### PR TITLE
[UNI-21] feat : 제보 폼 페이지 개발 (UNI-89, UNI-90)

### DIFF
--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -6,6 +6,7 @@ import UniversitySearchPage from "./pages/search";
 import MapPage from "./pages/map";
 import BuildingSearchPage from "./pages/buildingSearch";
 import NavigationResultPage from "./pages/navigationResult";
+import ReportForm from "./pages/reportForm";
 
 function App() {
 	return (
@@ -15,6 +16,7 @@ function App() {
 			<Route path="/university" element={<UniversitySearchPage />} />
 			<Route path="/building" element={<BuildingSearchPage />} />
 			<Route path="/map" element={<MapPage />} />
+			<Route path="/form" element={<ReportForm />} />
 			<Route path="/result" element={<NavigationResultPage />} />
 		</Routes>
 	);

--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -3,7 +3,7 @@ import useMap from "../hooks/useMap";
 import { NavigationRoute } from "../data/types/route";
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
 import createMarkerElement from "../components/map/mapMarkers";
-import { Markers } from "../constant/enums";
+import { Markers } from "../constant/enum/markerEnum";
 
 type MapProps = {
 	style?: React.CSSProperties;

--- a/uniro_frontend/src/components/map/TopSheet.tsx
+++ b/uniro_frontend/src/components/map/TopSheet.tsx
@@ -7,7 +7,7 @@ import { Link } from "react-router";
 import { motion } from "framer-motion";
 import useRoutePoint from "../../hooks/useRoutePoint";
 import useSearchBuilding from "../../hooks/useSearchBuilding";
-import { RoutePoint } from "../../constant/enums";
+import { RoutePoint } from "../../constant/enum/routeEnum";
 
 export default function TopSheet({ open }: { open: boolean }) {
 	const { origin, setOrigin, destination, setDestination, switchBuilding } = useRoutePoint();

--- a/uniro_frontend/src/components/map/mapMarkers.tsx
+++ b/uniro_frontend/src/components/map/mapMarkers.tsx
@@ -1,5 +1,5 @@
 import { MarkerTypes } from "../../data/types/marker";
-import { Markers } from "../../constant/enums";
+import { Markers } from "../../constant/enum/markerEnum";
 
 const markerImages = import.meta.glob("/src/assets/markers/*.svg", { eager: true });
 

--- a/uniro_frontend/src/components/report/formTitle.tsx
+++ b/uniro_frontend/src/components/report/formTitle.tsx
@@ -1,0 +1,27 @@
+import { PassableStatus, ReportModeType } from "../../data/types/report";
+
+type FormTitleProps = {
+	isPrimary: boolean;
+	reportMode: ReportModeType;
+	passableStatus: PassableStatus;
+};
+
+const createTitleString = ({ isPrimary, reportMode, passableStatus }: FormTitleProps) => {
+	const mainTitle = isPrimary
+		? "통행 가능 여부"
+		: `통행 ${passableStatus === PassableStatus.DANGER ? "불가" : "주의"} 불편 요소 선택`;
+	const subTitle = isPrimary
+		? "통행 불가능한 길은 추천 여부에서 제외됩니다."
+		: `불편했던 요소를 ${reportMode === "create" ? "선택" : "수정"}해주세요.`;
+	return { mainTitle, subTitle };
+};
+
+export const FormTitle = ({ isPrimary, reportMode, passableStatus }: FormTitleProps) => {
+	const { mainTitle, subTitle } = createTitleString({ isPrimary, reportMode, passableStatus });
+	return (
+		<div className="flex flex-col w-full items-start justify-center space-y-[2px] mt-6 ml-6">
+			<div className="text-gray-900 text-left font-medium text-kor-body2">{mainTitle}</div>
+			<div className="text-gray-700 text-left text-kor-body3 text-[15px] whitespace-pre-wrap">{subTitle}</div>
+		</div>
+	);
+};

--- a/uniro_frontend/src/components/report/formTitle.tsx
+++ b/uniro_frontend/src/components/report/formTitle.tsx
@@ -1,4 +1,5 @@
-import { PassableStatus, ReportModeType } from "../../data/types/report";
+import { PassableStatus } from "../../constant/enum/reportEnum";
+import { ReportModeType } from "../../data/types/report";
 
 type FormTitleProps = {
 	isPrimary: boolean;

--- a/uniro_frontend/src/components/report/primaryButton.tsx
+++ b/uniro_frontend/src/components/report/primaryButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { PassableStatus } from "../../data/types/report";
 import { getThemeByPassableStatus } from "../../utils/report/getThemeByPassableStatus";
+import { PassableStatus } from "../../constant/enum/reportEnum";
 
 export const PrimaryFormButton = ({
 	onClick,

--- a/uniro_frontend/src/components/report/primaryButton.tsx
+++ b/uniro_frontend/src/components/report/primaryButton.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import { PassableStatus } from "../../data/types/report";
+import { getThemeByPassableStatus } from "../../utils/report/getThemeByPassableStatus";
+
+export const PrimaryFormButton = ({
+	onClick,
+	formPassableStatus,
+	passableStatus,
+	content,
+}: {
+	onClick: (status: PassableStatus) => void;
+	formPassableStatus: PassableStatus;
+	passableStatus: PassableStatus;
+	content: string;
+}) => {
+	const [selectedThemeString, _] = useState<string>(getThemeByPassableStatus(passableStatus));
+	return (
+		<button
+			onClick={() => onClick(passableStatus)}
+			className={`mb-3 mr-3 py-[18px] px-[22px] border-[1px] rounded-[20px] w-fit text-kor-body2 border-gray-400 ${formPassableStatus === passableStatus && selectedThemeString}`}
+		>
+			{content}
+		</button>
+	);
+};

--- a/uniro_frontend/src/components/report/primaryForm.tsx
+++ b/uniro_frontend/src/components/report/primaryForm.tsx
@@ -1,4 +1,6 @@
-import { PassableStatus, PrimaryQuestionButton, ReportModeType } from "../../data/types/report";
+import { PassableStatus } from "../../constant/enum/reportEnum";
+import { PrimaryQuestionButton, ReportModeType } from "../../data/types/report";
+
 import { FormTitle } from "./formTitle";
 import { PrimaryFormButton } from "./primaryButton";
 

--- a/uniro_frontend/src/components/report/primaryForm.tsx
+++ b/uniro_frontend/src/components/report/primaryForm.tsx
@@ -1,0 +1,37 @@
+import { PassableStatus, PrimaryQuestionButton, ReportModeType } from "../../data/types/report";
+import { FormTitle } from "./formTitle";
+import { PrimaryFormButton } from "./primaryButton";
+
+const buttonConfig = [
+	{ content: "통행이 불가능해요", passableStatus: PassableStatus.DANGER },
+	{ content: "통행이 가능하지만 주의가 필요해요", passableStatus: PassableStatus.CAUTION },
+	{ content: "통행이 가능해졌어요", passableStatus: PassableStatus.RESTORED, mode: "update" },
+] as PrimaryQuestionButton[];
+
+interface PrimaryFormProps {
+	passableStatus: PassableStatus;
+	handlePrimarySelect: (status: PassableStatus) => void;
+	reportMode: ReportModeType;
+}
+
+export const PrimaryForm = ({ passableStatus, handlePrimarySelect, reportMode }: PrimaryFormProps) => {
+	return (
+		<>
+			<FormTitle isPrimary={true} reportMode={reportMode} passableStatus={passableStatus} />
+			<div className="flex flex-wrap w-full pt-5 pl-6 space-y-3 pr-4 space-x-3">
+				{buttonConfig.map((button, index) => {
+					if (button.mode && button.mode !== reportMode) return null;
+					return (
+						<PrimaryFormButton
+							key={index}
+							onClick={handlePrimarySelect}
+							formPassableStatus={passableStatus}
+							passableStatus={button.passableStatus}
+							content={button.content}
+						/>
+					);
+				})}
+			</div>
+		</>
+	);
+};

--- a/uniro_frontend/src/components/report/reportDivider.tsx
+++ b/uniro_frontend/src/components/report/reportDivider.tsx
@@ -1,0 +1,3 @@
+export const ReportDivider = () => {
+	return <div className="w-full border border-y-4 border-gray-200" />;
+};

--- a/uniro_frontend/src/components/report/reportTitle.tsx
+++ b/uniro_frontend/src/components/report/reportTitle.tsx
@@ -1,0 +1,10 @@
+import { ReportModeType } from "../../data/types/report";
+export const ReportTitle = ({ reportMode }: { reportMode: ReportModeType }) => {
+	const CREATE_TITLE = "불편한 길을 알려주세요.";
+	const UPDATE_TITLE = "불편한 길을 수정해주세요.";
+	return (
+		<div className="flex flex-col items-start justify-center max-w-[450px] w-full bg-gray-100 py-6 pl-6 text-left text-gray-900 text-kor-heading1 font-semibold">
+			{reportMode === "create" ? CREATE_TITLE : UPDATE_TITLE}
+		</div>
+	);
+};

--- a/uniro_frontend/src/components/report/secondaryButton.tsx
+++ b/uniro_frontend/src/components/report/secondaryButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { CautionIssueType, DangerIssueType, PassableStatus } from "../../data/types/report";
+import { getThemeByPassableStatus } from "../../utils/report/getThemeByPassableStatus";
+
+export const SecondaryFormButton = ({
+	onClick,
+	formPassableStatus,
+	content,
+	isSelected,
+}: {
+	onClick: (answer: DangerIssueType | CautionIssueType) => void;
+	formPassableStatus: PassableStatus;
+	content: DangerIssueType | CautionIssueType;
+	isSelected: boolean;
+}) => {
+	return (
+		<button
+			onClick={() => onClick(content)}
+			className={`mb-3 mr-3 py-[18px] px-[22px] border-[1px] rounded-[20px] w-fit text-kor-body2 border-gray-400 ${isSelected && getThemeByPassableStatus(formPassableStatus)}`}
+		>
+			{content}
+		</button>
+	);
+};

--- a/uniro_frontend/src/components/report/secondaryForm.tsx
+++ b/uniro_frontend/src/components/report/secondaryForm.tsx
@@ -1,0 +1,64 @@
+import { form } from "framer-motion/client";
+import {
+	CautionIssueType,
+	DangerIssueType,
+	IssueQuestionButtons,
+	PassableStatus,
+	ReportFormData,
+	ReportModeType,
+} from "../../data/types/report";
+import { FormTitle } from "./formTitle";
+import { SecondaryFormButton } from "./secondaryButton";
+
+const buttonConfig = {
+	danger: [DangerIssueType.LOW_STEP, DangerIssueType.CRACK, DangerIssueType.LOW_SLOPE, DangerIssueType.OTHERS],
+	caution: [
+		CautionIssueType.HIGH_STEP,
+		CautionIssueType.STAIRS,
+		CautionIssueType.STEEP_SLOPE,
+		CautionIssueType.OTHERS,
+	],
+} as IssueQuestionButtons;
+
+type SecondaryFormProps = {
+	reportMode: ReportModeType;
+	formData: ReportFormData;
+	handleSecondarySelect: (answer: DangerIssueType | CautionIssueType) => void;
+};
+
+export const SecondaryForm = ({ formData, handleSecondarySelect, reportMode }: SecondaryFormProps) => {
+	return (
+		<>
+			{(formData.passableStatus === PassableStatus.CAUTION ||
+				formData.passableStatus === PassableStatus.DANGER) && (
+				<FormTitle isPrimary={false} reportMode={reportMode} passableStatus={formData.passableStatus} />
+			)}
+			<div className="flex flex-wrap w-full pt-5 pl-6 pr-4">
+				{formData.passableStatus === PassableStatus.CAUTION &&
+					buttonConfig.caution.map((button, index) => {
+						return (
+							<SecondaryFormButton
+								onClick={handleSecondarySelect}
+								formPassableStatus={formData.passableStatus}
+								isSelected={formData.cautionIssues.includes(button)}
+								content={button}
+								key={index}
+							/>
+						);
+					})}
+				{formData.passableStatus === PassableStatus.DANGER &&
+					buttonConfig.danger.map((button, index) => {
+						return (
+							<SecondaryFormButton
+								onClick={handleSecondarySelect}
+								formPassableStatus={formData.passableStatus}
+								isSelected={formData.dangerIssues.includes(button)}
+								content={button}
+								key={index}
+							/>
+						);
+					})}
+			</div>
+		</>
+	);
+};

--- a/uniro_frontend/src/components/report/secondaryForm.tsx
+++ b/uniro_frontend/src/components/report/secondaryForm.tsx
@@ -1,12 +1,6 @@
-import { form } from "framer-motion/client";
-import {
-	CautionIssueType,
-	DangerIssueType,
-	IssueQuestionButtons,
-	PassableStatus,
-	ReportFormData,
-	ReportModeType,
-} from "../../data/types/report";
+import { CautionIssueType, DangerIssueType, PassableStatus } from "../../constant/enum/reportEnum";
+import { IssueQuestionButtons, ReportFormData, ReportModeType } from "../../data/types/report";
+
 import { FormTitle } from "./formTitle";
 import { SecondaryFormButton } from "./secondaryButton";
 

--- a/uniro_frontend/src/constant/enum/markerEnum.ts
+++ b/uniro_frontend/src/constant/enum/markerEnum.ts
@@ -8,8 +8,3 @@ export const enum Markers {
 	WAYPOINT = "waypoint",
 	NUMBERED_WAYPOINT = "numberedWayPoint",
 }
-
-export const enum RoutePoint {
-	ORIGIN = "origin",
-	DESTINATION = "destination",
-}

--- a/uniro_frontend/src/constant/enum/markerEnum.ts
+++ b/uniro_frontend/src/constant/enum/markerEnum.ts
@@ -8,3 +8,8 @@ export const enum Markers {
 	WAYPOINT = "waypoint",
 	NUMBERED_WAYPOINT = "numberedWayPoint",
 }
+
+export const enum RoutePoint {
+	ORIGIN = "origin",
+	DESTINATION = "destination",
+}

--- a/uniro_frontend/src/constant/enum/reportEnum.ts
+++ b/uniro_frontend/src/constant/enum/reportEnum.ts
@@ -18,21 +18,3 @@ export enum CautionIssueType {
 	STEEP_SLOPE = "경사가 매우 높아요",
 	OTHERS = "그 외 요소",
 }
-
-export type ReportModeType = "create" | "update";
-
-export interface PrimaryQuestionButton {
-	content: string;
-	passableStatus: PassableStatus;
-	mode?: ReportModeType;
-}
-
-export interface IssueQuestionButtons {
-	danger: DangerIssueType[];
-	caution: CautionIssueType[];
-}
-export interface ReportFormData {
-	passableStatus: PassableStatus;
-	dangerIssues: DangerIssueType[];
-	cautionIssues: CautionIssueType[];
-}

--- a/uniro_frontend/src/constant/enum/routeEnum.ts
+++ b/uniro_frontend/src/constant/enum/routeEnum.ts
@@ -1,0 +1,4 @@
+export const enum RoutePoint {
+	ORIGIN = "origin",
+	DESTINATION = "destination",
+}

--- a/uniro_frontend/src/constant/reportTheme.ts
+++ b/uniro_frontend/src/constant/reportTheme.ts
@@ -1,0 +1,8 @@
+import { PassableStatus } from "./enum/reportEnum";
+
+export const THEME_MAP: Record<PassableStatus, string> = {
+	[PassableStatus.DANGER]: "border-system-red text-system-red bg-[#FFF5F7]",
+	[PassableStatus.CAUTION]: "border-system-orange text-system-orange bg-[#FFF7EF]",
+	[PassableStatus.RESTORED]: "border-primary-400 text-primary-400 bg-[#F0F5FE]",
+	[PassableStatus.INITIAL]: "bg-gray-100 border-gray-400",
+};

--- a/uniro_frontend/src/data/types/marker.d.ts
+++ b/uniro_frontend/src/data/types/marker.d.ts
@@ -1,4 +1,4 @@
-import { Markers } from "../../constant/enums";
+import { Markers } from "../../constant/enum/markerEnum";
 
 export type AdvancedMarker = google.maps.marker.AdvancedMarkerElement;
 

--- a/uniro_frontend/src/data/types/report.d.ts
+++ b/uniro_frontend/src/data/types/report.d.ts
@@ -1,0 +1,19 @@
+import { CautionIssueType, DangerIssueType, PassableStatus } from "../../constant/enum/reportEnum";
+
+export type ReportModeType = "create" | "update";
+
+export interface PrimaryQuestionButton {
+	content: string;
+	passableStatus: PassableStatus;
+	mode?: ReportModeType;
+}
+
+export interface IssueQuestionButtons {
+	danger: DangerIssueType[];
+	caution: CautionIssueType[];
+}
+export interface ReportFormData {
+	passableStatus: PassableStatus;
+	dangerIssues: DangerIssueType[];
+	cautionIssues: CautionIssueType[];
+}

--- a/uniro_frontend/src/data/types/report.ts
+++ b/uniro_frontend/src/data/types/report.ts
@@ -1,0 +1,38 @@
+export enum PassableStatus {
+	DANGER = "DANGER",
+	CAUTION = "CAUTION",
+	RESTORED = "RESTORED",
+	INITIAL = "INITIAL",
+}
+
+export enum DangerIssueType {
+	LOW_STEP = "낮은 턱이 있어요",
+	CRACK = "도로에 균열이 있어요",
+	LOW_SLOPE = "낮은 비탈길이 있어요",
+	OTHERS = "그 외 요소",
+}
+
+export enum CautionIssueType {
+	HIGH_STEP = "높은 턱이 있어요",
+	STAIRS = "계단이 있어요",
+	STEEP_SLOPE = "경사가 매우 높아요",
+	OTHERS = "그 외 요소",
+}
+
+export type ReportModeType = "create" | "update";
+
+export interface PrimaryQuestionButton {
+	content: string;
+	passableStatus: PassableStatus;
+	mode?: ReportModeType;
+}
+
+export interface IssueQuestionButtons {
+	danger: DangerIssueType[];
+	caution: CautionIssueType[];
+}
+export interface ReportFormData {
+	passableStatus: PassableStatus;
+	dangerIssues: DangerIssueType[];
+	cautionIssues: CautionIssueType[];
+}

--- a/uniro_frontend/src/data/types/route.d.ts
+++ b/uniro_frontend/src/data/types/route.d.ts
@@ -1,4 +1,4 @@
-import { RoutePoint } from "../../constant/enums";
+import { RoutePoint } from "../../constant/enum/markerEnum";
 import { RouteEdge } from "./edge";
 import { Building } from "./node";
 

--- a/uniro_frontend/src/hooks/useSearchBuilding.ts
+++ b/uniro_frontend/src/hooks/useSearchBuilding.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { Building } from "../data/types/node";
 import { RoutePointType } from "../data/types/route";
-import { RoutePoint } from "../constant/enums";
+import { RoutePoint } from "../constant/enum/routeEnum";
 
 interface SearchModeStore {
 	mode: RoutePointType;

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -15,8 +15,8 @@ import useSearchBuilding from "../hooks/useSearchBuilding";
 import Button from "../components/customButton";
 import { AdvancedMarker, MarkerTypes } from "../data/types/marker";
 import { RoutePointType } from "../data/types/route";
-import { RoutePoint } from "../constant/enums";
-import { Markers } from "../constant/enums";
+import { RoutePoint } from "../constant/enum/routeEnum";
+import { Markers } from "../constant/enum/markerEnum";
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
 
 export type SelectedMarkerTypes = {
@@ -52,7 +52,7 @@ export default function MapPage() {
 
 					if (type === Markers.BUILDING) return undefined;
 
-					element.content = createMarkerElement({ type, });
+					element.content = createMarkerElement({ type });
 				}
 				return undefined;
 			});

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from "react";
+import {
+	DangerIssueType,
+	PassableStatus,
+	ReportModeType,
+	CautionIssueType,
+	ReportFormData,
+} from "../data/types/report";
+import { ReportTitle } from "../components/report/reportTitle";
+import { ReportDivider } from "../components/report/reportDivider";
+import { PrimaryForm } from "../components/report/primaryForm";
+import { SecondaryForm } from "../components/report/secondaryForm";
+import Button from "../components/customButton";
+import useScrollControl from "../hooks/useScrollControl";
+import useModal from "../hooks/useModal";
+
+const ReportForm = () => {
+	useScrollControl();
+
+	const [reportMode, setReportMode] = useState<ReportModeType | null>(null);
+
+	const [formData, setFormData] = useState<ReportFormData>({
+		passableStatus: PassableStatus.INITIAL,
+		dangerIssues: [],
+		cautionIssues: [],
+	});
+
+	const [FailModal, isFailOpen, openFail, closeFail] = useModal();
+	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal();
+
+	useEffect(() => {
+		setTimeout(() => {
+			setReportMode("create");
+		}, 2000);
+	}, []);
+
+	const handlePrimarySelect = (status: PassableStatus) => {
+		setFormData((prev) => ({
+			...prev,
+			passableStatus: status === prev.passableStatus ? PassableStatus.INITIAL : status,
+			dangerIssues: status === PassableStatus.DANGER ? [] : prev.dangerIssues,
+			cautionIssues: status === PassableStatus.CAUTION ? [] : prev.cautionIssues,
+		}));
+	};
+
+	const handleSecondarySelect = (answerType: DangerIssueType | CautionIssueType) => {
+		if (formData.passableStatus === PassableStatus.DANGER) {
+			setFormData((prev) => ({
+				...prev,
+				dangerIssues: prev.dangerIssues.includes(answerType as DangerIssueType)
+					? prev.dangerIssues.filter((issue) => issue !== answerType)
+					: [...prev.dangerIssues, answerType as DangerIssueType],
+			}));
+		} else if (formData.passableStatus === PassableStatus.CAUTION) {
+			setFormData((prev) => ({
+				...prev,
+				cautionIssues: prev.cautionIssues.includes(answerType as CautionIssueType)
+					? prev.cautionIssues.filter((issue) => issue !== answerType)
+					: [...prev.cautionIssues, answerType as CautionIssueType],
+			}));
+		}
+	};
+
+	const onReportSubmitSuccess = () => {
+		openSuccess();
+	};
+
+	const onReportSubmitFail = () => {
+		openFail();
+	};
+
+	return reportMode ? (
+		<div className="flex flex-col h-svh w-full max-w-[450px] mx-auto relative">
+			<ReportTitle reportMode={reportMode} />
+			<ReportDivider />
+			<div className="flex-1 overflow-y-auto">
+				<PrimaryForm
+					reportMode={reportMode}
+					passableStatus={formData.passableStatus}
+					handlePrimarySelect={handlePrimarySelect}
+				/>
+				<SecondaryForm
+					reportMode={reportMode}
+					formData={formData}
+					handleSecondarySelect={handleSecondarySelect}
+				/>
+			</div>
+			<div className="mb-4 w-full px-4">
+				<Button onClick={onReportSubmitSuccess} variant="primary">
+					제보하기
+				</Button>
+			</div>
+			<SuccessModal>
+				<p className="text-kor-body1 font-bold text-primary-500">불편한 길 제보를 완료했어요!</p>
+				<div className="space-y-0">
+					<p className="text-kor-body3 font-regular text-gray-700">제보는 바로 반영되지만,</p>
+					<p className="text-kor-body3 font-regular text-gray-700">
+						더 정확한 정보를 위해 추후 수정될 수 있어요.
+					</p>
+				</div>
+			</SuccessModal>
+			<FailModal>
+				<p className="text-kor-body1 font-bold text-system-red">이미 삭제된 경로예요</p>
+				<div className="space-y-0">
+					<p className="text-kor-body3 font-regular text-gray-700">
+						해당 경로는 다른 사용자에 의해 삭제되어,
+					</p>
+					<p className="text-kor-body3 font-regular text-gray-700">지도 화면에서 바로 확인할 수 있어요.</p>
+				</div>
+			</FailModal>
+		</div>
+	) : (
+		<div>로딩중...</div>
+	);
+};
+
+export default ReportForm;

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -1,16 +1,14 @@
 import React, { useEffect, useState } from "react";
-import {
-	DangerIssueType,
-	PassableStatus,
-	ReportModeType,
-	CautionIssueType,
-	ReportFormData,
-} from "../data/types/report";
+
+import { PassableStatus, DangerIssueType, CautionIssueType } from "../constant/enum/reportEnum";
+import { ReportModeType, ReportFormData } from "../data/types/report";
+
 import { ReportTitle } from "../components/report/reportTitle";
 import { ReportDivider } from "../components/report/reportDivider";
 import { PrimaryForm } from "../components/report/primaryForm";
 import { SecondaryForm } from "../components/report/secondaryForm";
 import Button from "../components/customButton";
+
 import useScrollControl from "../hooks/useScrollControl";
 import useModal from "../hooks/useModal";
 

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -23,14 +23,28 @@ const ReportForm = () => {
 		cautionIssues: [],
 	});
 
+	const [disabled, setDisabled] = useState<boolean>(true);
+
 	const [FailModal, isFailOpen, openFail, closeFail] = useModal();
 	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal();
 
 	useEffect(() => {
 		setTimeout(() => {
-			setReportMode("create");
+			setReportMode("update");
 		}, 2000);
 	}, []);
+
+	useEffect(() => {
+		if (
+			formData.passableStatus === PassableStatus.INITIAL ||
+			(formData.passableStatus === PassableStatus.DANGER && formData.dangerIssues.length === 0) ||
+			(formData.passableStatus === PassableStatus.CAUTION && formData.cautionIssues.length === 0)
+		) {
+			setDisabled(true);
+			return;
+		}
+		setDisabled(false);
+	}, [formData]);
 
 	const handlePrimarySelect = (status: PassableStatus) => {
 		setFormData((prev) => ({
@@ -84,7 +98,7 @@ const ReportForm = () => {
 				/>
 			</div>
 			<div className="mb-4 w-full px-4">
-				<Button onClick={onReportSubmitSuccess} variant="primary">
+				<Button onClick={onReportSubmitSuccess} variant={disabled ? "disabled" : "primary"}>
 					제보하기
 				</Button>
 			</div>

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -48,7 +48,6 @@ const ReportForm = () => {
 
 	const handlePrimarySelect = (status: PassableStatus) => {
 		setFormData((prev) => ({
-			...prev,
 			passableStatus: status === prev.passableStatus ? PassableStatus.INITIAL : status,
 			dangerIssues: status === PassableStatus.DANGER ? [] : prev.dangerIssues,
 			cautionIssues: status === PassableStatus.CAUTION ? [] : prev.cautionIssues,

--- a/uniro_frontend/src/utils/report/getThemeByPassableStatus.ts
+++ b/uniro_frontend/src/utils/report/getThemeByPassableStatus.ts
@@ -1,0 +1,20 @@
+import { PassableStatus } from "../../data/types/report";
+
+export const getThemeByPassableStatus = (status: PassableStatus): string => {
+	const orangeTheme = "border-system-orange text-system-orange bg-[#FFF7EF]";
+	const redTheme = "border-system-red text-system-red bg-[#FFF5F7]";
+	const blueTheme = "border-primary-400 text-primary-400 bg-[#F0F5FE]";
+	const whiteTheme = "bg-gray-100 border-gray-400";
+
+	switch (status) {
+		case PassableStatus.DANGER:
+			return redTheme;
+		case PassableStatus.CAUTION:
+			return orangeTheme;
+		case PassableStatus.RESTORED:
+			return blueTheme;
+		case PassableStatus.INITIAL:
+		default:
+			return whiteTheme;
+	}
+};

--- a/uniro_frontend/src/utils/report/getThemeByPassableStatus.ts
+++ b/uniro_frontend/src/utils/report/getThemeByPassableStatus.ts
@@ -1,20 +1,6 @@
 import { PassableStatus } from "../../constant/enum/reportEnum";
+import { THEME_MAP } from "../../constant/reportTheme";
 
 export const getThemeByPassableStatus = (status: PassableStatus): string => {
-	const orangeTheme = "border-system-orange text-system-orange bg-[#FFF7EF]";
-	const redTheme = "border-system-red text-system-red bg-[#FFF5F7]";
-	const blueTheme = "border-primary-400 text-primary-400 bg-[#F0F5FE]";
-	const whiteTheme = "bg-gray-100 border-gray-400";
-
-	switch (status) {
-		case PassableStatus.DANGER:
-			return redTheme;
-		case PassableStatus.CAUTION:
-			return orangeTheme;
-		case PassableStatus.RESTORED:
-			return blueTheme;
-		case PassableStatus.INITIAL:
-		default:
-			return whiteTheme;
-	}
+	return THEME_MAP[status];
 };

--- a/uniro_frontend/src/utils/report/getThemeByPassableStatus.ts
+++ b/uniro_frontend/src/utils/report/getThemeByPassableStatus.ts
@@ -1,4 +1,4 @@
-import { PassableStatus } from "../../data/types/report";
+import { PassableStatus } from "../../constant/enum/reportEnum";
 
 export const getThemeByPassableStatus = (status: PassableStatus): string => {
 	const orangeTheme = "border-system-orange text-system-orange bg-[#FFF7EF]";


### PR DESCRIPTION
## #️⃣ 작업 내용
- 제보 폼 페이지를 개발 완료했습니다.

## 핵심 기능

### 1. Report Page State
```typescript
export interface ReportFormData {
	passableStatus: PassableStatus;
	dangerIssues: DangerIssueType[];
	cautionIssues: CautionIssueType[];
}
```
Form Data는 백엔드와 사전에 이야기한 대로, 위험 / 주의 여부와, 위험 / 주의 배열들이 비어있으면 삭제로 판단하기로 했던 로직을 interface에 반영했습니다.

### 2. PassableStatus
```typescript
export enum PassableStatus {
	DANGER = "DANGER",
	CAUTION = "CAUTION",
	RESTORED = "RESTORED",
	INITIAL = "INITIAL",
}
```
위 폼데이터에 들어있던 Type인 PassableStatus 타입은, 위험, 주의, 삭제, 초기로 나누었습니다.
가장 처음 로딩되었을 때, 혹은 버튼을 모두 해제하였을 때 초기로 설정하고, 나머지는 조건에 맞게 Status를 넘겨주었습니다.
대부분의 로직을, PassableStatus를 prop으로 넘겨주는 방식으로 처리하였습니다.

### 2. Theme Util 
```typescript
import { PassableStatus } from "../../constant/enum/reportEnum";

export const getThemeByPassableStatus = (status: PassableStatus): string => {
	const orangeTheme = "border-system-orange text-system-orange bg-[#FFF7EF]";
	const redTheme = "border-system-red text-system-red bg-[#FFF5F7]";
	const blueTheme = "border-primary-400 text-primary-400 bg-[#F0F5FE]";
	const whiteTheme = "bg-gray-100 border-gray-400";

	switch (status) {
		case PassableStatus.DANGER:
			return redTheme;
		case PassableStatus.CAUTION:
			return orangeTheme;
		case PassableStatus.RESTORED:
			return blueTheme;
		case PassableStatus.INITIAL:
		default:
			return whiteTheme;
	}
};
```
PassableStatus에 따라 Button의 Theme을 변경할 수 있도록 했습니다. PR을 쓰다보니, 이런것들을 Context로 관리할까 생각이 들긴 하는데 동현님 생각도 궁금합니다. 사실 그렇게 Depth가 높진 않아서 괜찮을 것 같긴 한데.. 의견이 궁금하네요 @dgfh0450 

### 3. 로딩 시뮬레이션
```typescript
       const [reportMode, setReportMode] = useState<ReportModeType | null>(null);

	const [formData, setFormData] = useState<ReportFormData>({
		passableStatus: PassableStatus.INITIAL,
		dangerIssues: [],
		cautionIssues: [],
	});

	const [FailModal, isFailOpen, openFail, closeFail] = useModal();
	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal();

	useEffect(() => {
		setTimeout(() => {
			setReportMode("create");
		}, 2000);
	}, []);
```
이 페이지에서 사전 API 요청이 필요한데, 이 부분에 대해서 loading 처리를 시뮬레이션 하기 위해서 간단하게 구현했습니다.

## 개선 사항
- Report(등록, 수정)와 Status(위험, 주의, 삭제)의 Context화


## 성능 측정
<img width="1494" alt="image" src="https://github.com/user-attachments/assets/bc4e1b63-ab3f-4723-9ba6-96850752d85a" />

점수가 낮아서 슬프네요.. 개선의 여지가 있다고 봅니다

## 동작 확인

### 생성
https://github.com/user-attachments/assets/622c45e0-e8b6-4009-a42a-e5d011243a03

### 수정
https://github.com/user-attachments/assets/733570e6-99af-4d04-b838-4b52db491ebb