### PR TITLE
[UNI-100] refactor : 코어 루트 삭제에 따른 조회 로직 수정

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     // 루트
     ROUTE_NOT_FOUND(404, "루트를 찾을 수 없습니다."),
     CAUTION_DANGER_CANT_EXIST_SIMULTANEOUSLY(400, "위험요소와 주의요소는 동시에 존재할 수 없습니다."),
+    INVALID_MAP(500,"현재 지도 데이터가 제약조건에 어긋난 상태입니다."),
 
     //길 생성
     ELEVATION_API_ERROR(500, "구글 해발고도 API에서 오류가 발생했습니다."),

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/InvalidMapException.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/custom/InvalidMapException.java
@@ -1,0 +1,10 @@
+package com.softeer5.uniro_backend.common.exception.custom;
+
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import com.softeer5.uniro_backend.common.exception.CustomException;
+
+public class InvalidMapException extends CustomException {
+    public InvalidMapException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
@@ -22,7 +22,7 @@ public interface RouteApi {
 			@ApiResponse(responseCode = "200", description = "모든 지도 조회 성공"),
 			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
-	public ResponseEntity<List<GetAllRoutesResDTO>> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
+	public ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
 
 	@Operation(summary = "위험&주의 요소 조회")
 	@ApiResponses(value = {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
@@ -20,8 +20,8 @@ public class RouteController implements RouteApi {
 
 	@Override
 	@GetMapping("/{univId}/routes")
-	public ResponseEntity<List<GetAllRoutesResDTO>> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
-		List<GetAllRoutesResDTO> allRoutes = routeService.getAllRoutes(univId);
+	public ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
+		GetAllRoutesResDTO allRoutes = routeService.getAllRoutes(univId);
 		return ResponseEntity.ok().body(allRoutes);
 	}
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/CoreRouteDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/CoreRouteDTO.java
@@ -1,0 +1,22 @@
+package com.softeer5.uniro_backend.route.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CoreRouteDTO {
+    private final Long coreNode1Id;
+    private final Long cordNode2Id;
+    private final List<RouteCoordinatesInfo> routes;
+
+    private CoreRouteDTO(Long coreNode1Id, Long cordNode2Id, List<RouteCoordinatesInfo> routes){
+        this.coreNode1Id = coreNode1Id;
+        this.cordNode2Id = cordNode2Id;
+        this.routes = routes;
+    }
+
+    public static CoreRouteDTO of(Long startNode, Long endNode, List<RouteCoordinatesInfo> routes){
+        return new CoreRouteDTO(startNode, endNode, routes);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
@@ -1,29 +1,28 @@
 package com.softeer5.uniro_backend.route.dto;
 
-import com.softeer5.uniro_backend.node.entity.Node;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
 public class GetAllRoutesResDTO {
-    @Schema(description = "node1(코어노드) id", example = "3")
-    private final Long coreNode1Id;
-    @Schema(description = "node2(코어노드) id", example = "4")
-    private final Long cordNode2Id;
-    @Schema(description = "길을 이루는 좌표목록", example = "")
-    private final List<RouteCoordinatesInfo> routes;
+    @Schema(description = "노드 정보 (id, 좌표)", example = "")
+    private final List<NodeInfo> nodeInfos;
+    @Schema(description = "루트 정보 (id, startNodeId, endNodeId)", example = "")
+    private final List<CoreRouteDTO> coreRoutes;
 
 
-    private GetAllRoutesResDTO(Long coreNode1Id, Long cordNode2Id, List<RouteCoordinatesInfo> routes){
-        this.coreNode1Id = coreNode1Id;
-        this.cordNode2Id = cordNode2Id;
-        this.routes = routes;
+    private GetAllRoutesResDTO(List<NodeInfo> nodeInfos, List<CoreRouteDTO> coreRoutes){
+        this.nodeInfos = nodeInfos;
+        this.coreRoutes = coreRoutes;
     }
 
-    public static GetAllRoutesResDTO of(Long startNode, Long endNode, List<RouteCoordinatesInfo> routes){
-        return new GetAllRoutesResDTO(startNode, endNode, routes);
+    public static GetAllRoutesResDTO of(List<NodeInfo> nodeInfos, List<CoreRouteDTO> coreRoutes){
+        return new GetAllRoutesResDTO(nodeInfos, coreRoutes);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
@@ -1,31 +1,29 @@
 package com.softeer5.uniro_backend.route.dto;
 
 import com.softeer5.uniro_backend.node.entity.Node;
-import com.softeer5.uniro_backend.route.entity.CoreRoute;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.List;
-import java.util.Map;
 
 @Getter
 @Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
 public class GetAllRoutesResDTO {
     @Schema(description = "node1(코어노드) id", example = "3")
-    private final Long node1Id;
+    private final Long coreNode1Id;
     @Schema(description = "node2(코어노드) id", example = "4")
-    private final Long node2Id;
+    private final Long cordNode2Id;
     @Schema(description = "길을 이루는 좌표목록", example = "")
-    private final List<Map<String, Double>> routes;
+    private final List<RouteCoordinatesInfo> routes;
 
 
-    private GetAllRoutesResDTO(Long node1Id, Long node2Id, List<Map<String, Double>> routes){
-        this.node1Id = node1Id;
-        this.node2Id = node2Id;
+    private GetAllRoutesResDTO(Long coreNode1Id, Long cordNode2Id, List<RouteCoordinatesInfo> routes){
+        this.coreNode1Id = coreNode1Id;
+        this.cordNode2Id = cordNode2Id;
         this.routes = routes;
     }
 
-    public static GetAllRoutesResDTO of(List<Node> nodes){
-        return new GetAllRoutesResDTO(nodes.get(0).getId(), nodes.get(nodes.size()-1).getId(), nodes.stream().map(Node::getXY).toList());
+    public static GetAllRoutesResDTO of(Long startNode, Long endNode, List<RouteCoordinatesInfo> routes){
+        return new GetAllRoutesResDTO(startNode, endNode, routes);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/GetAllRoutesResDTO.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.route.dto;
 
+import com.softeer5.uniro_backend.node.entity.Node;
 import com.softeer5.uniro_backend.route.entity.CoreRoute;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
@@ -10,8 +11,6 @@ import java.util.Map;
 @Getter
 @Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
 public class GetAllRoutesResDTO {
-    @Schema(description = "코어루트(코어노드-코어노드) id", example = "1")
-    private final Long coreRouteId;
     @Schema(description = "node1(코어노드) id", example = "3")
     private final Long node1Id;
     @Schema(description = "node2(코어노드) id", example = "4")
@@ -19,14 +18,14 @@ public class GetAllRoutesResDTO {
     @Schema(description = "길을 이루는 좌표목록", example = "")
     private final List<Map<String, Double>> routes;
 
-    private GetAllRoutesResDTO(Long coreRouteId, Long node1Id, Long node2Id, List<Map<String, Double>> routes){
-        this.coreRouteId = coreRouteId;
+
+    private GetAllRoutesResDTO(Long node1Id, Long node2Id, List<Map<String, Double>> routes){
         this.node1Id = node1Id;
         this.node2Id = node2Id;
         this.routes = routes;
     }
 
-    public static GetAllRoutesResDTO of(CoreRoute coreRoute){
-        return new GetAllRoutesResDTO(coreRoute.getId(), coreRoute.getNode1Id(), coreRoute.getNode2Id(), coreRoute.getPathAsList());
+    public static GetAllRoutesResDTO of(List<Node> nodes){
+        return new GetAllRoutesResDTO(nodes.get(0).getId(), nodes.get(nodes.size()-1).getId(), nodes.stream().map(Node::getXY).toList());
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/NodeInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/NodeInfo.java
@@ -1,0 +1,18 @@
+package com.softeer5.uniro_backend.route.dto;
+
+
+import lombok.*;
+
+import java.util.Map;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Setter
+public class NodeInfo{
+    private final Long nodeId;
+    private final Map<String, Double> coordinates;
+
+    public static NodeInfo of(Long nodeId, Map<String, Double> coordinates) {
+        return new NodeInfo(nodeId, coordinates);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/RouteCoordinatesInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/RouteCoordinatesInfo.java
@@ -1,0 +1,21 @@
+package com.softeer5.uniro_backend.route.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RouteCoordinatesInfo {
+    private final Long routeId;
+    private final Long startNodeId;
+    private final Map<String, Double> startNode;
+    private final Long endNodeId;
+    private final Map<String, Double> endNode;
+
+    public static RouteCoordinatesInfo of(Long routeId, Long startNodeId, Map<String, Double> startNode, Long endNodeId, Map<String, Double> endNode) {
+        return new RouteCoordinatesInfo(routeId, startNodeId, startNode, endNodeId, endNode);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/RouteCoordinatesInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/RouteCoordinatesInfo.java
@@ -1,8 +1,6 @@
 package com.softeer5.uniro_backend.route.dto;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 import java.util.Map;
 
@@ -10,12 +8,19 @@ import java.util.Map;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class RouteCoordinatesInfo {
     private final Long routeId;
-    private final Long startNodeId;
-    private final Map<String, Double> startNode;
-    private final Long endNodeId;
-    private final Map<String, Double> endNode;
+    private final NodeInfo startNode;
+    private final NodeInfo endNode;
+
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    private static class NodeInfo{
+        private final Long nodeId;
+        private final Map<String, Double> coordinates;
+    }
 
     public static RouteCoordinatesInfo of(Long routeId, Long startNodeId, Map<String, Double> startNode, Long endNodeId, Map<String, Double> endNode) {
-        return new RouteCoordinatesInfo(routeId, startNodeId, startNode, endNodeId, endNode);
+        return new RouteCoordinatesInfo(routeId, new NodeInfo(startNodeId,startNode),
+                new NodeInfo(endNodeId, endNode));
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/RouteCoordinatesInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/RouteCoordinatesInfo.java
@@ -8,19 +8,10 @@ import java.util.Map;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class RouteCoordinatesInfo {
     private final Long routeId;
-    private final NodeInfo startNode;
-    private final NodeInfo endNode;
+    private final Long startNodeId;
+    private final Long endNodeId;
 
-    @AllArgsConstructor
-    @Getter
-    @Setter
-    private static class NodeInfo{
-        private final Long nodeId;
-        private final Map<String, Double> coordinates;
-    }
-
-    public static RouteCoordinatesInfo of(Long routeId, Long startNodeId, Map<String, Double> startNode, Long endNodeId, Map<String, Double> endNode) {
-        return new RouteCoordinatesInfo(routeId, new NodeInfo(startNodeId,startNode),
-                new NodeInfo(endNodeId, endNode));
+    public static RouteCoordinatesInfo of(Long routeId, Long startNodeId, Long endNodeId) {
+        return new RouteCoordinatesInfo(routeId, startNodeId, endNodeId);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
@@ -1,14 +1,14 @@
 package com.softeer5.uniro_backend.route.service;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.DangerCautionConflictException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteNotFoundException;
 import com.softeer5.uniro_backend.common.utils.Utils;
+import com.softeer5.uniro_backend.node.entity.Node;
 import com.softeer5.uniro_backend.route.dto.*;
-import com.softeer5.uniro_backend.route.entity.CoreRoute;
-import com.softeer5.uniro_backend.route.repository.CoreRouteRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,12 +22,127 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class RouteService {
 	private final RouteRepository routeRepository;
-	private final CoreRouteRepository coreRouteRepository;
 
 
 	public List<GetAllRoutesResDTO> getAllRoutes(Long univId) {
-		List<CoreRoute> coreRoutes = coreRouteRepository.findByUnivId(univId);
+		List<Route> routes = routeRepository.findAllRouteByUnivIdWithNodes(univId);
+
+		// 맵이 존재하지 않을 경우 예외
+		if(routes.isEmpty()) {
+			throw new RouteNotFoundException("Route Not Found", ErrorCode.ROUTE_NOT_FOUND);
+		}
+
+		//인접 리스트
+		Map<Long, List<Route>> adjMap = new HashMap<>();
+		//BFS를 시작할 노드
+		Node startNode = null;
+		for(Route route : routes) {
+			adjMap.computeIfAbsent(route.getNode1().getId(), k -> new ArrayList<>()).add(route);
+			adjMap.computeIfAbsent(route.getNode2().getId(), k -> new ArrayList<>()).add(route);
+
+			if(startNode != null) continue;
+			if(route.getNode1().isCore()) startNode = route.getNode1();
+			else if(route.getNode2().isCore()) startNode = route.getNode2();
+		}
+
+		// 맵에 코어노드가 없는 경우 서브노드끼리 순서 매겨서 리턴
+		if(startNode==null){
+			List<Long> endNodes = adjMap.entrySet()
+					.stream()
+					.filter(entry -> entry.getValue().size() == 1)  // 리스트 크기가 1인 항목 필터링
+					.map(Map.Entry::getKey)
+					.collect(Collectors.toList());
+
+			Node
+			//만약 끝 노드가 없는경우 서브노드끼리 사이클이 돌고있는 상황
+			if(endNodes.isEmpty()){
+
+			}
+
+			//끝 노드가 2개인 경우 둘 중 하나에서 출발
+			if(endNodes.size()==2){
+
+			}
+
+			getCoreRoutes(adjMap, startNode);
+
+			// 예외처리 (유효하지 않는 맵)
+		}
+
+		List<List<Node>> coreRoutes = getCoreRoutes(adjMap, startNode);
+
 		return coreRoutes.stream().map(GetAllRoutesResDTO::of).toList();
+	}
+
+	// coreRoute를 만들어주는 메서드
+	private List<List<Node>> getCoreRoutes(Map<Long, List<Route>> adjMap, Node startNode) {
+		List<List<Node>> result = new ArrayList<>();
+		// core node간의 BFS 할 때 방문여부를 체크하는 set
+		Set<Long> visitedCoreNodes = new HashSet<>();
+		// 길 중복을 처리하기 위한 set
+		Set<String> routeSet = new HashSet<>();
+
+		// BFS 전처리
+		Queue<Node> nodeQueue = new LinkedList<>();
+		nodeQueue.add(startNode);
+		visitedCoreNodes.add(startNode.getId());
+
+		// BFS
+		while(!nodeQueue.isEmpty()) {
+			// 현재 노드 (코어노드)
+			Node now = nodeQueue.poll();
+			for(Route r : adjMap.get(now.getId())) {
+				// 다음 노드 (서브노드일수도 있고 코어노드일 수도 있음)
+				Node nxt = now.getId().equals(r.getNode1().getId()) ? r.getNode2() : r.getNode1();
+				String hash = makeHash(now.getId(),nxt.getId());
+
+				// 만약 now-nxt를 연결하는 길이 이미 등록되어있다면, 해당 coreRoute는 이미 등록된 것이므로 continue;
+				if(routeSet.contains(hash)) continue;
+
+				// 코어루트를 이루는 node들을 List로 저장
+				List<Node> coreRoute = new ArrayList<>();
+				// 코어루트에 중복된 node가 들어가지 않도록 판단하는 set
+				Set<Long> visitedNodes = new HashSet<>();
+				coreRoute.add(now);
+				routeSet.add(makeHash(now.getId(),nxt.getId()));
+				visitedNodes.add(now.getId());
+
+				Node currentNode = nxt;
+				while (true) {
+					coreRoute.add(currentNode);
+					visitedNodes.add(currentNode.getId());
+
+					//코어노드를 만나면 queue에 넣을지 판단한 뒤 종료
+					if (currentNode.isCore()) {
+						if (!visitedCoreNodes.contains(currentNode.getId())) {
+							visitedCoreNodes.add(currentNode.getId());
+							nodeQueue.add(currentNode);
+						}
+						break;
+					}
+					// 끝점인 경우 종료
+					if (adjMap.get(currentNode.getId()).size() == 1) break;
+
+					// 서브노드에 연결된 두 route 중 방문하지 않았던 route를 선택한 뒤, currentNode를 업데이트
+					for (Route R : adjMap.get(currentNode.getId())) {
+						Node nextNode = R.getNode1().getId().equals(currentNode.getId()) ? R.getNode2() : R.getNode1();
+						if (visitedNodes.contains(nextNode.getId())) continue;
+						routeSet.add(makeHash(nextNode.getId(),currentNode.getId()));
+						currentNode = nextNode;
+					}
+				}
+				result.add(coreRoute);
+			}
+
+		}
+		return result;
+	}
+
+	private String makeHash(Long id1, Long id2) {
+		if(id1<id2){
+			return id1 + "-" + id2;
+		}
+		return id2 + "-" + id1;
 	}
 
 	public GetRiskRoutesResDTO getRiskRoutes(Long univId) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.DangerCautionConflictException;
+import com.softeer5.uniro_backend.common.exception.custom.InvalidMapException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteNotFoundException;
 import com.softeer5.uniro_backend.common.utils.Utils;
 import com.softeer5.uniro_backend.node.entity.Node;
@@ -34,11 +35,14 @@ public class RouteService {
 
 		//인접 리스트
 		Map<Long, List<Route>> adjMap = new HashMap<>();
+		Map<Long, Node> nodeMap = new HashMap<>();
 		//BFS를 시작할 노드
 		Node startNode = null;
 		for(Route route : routes) {
 			adjMap.computeIfAbsent(route.getNode1().getId(), k -> new ArrayList<>()).add(route);
 			adjMap.computeIfAbsent(route.getNode2().getId(), k -> new ArrayList<>()).add(route);
+			nodeMap.put(route.getNode1().getId(), route.getNode1());
+			nodeMap.put(route.getNode2().getId(), route.getNode2());
 
 			if(startNode != null) continue;
 			if(route.getNode1().isCore()) startNode = route.getNode1();
@@ -53,34 +57,28 @@ public class RouteService {
 					.map(Map.Entry::getKey)
 					.collect(Collectors.toList());
 
-			Node
-			//만약 끝 노드가 없는경우 서브노드끼리 사이클이 돌고있는 상황
-			if(endNodes.isEmpty()){
-
-			}
-
 			//끝 노드가 2개인 경우 둘 중 하나에서 출발
 			if(endNodes.size()==2){
-
+				startNode = nodeMap.get(endNodes.get(0));
+				return List.of(getSingleRoutes(adjMap, startNode));
 			}
 
-			getCoreRoutes(adjMap, startNode);
+			// 그 외의 경우의 수는 모두 사이클만 존재하거나, 규칙에 어긋난 맵
+			throw new InvalidMapException("Invalid Map", ErrorCode.INVALID_MAP);
 
-			// 예외처리 (유효하지 않는 맵)
 		}
 
-		List<List<Node>> coreRoutes = getCoreRoutes(adjMap, startNode);
 
-		return coreRoutes.stream().map(GetAllRoutesResDTO::of).toList();
+		return getCoreRoutes(adjMap, startNode);
 	}
 
 	// coreRoute를 만들어주는 메서드
-	private List<List<Node>> getCoreRoutes(Map<Long, List<Route>> adjMap, Node startNode) {
-		List<List<Node>> result = new ArrayList<>();
+	private List<GetAllRoutesResDTO> getCoreRoutes(Map<Long, List<Route>> adjMap, Node startNode) {
+		List<GetAllRoutesResDTO> result = new ArrayList<>();
 		// core node간의 BFS 할 때 방문여부를 체크하는 set
 		Set<Long> visitedCoreNodes = new HashSet<>();
 		// 길 중복을 처리하기 위한 set
-		Set<String> routeSet = new HashSet<>();
+		Set<Long> routeSet = new HashSet<>();
 
 		// BFS 전처리
 		Queue<Node> nodeQueue = new LinkedList<>();
@@ -92,26 +90,18 @@ public class RouteService {
 			// 현재 노드 (코어노드)
 			Node now = nodeQueue.poll();
 			for(Route r : adjMap.get(now.getId())) {
-				// 다음 노드 (서브노드일수도 있고 코어노드일 수도 있음)
-				Node nxt = now.getId().equals(r.getNode1().getId()) ? r.getNode2() : r.getNode1();
-				String hash = makeHash(now.getId(),nxt.getId());
-
 				// 만약 now-nxt를 연결하는 길이 이미 등록되어있다면, 해당 coreRoute는 이미 등록된 것이므로 continue;
-				if(routeSet.contains(hash)) continue;
+				if(routeSet.contains(r.getId())) continue;
+
+				// 다음 노드 (서브노드일수도 있고 코어노드일 수도 있음)
+				Node currentNode = now.getId().equals(r.getNode1().getId()) ? r.getNode2() : r.getNode1();
 
 				// 코어루트를 이루는 node들을 List로 저장
-				List<Node> coreRoute = new ArrayList<>();
-				// 코어루트에 중복된 node가 들어가지 않도록 판단하는 set
-				Set<Long> visitedNodes = new HashSet<>();
-				coreRoute.add(now);
-				routeSet.add(makeHash(now.getId(),nxt.getId()));
-				visitedNodes.add(now.getId());
+				List<RouteCoordinatesInfo> coreRoute = new ArrayList<>();
+				coreRoute.add(RouteCoordinatesInfo.of(r.getId(),now.getId(), now.getXY(),currentNode.getId(),currentNode.getXY()));
+				routeSet.add(r.getId());
 
-				Node currentNode = nxt;
 				while (true) {
-					coreRoute.add(currentNode);
-					visitedNodes.add(currentNode.getId());
-
 					//코어노드를 만나면 queue에 넣을지 판단한 뒤 종료
 					if (currentNode.isCore()) {
 						if (!visitedCoreNodes.contains(currentNode.getId())) {
@@ -125,24 +115,39 @@ public class RouteService {
 
 					// 서브노드에 연결된 두 route 중 방문하지 않았던 route를 선택한 뒤, currentNode를 업데이트
 					for (Route R : adjMap.get(currentNode.getId())) {
+						if (routeSet.contains(R.getId())) continue;
 						Node nextNode = R.getNode1().getId().equals(currentNode.getId()) ? R.getNode2() : R.getNode1();
-						if (visitedNodes.contains(nextNode.getId())) continue;
-						routeSet.add(makeHash(nextNode.getId(),currentNode.getId()));
+						coreRoute.add(RouteCoordinatesInfo.of(R.getId(), currentNode.getId(), currentNode.getXY(), nextNode.getId(), nextNode.getXY()));
+						routeSet.add(R.getId());
 						currentNode = nextNode;
 					}
 				}
-				result.add(coreRoute);
+				result.add(GetAllRoutesResDTO.of(now.getId(), currentNode.getId(), coreRoute));
 			}
 
 		}
 		return result;
 	}
 
-	private String makeHash(Long id1, Long id2) {
-		if(id1<id2){
-			return id1 + "-" + id2;
+	private GetAllRoutesResDTO getSingleRoutes(Map<Long, List<Route>> adjMap, Node startNode) {
+		List<RouteCoordinatesInfo> coreRoute = new ArrayList<>();
+		Set<Long> visitedNodes = new HashSet<>();
+		visitedNodes.add(startNode.getId());
+
+
+		Node currentNode = startNode;
+		boolean flag = true;
+		while(flag){
+			flag = false;
+			for (Route r : adjMap.get(currentNode.getId())) {
+				Node nextNode = r.getNode1().getId().equals(currentNode.getId()) ? r.getNode2() : r.getNode1();
+				if(visitedNodes.contains(nextNode.getId())) continue;
+				coreRoute.add(RouteCoordinatesInfo.of(r.getId(), currentNode.getId(), currentNode.getXY(), nextNode.getId(), nextNode.getXY()));
+				flag = true;
+				currentNode = nextNode;
+			}
 		}
-		return id2 + "-" + id1;
+		return GetAllRoutesResDTO.of(startNode.getId(), currentNode.getId(), coreRoute);
 	}
 
 	public GetRiskRoutesResDTO getRiskRoutes(Long univId) {


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
코어 루트가 삭제되어 대학교의 모든 route를 조회하는 로직을 수정하였습니다.
- 코어노드 간에는 BFS로 이동하였으며, 코어노드와 코어노드 사이에 존재하는 서브노드들 (기존의 코어 루트)을 선형으로 탐색하여 List에 담아 처리하였습니다.
- 사이클, route 미존재, 코어노드가 없는 경우 등 예외처리를 진행하였습니다.


## 💡 To Reviewer
- 로직 특성상 코드가 길고 사용하는 변수가 많아서 읽기 어려울 것으로 예상됩니다. 최대한 주석을 달았지만, 이해되지 않는 부분 있으면 코멘트나 오프라인으로 질문해주시면 감사하겠습니다.
- BFS 로직 안에 존재하는 이중 while문을 분리하고 싶었으나 그렇게 될 경우 7,8개의 파라미터를 넘겨줘야 하는 상황입니다. 좋은 코드 수정 방향 있으면 조언 부탁드립니다.
- 현재 lat, lng가 반대로 출력되는것 같은데 같은 현상 겪고 계신지 확인 부탁드립니다.

## 🧪 테스트 결과
<<테스트 결과>>
<img width="621" alt="image" src="https://github.com/user-attachments/assets/04246235-1e19-46c9-8d1f-5a6c0dca97a8" />


<<코어노드가 없는 (일자로 된 경우) 지도에서의 예외처리 테스트>>
<img width="648" alt="image" src="https://github.com/user-attachments/assets/906a58f2-daf8-4721-a0fa-ff20c0b98000" />



## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->