### PR TITLE
[UNI-105] feat : 예외 처리 로직 구현

### DIFF
--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -10,10 +10,14 @@ import ReportRoutePage from "./pages/reportRoute";
 import ReportForm from "./pages/reportForm";
 import ReportHazardPage from "./pages/reportHazard";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import OfflinePage from "./pages/offline";
+import useNetworkStatus from "./hooks/useNetworkStatus";
 
 const queryClient = new QueryClient();
 
 function App() {
+	useNetworkStatus();
+
 	return (
 		<QueryClientProvider client={queryClient}>
 			<Routes>
@@ -26,6 +30,9 @@ function App() {
 				<Route path="/result" element={<NavigationResultPage />} />
 				<Route path="/report/route" element={<ReportRoutePage />} />
 				<Route path="/report/hazard" element={<ReportHazardPage />} />
+
+				/** 에러 페이지 */
+				<Route path="/error/offline" element={<OfflinePage />} />
 			</Routes>
 		</QueryClientProvider>
 	);

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -31,7 +31,6 @@ function App() {
 				<Route path="/result" element={<NavigationResultPage />} />
 				<Route path="/report/route" element={<ReportRoutePage />} />
 				<Route path="/report/hazard" element={<ReportHazardPage />} />
-
 				/** 에러 페이지 */
 				<Route path="/error" element={<ErrorPage />} />
 				<Route path="/error/offline" element={<OfflinePage />} />

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -12,6 +12,7 @@ import ReportHazardPage from "./pages/reportHazard";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import OfflinePage from "./pages/offline";
 import useNetworkStatus from "./hooks/useNetworkStatus";
+import ErrorPage from "./pages/error";
 
 const queryClient = new QueryClient();
 
@@ -32,6 +33,7 @@ function App() {
 				<Route path="/report/hazard" element={<ReportHazardPage />} />
 
 				/** 에러 페이지 */
+				<Route path="/error" element={<ErrorPage />} />
 				<Route path="/error/offline" element={<OfflinePage />} />
 			</Routes>
 		</QueryClientProvider>

--- a/uniro_frontend/src/hooks/useNetworkStatus.tsx
+++ b/uniro_frontend/src/hooks/useNetworkStatus.tsx
@@ -1,27 +1,27 @@
-import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
 
 export default function useNetworkStatus() {
-    const [isOffline, setIsOffline] = useState<boolean>(false);
-    const navigate = useNavigate();
+	const [isOffline, setIsOffline] = useState<boolean>(false);
+	const navigate = useNavigate();
 
-    const handleOffline = () => {
-        setIsOffline(true);
-        navigate('/error/offline');
-    }
+	const handleOffline = () => {
+		setIsOffline(true);
+		navigate("/error/offline");
+	};
 
-    const handleOnline = () => {
-        setIsOffline(false);
-        navigate(-1);
-    }
+	const handleOnline = () => {
+		setIsOffline(false);
+		navigate(-1);
+	};
 
-    useEffect(() => {
-        window.addEventListener("offline", handleOffline);
-        window.addEventListener('online', handleOnline);
+	useEffect(() => {
+		window.addEventListener("offline", handleOffline);
+		window.addEventListener("online", handleOnline);
 
-        return () => {
-            window.removeEventListener("offline", handleOffline);
-            window.removeEventListener("online", handleOnline);
-        }
-    })
+		return () => {
+			window.removeEventListener("offline", handleOffline);
+			window.removeEventListener("online", handleOnline);
+		};
+	});
 }

--- a/uniro_frontend/src/hooks/useNetworkStatus.tsx
+++ b/uniro_frontend/src/hooks/useNetworkStatus.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+
+export default function useNetworkStatus() {
+    const [isOffline, setIsOffline] = useState<boolean>(false);
+    const navigate = useNavigate();
+
+    const handleOffline = () => {
+        setIsOffline(true);
+        navigate('/error/offline');
+    }
+
+    const handleOnline = () => {
+        setIsOffline(false);
+        navigate(-1);
+    }
+
+    useEffect(() => {
+        window.addEventListener("offline", handleOffline);
+        window.addEventListener('online', handleOnline);
+
+        return () => {
+            window.removeEventListener("offline", handleOffline);
+            window.removeEventListener("online", handleOnline);
+        }
+    })
+}

--- a/uniro_frontend/src/hooks/useNetworkStatus.tsx
+++ b/uniro_frontend/src/hooks/useNetworkStatus.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 
 export default function useNetworkStatus() {
-	const [isOffline, setIsOffline] = useState<boolean>(false);
+	const [isOffline, setIsOffline] = useState(false);
 	const navigate = useNavigate();
 
 	const handleOffline = () => {

--- a/uniro_frontend/src/hooks/useRedirectUndefined.tsx
+++ b/uniro_frontend/src/hooks/useRedirectUndefined.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+
+export default function useRedirectUndefined<T>(deps: T[], url?: string) {
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		for (const dep of deps) {
+			if (dep === undefined) {
+				navigate(url ? url : "/landing");
+			}
+		}
+	}, [deps]);
+}

--- a/uniro_frontend/src/hooks/useRedirectUndefined.tsx
+++ b/uniro_frontend/src/hooks/useRedirectUndefined.tsx
@@ -1,14 +1,12 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router";
 
-export default function useRedirectUndefined<T>(deps: T[], url?: string) {
+export default function useRedirectUndefined<T>(deps: T[], url: string = "/landing") {
 	const navigate = useNavigate();
 
 	useEffect(() => {
-		for (const dep of deps) {
-			if (dep === undefined) {
-				navigate(url ? url : "/landing");
-			}
+		if (deps.some((dep) => dep === undefined)) {
+			navigate(url);
 		}
-	}, [deps]);
+	}, [navigate, ...deps]);
 }

--- a/uniro_frontend/src/hooks/useRedirectUndefined.tsx
+++ b/uniro_frontend/src/hooks/useRedirectUndefined.tsx
@@ -8,5 +8,5 @@ export default function useRedirectUndefined<T>(deps: T[], url: string = "/landi
 		if (deps.some((dep) => dep === undefined)) {
 			navigate(url);
 		}
-	}, [navigate, ...deps]);
+	}, [...deps]);
 }

--- a/uniro_frontend/src/pages/buildingSearch.tsx
+++ b/uniro_frontend/src/pages/buildingSearch.tsx
@@ -2,9 +2,15 @@ import Input from "../components/customInput";
 import { hanyangBuildings } from "../data/mock/hanyangBuildings";
 import BuildingCard from "../components/building/buildingCard";
 import useSearchBuilding from "../hooks/useSearchBuilding";
+import useUniversityInfo from "../hooks/useUniversityInfo";
+import useRedirectUndefined from "../hooks/useRedirectUndefined";
 
 export default function BuildingSearchPage() {
 	const { setBuilding } = useSearchBuilding();
+
+	const { university } = useUniversityInfo();
+	useRedirectUndefined<string | undefined>([university]);
+
 	return (
 		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center">
 			<div className="px-[14px] py-4 border-b-[1px] border-gray-400">

--- a/uniro_frontend/src/pages/error.tsx
+++ b/uniro_frontend/src/pages/error.tsx
@@ -1,0 +1,9 @@
+import Error from "../components/error/Error";
+
+export default function ErrorPage() {
+	return (
+		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center items-center">
+			<Error />
+		</div>
+	);
+}

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -19,6 +19,8 @@ import { RoutePoint } from "../constant/enum/routeEnum";
 import { Markers } from "../constant/enum/markerEnum";
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
 import toggleMarkers from "../utils/markers/toggleMarkers";
+import useUniversityInfo from "../hooks/useUniversityInfo";
+import useRedirectUndefined from "../hooks/useRedirectUndefined";
 
 export type SelectedMarkerTypes = {
 	type: MarkerTypes;
@@ -42,6 +44,9 @@ export default function MapPage() {
 
 	const { origin, setOrigin, destination, setDestination } = useRoutePoint();
 	const { mode, building: selectedBuilding } = useSearchBuilding();
+
+	const { university } = useUniversityInfo();
+	useRedirectUndefined<string | undefined>([university]);
 
 	const initMap = () => {
 		if (map === null) return;

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -14,6 +14,8 @@ import BottomSheetHandle from "../components/navigation/bottomSheet/bottomSheetH
 
 import useLoading from "../hooks/useLoading";
 import Loading from "../components/loading/loading";
+import useUniversityInfo from "../hooks/useUniversityInfo";
+import useRedirectUndefined from "../hooks/useRedirectUndefined";
 
 // 1. 돌아가면 위치 reset ✅
 // 2. 상세경로 scroll 끝까지 가능하게 하기 ❎
@@ -38,6 +40,9 @@ const NavigationResultPage = () => {
 	const [route, setRoute] = useState<NavigationRoute>(mockNavigationRoute);
 
 	useScrollControl();
+
+	const { university } = useUniversityInfo();
+	useRedirectUndefined<string | undefined>([university]);
 
 	useEffect(() => {
 		show();

--- a/uniro_frontend/src/pages/offline.tsx
+++ b/uniro_frontend/src/pages/offline.tsx
@@ -1,9 +1,9 @@
-import Offline from "../components/error/Offline"
+import Offline from "../components/error/Offline";
 
 export default function OfflinePage() {
-    return (
-        <div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center items-center">
-            <Offline />
-        </div>
-    )
+	return (
+		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center items-center">
+			<Offline />
+		</div>
+	);
 }

--- a/uniro_frontend/src/pages/offline.tsx
+++ b/uniro_frontend/src/pages/offline.tsx
@@ -1,0 +1,9 @@
+import Offline from "../components/error/Offline"
+
+export default function OfflinePage() {
+    return (
+        <div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center items-center">
+            <Offline />
+        </div>
+    )
+}

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -12,6 +12,8 @@ import Button from "../components/customButton";
 import useScrollControl from "../hooks/useScrollControl";
 import useModal from "../hooks/useModal";
 import useReportHazard from "../hooks/useReportHazard";
+import useUniversityInfo from "../hooks/useUniversityInfo";
+import useRedirectUndefined from "../hooks/useRedirectUndefined";
 
 const ReportForm = () => {
 	useScrollControl();
@@ -30,6 +32,9 @@ const ReportForm = () => {
 	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal();
 
 	const { reportType, startNode, endNode } = useReportHazard();
+
+	const { university } = useUniversityInfo();
+	useRedirectUndefined<string | undefined>([university, reportType]);
 
 	useEffect(() => {
 		console.log(reportType, startNode, endNode);

--- a/uniro_frontend/src/pages/reportHazard.tsx
+++ b/uniro_frontend/src/pages/reportHazard.tsx
@@ -18,6 +18,8 @@ import { ReportHazardMessage } from "../constant/enum/messageEnum";
 import { motion } from "framer-motion";
 import useReportHazard from "../hooks/useReportHazard";
 import AnimatedContainer from "../container/animatedContainer";
+import useUniversityInfo from "../hooks/useUniversityInfo";
+import useRedirectUndefined from "../hooks/useRedirectUndefined";
 
 interface reportMarkerTypes extends MarkerTypesWithElement {
 	edge: [google.maps.LatLng | google.maps.LatLngLiteral, google.maps.LatLng | google.maps.LatLngLiteral];
@@ -29,6 +31,9 @@ export default function ReportHazardPage() {
 	const { setReportType, setNode } = useReportHazard();
 
 	const [message, setMessage] = useState<ReportHazardMessage>(ReportHazardMessage.DEFAULT);
+
+	const { university } = useUniversityInfo();
+	useRedirectUndefined<string | undefined>([university]);
 
 	const resetMarker = (prevMarker: MarkerTypesWithElement) => {
 		if (prevMarker.type === Markers.REPORT) {

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -14,6 +14,8 @@ import Button from "../components/customButton";
 import { CautionToggleButton, DangerToggleButton } from "../components/map/floatingButtons";
 import { mockHazardEdges } from "../data/mock/hanyangHazardEdge";
 import toggleMarkers from "../utils/markers/toggleMarkers";
+import useUniversityInfo from "../hooks/useUniversityInfo";
+import useRedirectUndefined from "../hooks/useRedirectUndefined";
 
 const colors = [
 	"#f1a2b3",
@@ -45,6 +47,9 @@ export default function ReportRoutePage() {
 
 	const [cautionMarkers, setCautionMarkers] = useState<AdvancedMarker[]>([]);
 	const [isCautionAcitve, setIsCautionActive] = useState<boolean>(true);
+
+	const { university } = useUniversityInfo();
+	useRedirectUndefined<string | undefined>([university]);
 
 	const addHazardMarker = () => {
 		if (AdvancedMarker === null || map === null) return;


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 네트워크 예외 (클라이언트 Offline, Online) 처리 로직 구현
2. 에러 페이지 (Offline, Error) 페이지 생성
3. 경로 예외 처리 (데이터 없이 URL로 접근하는 경우) 처리 로직 구현

## 핵심 기능
### 1. 네트워크 예외 처리 Hook 생성
```typescript
import { useEffect, useState } from "react";
import { useNavigate } from "react-router";

export default function useNetworkStatus() {
	const [isOffline, setIsOffline] = useState<boolean>(false);
	const navigate = useNavigate();

	const handleOffline = () => {
		setIsOffline(true);
		navigate("/error/offline");
	};

	const handleOnline = () => {
		setIsOffline(false);
		navigate(-1);
	};

	useEffect(() => {
		window.addEventListener("offline", handleOffline);
		window.addEventListener("online", handleOnline);

		return () => {
			window.removeEventListener("offline", handleOffline);
			window.removeEventListener("online", handleOnline);
		};
	});
}
```
- window에 offline, online 이벤트를 등록하여 네트워크 변화를 감지하였습니다.
- offline시, 생성한 offline 페이지로 리다이렉트 되고
- offline에서 online으로 재연결시, `navigate(-1)` 을 써서 이전 페이지로 돌아갈 수 있도록 하여 사용자 경험을 개선하였습니다.
- 이 훅은 App.tsx 최상위에서 한 번 선언하면 모든 페이지에서 적용이 됩니다.
```typescript
function App() {
	useNetworkStatus();
        return (
        ...
        )
}
```

### 2. 경로 예외 처리
- 현재 모든 페이지는 학교를 선택한 이후 과정이 이뤄지기에 URL로 학교 설정 없이 접근하게 될 경우, 이후 로직들에 에러가 발생할 수 있는 문제가 존재합니다.
- 이를 해결하기 위해 각 페이지에서 GlobalState에 저장된 값 (ex. 학교 정보, 경로, 제보 타입 등) 들을 검사하고 없을 경우 처리를 하는 로직이 필요하였습니다.
- 커스텀 훅 `useRedirectUndefined` 를 생성하여 특정 값들이 undefined일 경우, 잘못된 접근이라 판단하여 redirect를 시키도록 구현하였습니다.
```typescript
export default function useRedirectUndefined<T>(deps: T[], url?: string) {
	const navigate = useNavigate();

	useEffect(() => {
		for (const dep of deps) {
			if (dep === undefined) {
				navigate(url ? url : "/landing");
			}
		}
	}, [deps]);
}

// 제보 Form 페이지
const { reportType, startNode, endNode } = useReportHazard();

const { university } = useUniversityInfo();
useRedirectUndefined<string | undefined>([university, reportType]);
```
- 다음과 같이 deps를 배열로 받아서 배열의 값 중 하나라도 undefined라면 navigate 시킵니다.
- 필요시 url을 받아 원하는 페이지로 redirect 시킬 수 있습니다.

#### 리팩토링
```typescript
export default function useRedirectUndefined<T>(deps: T[], url: string = "/landing") {
	const navigate = useNavigate();

	useEffect(() => {
		if (deps.some((dep) => dep === undefined)) {
			navigate(url);
		}
	}, [...deps]);
}
```
- 다음과 같이 코드를 개선하였습니다.
- for문으로 인해 반복 navigate가 될 수 있는 부분을 개선하였습니다.
- deps를 spread operator를 사용하여 내부 개별 값의 변화에도 useEffect를 동작할 수 있도록 하였습니다.
- url에 default값을 landing으로 부여하였습니다.


## 동작 확인

### Offline 감지
https://github.com/user-attachments/assets/58814938-ff10-4158-b186-c6ee764903bd

### URL 접근 방지
https://github.com/user-attachments/assets/4e455a72-d8b2-4a3b-b430-0f47f221fdd3



### Related Issue
- UNI-106, UNI-107
