### PR TITLE
[UNI-108] feat : 페이지간 라우터 연결 및 뒤로가기 공통 컴포넌트 생성

### DIFF
--- a/uniro_frontend/src/components/map/backButton.tsx
+++ b/uniro_frontend/src/components/map/backButton.tsx
@@ -1,0 +1,21 @@
+import { useNavigate } from "react-router";
+import ChevronLeft from "../../../public/icons/chevron-left.svg?react";
+
+interface BackButtonProps {
+    className?: string;
+    onClick?: () => void
+}
+
+export default function BackButton({ className = "", onClick }: BackButtonProps) {
+    const navigate = useNavigate();
+
+    const handleBack = () => {
+        navigate(-1);
+    }
+
+    return (
+        <button className={`w-[52px] h-[52px] flex items-center justify-center border border-gray-400 rounded-full bg-gray-100 active:bg-gray-200 ${className}`} onClick={onClick ?? handleBack}>
+            <ChevronLeft width={35} height={35} />
+        </button>
+    )
+}

--- a/uniro_frontend/src/components/map/reportButton.tsx
+++ b/uniro_frontend/src/components/map/reportButton.tsx
@@ -1,14 +1,14 @@
-import { Link } from "react-router";
 import ReportIcon from "../../assets/report.svg?react";
+import { ButtonHTMLAttributes } from "react";
 
-export default function ReportButton() {
+export default function ReportButton({ ...rest }: ButtonHTMLAttributes<HTMLButtonElement>) {
 	return (
-		<Link
-			to="/"
+		<button
+			{...rest}
 			className="rounded-full w-fit h-[50px] px-6 py-3 flex flex-row items-center bg-gray-900 text-gray-100"
 		>
 			제보하기
 			<ReportIcon className="ml-3" stroke="#FFFFFF" />
-		</Link>
+		</button>
 	);
 }

--- a/uniro_frontend/src/components/map/reportModal.tsx
+++ b/uniro_frontend/src/components/map/reportModal.tsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router";
+import ChevronRight from "../../../public/icons/chevron-right.svg?react";
+
+interface ReportModalProps {
+	close: () => void;
+}
+
+export default function ReportModal({ close }: ReportModalProps) {
+	return (
+		<div
+			className="fixed inset-0 flex flex-col items-center justify-end bg-[rgba(0,0,0,0.2)] z-20 py-6 px-4 space-y-[10px]"
+			onClick={close}
+		>
+			<Link
+				to={"/report/route"}
+				className="w-full h-[58px] flex items-center justify-between px-5 bg-gray-100 rounded-400 text-kor-body2 font-semibold text-primary-500"
+			>
+				<p>새로운 길 제보</p>
+				<ChevronRight fill="none" />
+			</Link>
+
+			<Link
+				to={"/report/hazard"}
+				className="w-full h-[58px] flex items-center justify-between px-5 bg-gray-100 rounded-400 text-kor-body2 font-semibold text-primary-500"
+			>
+				<p>불편한 길 제보</p>
+				<ChevronRight fill="none" />
+			</Link>
+		</div>
+	);
+}

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -20,6 +20,8 @@ import { Markers } from "../constant/enum/markerEnum";
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
 import toggleMarkers from "../utils/markers/toggleMarkers";
 import { Link } from "react-router";
+import useModal from "../hooks/useModal";
+import ReportModal from "../components/map/reportModal";
 
 export type SelectedMarkerTypes = {
 	type: MarkerTypes;
@@ -43,6 +45,8 @@ export default function MapPage() {
 
 	const { origin, setOrigin, destination, setDestination } = useRoutePoint();
 	const { mode, building: selectedBuilding } = useSearchBuilding();
+
+	const [_, isOpen, open, close] = useModal();
 
 	const initMap = () => {
 		if (map === null) return;
@@ -294,14 +298,14 @@ export default function MapPage() {
 			</BottomSheet>
 			{origin && destination && origin.id !== destination.id ? (
 				/** 출발지랑 도착지가 존재하는 경우 길찾기 버튼 보이기 */
-				<Link to='/result' className="absolute bottom-6 space-y-2 w-full px-4">
+				<Link to="/result" className="absolute bottom-6 space-y-2 w-full px-4">
 					<Button variant="primary">길찾기</Button>
 				</Link>
 			) : (
 				/** 출발지랑 도착지가 존재하지 않거나, 같은 경우 기존 Button UI 보이기 */
 				<>
 					<div className="absolute right-4 bottom-6 space-y-2">
-						<ReportButton />
+						<ReportButton onClick={open} />
 					</div>
 					<div className="absolute right-4 bottom-[90px] space-y-2">
 						<CautionToggleButton isActive={isCautionAcitve} onClick={toggleCautionButton} />
@@ -309,6 +313,7 @@ export default function MapPage() {
 					</div>
 				</>
 			)}
+			{isOpen && <ReportModal close={close} />}
 		</div>
 	);
 }

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -19,6 +19,7 @@ import { RoutePoint } from "../constant/enum/routeEnum";
 import { Markers } from "../constant/enum/markerEnum";
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
 import toggleMarkers from "../utils/markers/toggleMarkers";
+import { Link } from "react-router";
 
 export type SelectedMarkerTypes = {
 	type: MarkerTypes;
@@ -293,9 +294,9 @@ export default function MapPage() {
 			</BottomSheet>
 			{origin && destination && origin.id !== destination.id ? (
 				/** 출발지랑 도착지가 존재하는 경우 길찾기 버튼 보이기 */
-				<div className="absolute bottom-6 space-y-2 w-full px-4">
+				<Link to='/result' className="absolute bottom-6 space-y-2 w-full px-4">
 					<Button variant="primary">길찾기</Button>
-				</div>
+				</Link>
 			) : (
 				/** 출발지랑 도착지가 존재하지 않거나, 같은 경우 기존 Button UI 보이기 */
 				<>

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -14,6 +14,7 @@ import BottomSheetHandle from "../components/navigation/bottomSheet/bottomSheetH
 
 import useLoading from "../hooks/useLoading";
 import Loading from "../components/loading/loading";
+import BackButton from "../components/map/backButton";
 
 // 1. 돌아가면 위치 reset ✅
 // 2. 상세경로 scroll 끝까지 가능하게 하기 ❎
@@ -102,9 +103,7 @@ const NavigationResultPage = () => {
 				positionDelta={60}
 				isTop={true}
 			>
-				<button onClick={hideDetailView}>
-					<GoBack />
-				</button>
+				<BackButton onClick={hideDetailView} />
 			</AnimatedContainer>
 
 			<AnimatedContainer

--- a/uniro_frontend/src/pages/reportHazard.tsx
+++ b/uniro_frontend/src/pages/reportHazard.tsx
@@ -18,6 +18,7 @@ import { ReportHazardMessage } from "../constant/enum/messageEnum";
 import { motion } from "framer-motion";
 import useReportHazard from "../hooks/useReportHazard";
 import AnimatedContainer from "../container/animatedContainer";
+import BackButton from "../components/map/backButton";
 
 interface reportMarkerTypes extends MarkerTypesWithElement {
 	edge: [google.maps.LatLng | google.maps.LatLngLiteral, google.maps.LatLng | google.maps.LatLngLiteral];
@@ -191,6 +192,7 @@ export default function ReportHazardPage() {
 					{message}
 				</motion.p>
 			</div>
+			<BackButton className="absolute top-[73px] left-4 z-5" />
 			<div ref={mapRef} className="w-full h-full" />
 			<AnimatedContainer
 				isVisible={reportMarker ? true : false}

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -14,6 +14,7 @@ import Button from "../components/customButton";
 import { CautionToggleButton, DangerToggleButton } from "../components/map/floatingButtons";
 import { mockHazardEdges } from "../data/mock/hanyangHazardEdge";
 import toggleMarkers from "../utils/markers/toggleMarkers";
+import BackButton from "../components/map/backButton";
 
 const colors = [
 	"#f1a2b3",
@@ -256,6 +257,7 @@ export default function ReportRoutePage() {
 					선 위 또는 기존 지점을 선택하세요
 				</p>
 			</div>
+			<BackButton className="absolute top-[73px] left-4 z-5" />
 			<div ref={mapRef} className="w-full h-full" />
 			{isActive && (
 				<div className="absolute w-full bottom-6 px-4">

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -251,6 +251,11 @@ export default function ReportRoutePage() {
 
 	return (
 		<div className="relative w-full h-dvh">
+			<div className="w-full h-[57px] flex items-center justify-center absolute top-0 bg-black opacity-50 z-10 py-3 px-4">
+				<p className="text-gray-100 text-kor-body2 font-medium text-center">
+					선 위 또는 기존 지점을 선택하세요
+				</p>
+			</div>
 			<div ref={mapRef} className="w-full h-full" />
 			{isActive && (
 				<div className="absolute w-full bottom-6 px-4">

--- a/uniro_frontend/src/pages/universitySearch.tsx
+++ b/uniro_frontend/src/pages/universitySearch.tsx
@@ -13,7 +13,7 @@ export default function UniversitySearchPage() {
 	return (
 		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto py-5">
 			<div className="w-full px-[14px] pb-[17px] border-b-[1px] border-gray-400">
-				<Input onLengthChange={() => {}} placeholder="우리 학교를 검색해보세요" handleVoiceInput={() => {}} />
+				<Input onLengthChange={() => { }} placeholder="우리 학교를 검색해보세요" handleVoiceInput={() => { }} />
 			</div>
 			<div className="overflow-y-scroll flex-1">
 				<ul
@@ -24,6 +24,7 @@ export default function UniversitySearchPage() {
 				>
 					{UniversityList.map(({ name, img }) => (
 						<UniversityButton
+							key={name}
 							selected={selectedUniv === name}
 							onClick={() => {
 								setSelectedUniv(name);
@@ -36,7 +37,7 @@ export default function UniversitySearchPage() {
 			</div>
 			<div className="px-[14px]">
 				{selectedUniv !== "" && (
-					<Link to="/" onClick={() => setUniversity(selectedUniv)}>
+					<Link to="/map" onClick={() => setUniversity(selectedUniv)}>
 						<Button variant="primary">다음</Button>
 					</Link>
 				)}


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 페이지간 라우터 연결
2. 공통 뒤로가기 컴포넌트 생성
3. 지도 제보하기 모달 생성

## 핵심 기능

### 공통 뒤로가기 버튼 컴포넌트 생성
```typescript
interface BackButtonProps {
    className?: string;
    onClick?: () => void
}

export default function BackButton({ className = "", onClick }: BackButtonProps) {
    const navigate = useNavigate();

    const handleBack = () => {
        navigate(-1);
    }

    return (
        <button className={`w-[52px] h-[52px] flex items-center justify-center border border-gray-400 rounded-full bg-gray-100 active:bg-gray-200 ${className}`} onClick={onClick ?? handleBack}>
            <ChevronLeft width={35} height={35} />
        </button>
    )
}
```
- 기존 이미지로 버튼을 생성하던 컴포넌트를 다음과 같이 공통 컴포넌트로 뒤로가기 버튼을 생성하였습니다.
- className을 props로 받아서 직접적인 위치 조정을 수행합니다.
- onClick이 있는 경우에는 해당 로직을 수행하고 없다면 `navigate(-1)` 으로 뒤로가는 로직을 수행합니다.

```typescript
<BackButton onClick={hideDetailView} />
<BackButton className="absolute top-[73px] left-4 z-5" />
```
- 다음과 같이 사용할 수 있습니다.

## 동작 확인

1. 학교 검색 -> 지도 메인 

https://github.com/user-attachments/assets/ca994a58-4ca2-4a8b-b8d3-198d435d487a

2. 지도 메인 -> 제보하기

https://github.com/user-attachments/assets/5c2c2969-18a8-489d-ba73-8dacadf24c25

3. 지도 메인 -> 경로 탐색 결과

https://github.com/user-attachments/assets/aa0296dd-3867-4429-ad9d-23570997d816