### PR TITLE
[UNI-116] fix : 전역 Suspense 페이지 전환 시 fallback 없이 freeze 되는 현상 해결

### DIFF
--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -10,21 +10,21 @@ import ReportRoutePage from "./pages/reportRoute";
 import ReportForm from "./pages/reportForm";
 import ReportHazardPage from "./pages/reportHazard";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { DynamicSuspense } from "./container/dynamicSuspense";
 import { useDynamicSuspense } from "./hooks/useDynamicSuspense";
 import OfflinePage from "./pages/offline";
 import useNetworkStatus from "./hooks/useNetworkStatus";
 import ErrorPage from "./pages/error";
+import { Suspense } from "react";
 
 const queryClient = new QueryClient();
 
 function App() {
-	useDynamicSuspense();
+  const { location, fallback } = useDynamicSuspense();
   useNetworkStatus();
-	return (
-		<QueryClientProvider client={queryClient}>
-			<DynamicSuspense>
-				<Routes>
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Suspense key={location.key} fallback={fallback}>
+        <Routes>
           <Route path="/" element={<Demo />} />
           <Route path="/landing" element={<LandingPage />} />
           <Route path="/university" element={<UniversitySearchPage />} />
@@ -37,10 +37,10 @@ function App() {
           /** 에러 페이지 */
           <Route path="/error" element={<ErrorPage />} />
           <Route path="/error/offline" element={<OfflinePage />} />
-			  </Routes>
-			</DynamicSuspense>
-		</QueryClientProvider>
-	);
+        </Routes>
+      </Suspense>
+    </QueryClientProvider>
+  );
 }
 
 export default App;

--- a/uniro_frontend/src/container/dynamicSuspense.tsx
+++ b/uniro_frontend/src/container/dynamicSuspense.tsx
@@ -1,8 +1,0 @@
-import { ReactNode, Suspense } from "react";
-import { useFallbackStore } from "../hooks/useFallbackStore";
-
-export const DynamicSuspense = ({ children }: { children: ReactNode }) => {
-	const fallback = useFallbackStore((state) => state.fallback);
-
-	return <Suspense fallback={fallback}>{children}</Suspense>;
-};

--- a/uniro_frontend/src/hooks/useDynamicSuspense.tsx
+++ b/uniro_frontend/src/hooks/useDynamicSuspense.tsx
@@ -5,10 +5,13 @@ import { fallbackConfig } from "../constant/fallback";
 
 export const useDynamicSuspense = () => {
 	const location = useLocation();
-	const { setFallback } = useFallbackStore();
+	const { fallback, setFallback } = useFallbackStore();
 
 	useEffect(() => {
 		const newFallback = fallbackConfig[location.pathname] || fallbackConfig["/"];
 		setFallback(newFallback);
+		console.log("fallback", newFallback);
 	}, [location.pathname, setFallback]);
+
+	return { location, fallback }
 };

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -1,7 +1,6 @@
-import React, { Suspense, useCallback, useEffect, useState } from "react";
-import { AnimatePresence, PanInfo, useDragControls } from "framer-motion";
+import React, { useCallback, useEffect, useState } from "react";
+import { PanInfo, useDragControls } from "framer-motion";
 import Button from "../components/customButton";
-import GoBack from "../assets/icon/goBack.svg?react";
 import RouteList from "../components/navigation/route/routeList";
 
 import { mockNavigationRoute } from "../data/mock/hanyangRoute";
@@ -15,10 +14,8 @@ import BottomSheetHandle from "../components/navigation/bottomSheet/bottomSheetH
 import useLoading from "../hooks/useLoading";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getMockTest } from "../utils/fetch/mockFetch";
-import Loading from "../components/loading/loading";
 import BackButton from "../components/map/backButton";
 
-import useLoading from "../hooks/useLoading";
 import useUniversityInfo from "../hooks/useUniversityInfo";
 import useRedirectUndefined from "../hooks/useRedirectUndefined";
 
@@ -55,7 +52,7 @@ const NavigationResultPage = () => {
 	useRedirectUndefined<string | undefined>([university]);
 
 	useEffect(() => {
-		console.log(data);
+		console.log("status", status);
 	}, [status]);
 
 	const dragControls = useDragControls();


### PR DESCRIPTION
## #️⃣ 작업 내용

전역 Suspense 페이지 전환 시 fallback 없이 freeze 되는 현상을 해결했습니다.
원인은 동료인 윤동현군의 예상대로 Router에서 Suspense를 제대로 처리하지 못하는 문제였습니다.

react-router 6.12 버전부터 생겼던 버그로, 오래전부터 많은 사람들이 겪어왔던 것 같습니다
[Issue 링크](https://github.com/remix-run/react-router/issues/10568)

Suspense의 key를 location의 key를 넣어주어, Suspense를 trigger 해주는 것 같은 원리인 것 같습니다.

하루종일 Suspense에 대해서 공부했는데 이런 해결책이라 좀 허무하지만, 그래도 머릿속에 어떤 원리로 동작하는지 공부하게 되었던 것 같습니다.

## 동작
기존 문제

https://github.com/user-attachments/assets/1aae683d-183d-445a-9fd5-449deb41e0d1

해결된 동작

https://github.com/user-attachments/assets/42d0b159-6ac0-4903-b1ac-bf7daab3a47d

