### PR TITLE
[UNI-87] 길추가 로직 4,5단계 구현 (리팩토링 예정)

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -3,4 +3,6 @@ package com.softeer5.uniro_backend.common.constant;
 public final class UniroConst {
 	public static final String NODE_KEY_DELIMITER = " ";
 	public static final int CORE_NODE_CONDITION = 3;
+	public static final double SECONDS_PER_MITER = 1.0;
+	public static final double METERS_PER_DEGREE = 113000.0;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/GeoUtils.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/GeoUtils.java
@@ -1,15 +1,12 @@
 package com.softeer5.uniro_backend.common.utils;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.*;
 import org.locationtech.jts.io.WKTWriter;
 
 import java.util.List;
 
 public final class GeoUtils {
-    private static final GeometryFactory geometryFactory = new GeometryFactory();
+    private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
     private GeoUtils(){
         // 인스턴스화 방지

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/MapClient.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/MapClient.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.node.client;
+package com.softeer5.uniro_backend.external;
 
 import com.softeer5.uniro_backend.node.entity.Node;
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/MapClientImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/MapClientImpl.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.node.client;
+package com.softeer5.uniro_backend.external;
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/entity/Node.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/node/entity/Node.java
@@ -28,6 +28,7 @@ public class Node {
 	private Long id;
 
 	@NotNull
+	@Column(columnDefinition = "POINT SRID 4326")
 	private Point coordinates;
 
 	private double height;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
@@ -51,6 +51,14 @@ public interface RouteApi {
 								  @PathVariable("routeId") Long routeId,
 								  @RequestBody PostRiskReqDTO postRiskReqDTO);
 
+	@Operation(summary = "길 추가 로직")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "길 추가 성공"),
+			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
+	})
+	ResponseEntity<Void> createRoute (@PathVariable("univId") Long univId,
+									  @RequestBody CreateRouteReqDTO routes);
+
 	@Operation(summary = "빠른 길 계산")
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "빠른 길 계산 성공"),

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteApi.java
@@ -53,7 +53,7 @@ public interface RouteApi {
 
 	@Operation(summary = "길 추가 로직")
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "길 추가 성공"),
+			@ApiResponse(responseCode = "201", description = "길 추가 성공"),
 			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
 	ResponseEntity<Void> createRoute (@PathVariable("univId") Long univId,

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
@@ -2,14 +2,14 @@ package com.softeer5.uniro_backend.route.controller;
 
 import com.softeer5.uniro_backend.route.dto.*;
 import com.softeer5.uniro_backend.route.service.RouteCalculationService;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.softeer5.uniro_backend.route.service.RouteService;
 
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -57,7 +57,7 @@ public class RouteController implements RouteApi {
 	public ResponseEntity<Void> createRoute (@PathVariable("univId") Long univId,
 											 @RequestBody CreateRouteReqDTO routes){
 		routeCalculationService.createRoute(univId,routes);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
 	@Override

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
@@ -53,6 +53,14 @@ public class RouteController implements RouteApi {
 	}
 
 	@Override
+	@PostMapping("/{univId}/route")
+	public ResponseEntity<Void> createRoute (@PathVariable("univId") Long univId,
+											 @RequestBody CreateRouteReqDTO routes){
+		routeCalculationService.createRoute(univId,routes);
+		return ResponseEntity.ok().build();
+	}
+
+	@Override
 	@GetMapping("/{univId}/routes/fastest")
 	public ResponseEntity<FastestRouteResDTO> calculateFastestRoute(@PathVariable("univId") Long univId,
 																	@RequestParam(value = "start-node-id") Long startNodeId,

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/CreateRouteCoordinates.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/CreateRouteCoordinates.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class CreateRouteServiceReqDTO {
+public class CreateRouteCoordinates {
 	private final double x;
 	private final double y;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/CreateRouteReqDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/CreateRouteReqDTO.java
@@ -1,0 +1,14 @@
+package com.softeer5.uniro_backend.route.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateRouteReqDTO {
+    private final Long startNodeId;
+    private final Long endNodeId;
+    private final List<CreateRouteCoordinates> coordinates;
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
@@ -2,6 +2,7 @@ package com.softeer5.uniro_backend.route.entity;
 
 import static jakarta.persistence.FetchType.*;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -35,7 +36,7 @@ public class Route {
 
 	private double cost;
 
-	@Column(columnDefinition = "geometry(LineString, 4326)") // WGS84 좌표계
+	@Column(columnDefinition = "LINESTRING SRID 4326") // WGS84 좌표계
 	private LineString path;
 
 	@ManyToOne(fetch = LAZY)
@@ -71,13 +72,25 @@ public class Route {
 	}
 
 	public void setCautionFactors(List<CautionType> cautionFactors) {
-		this.cautionFactors.clear();
-        this.cautionFactors.addAll(cautionFactors);
+		if (this.cautionFactors == null) {
+			this.cautionFactors = new HashSet<>();
+		} else {
+			this.cautionFactors.clear();
+		}
+		if (cautionFactors != null) {
+			this.cautionFactors.addAll(cautionFactors);
+		}
 	}
 
 	public void setDangerFactors(List<DangerType> dangerFactors) {
-		this.dangerFactors.clear();
-		this.dangerFactors.addAll(dangerFactors);
+		if (this.dangerFactors == null) {
+			this.dangerFactors = new HashSet<>();
+		} else {
+			this.dangerFactors.clear();
+		}
+		if (dangerFactors != null) {
+			this.dangerFactors.addAll(dangerFactors);
+		}
 	}
 
 	@Builder

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -2,20 +2,19 @@ package com.softeer5.uniro_backend.route.service;
 
 import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
 import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
+import static com.softeer5.uniro_backend.common.utils.GeoUtils.getInstance;
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.NodeNotFoundException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteCalculationException;
 import com.softeer5.uniro_backend.common.exception.custom.SameStartAndEndPointException;
 import com.softeer5.uniro_backend.common.exception.custom.UnreachableDestinationException;
-import com.softeer5.uniro_backend.common.utils.GeoUtils;
+import com.softeer5.uniro_backend.node.client.MapClient;
 import com.softeer5.uniro_backend.node.entity.Node;
-import com.softeer5.uniro_backend.route.dto.CreateRouteServiceReqDTO;
+import com.softeer5.uniro_backend.node.repository.NodeRepository;
+import com.softeer5.uniro_backend.route.dto.*;
 import com.softeer5.uniro_backend.route.entity.DirectionType;
 import com.softeer5.uniro_backend.route.entity.Route;
-import com.softeer5.uniro_backend.route.dto.RouteDetailDTO;
-import com.softeer5.uniro_backend.route.dto.RouteInfoDTO;
-import com.softeer5.uniro_backend.route.dto.FastestRouteResDTO;
 import com.softeer5.uniro_backend.route.repository.RouteRepository;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +36,8 @@ import java.util.*;
 @Transactional(readOnly = true)
 public class RouteCalculationService {
     private final RouteRepository routeRepository;
+    private final MapClient mapClient;
+    private final NodeRepository nodeRepository;
 
     @AllArgsConstructor
     private class CostToNextNode implements Comparable<CostToNextNode> {
@@ -257,14 +258,61 @@ public class RouteCalculationService {
                 , "lng", (n1.getCoordinates().getX() + n2.getCoordinates().getX())/2);
     }
 
+    @Transactional
+    public void createRoute(Long univId, CreateRouteReqDTO requests){
+        List<Node> nodes = checkRouteCross(univId, requests.getStartNodeId(), requests.getEndNodeId(), requests.getCoordinates());
+        mapClient.fetchHeights(nodes);
+        createLinkedRouteAndSave(univId,nodes);
+    }
+
+    private void createLinkedRouteAndSave(Long univId, List<Node> nodes) {
+        GeometryFactory geometryFactory = getInstance();
+        Set<String> nodeSet = new HashSet<>();
+        List<Node> nodeForSave = new ArrayList<>();
+        List<Route> routeForSave = new ArrayList<>();
+        for(int i=1;i<nodes.size();i++){
+            Node now = nodes.get(i);
+            Node prev = nodes.get(i-1);
+            routeForSave.add(Route.builder()
+                    .cost(calculateCost(prev,now))
+                    .path(geometryFactory.createLineString(
+                            new Coordinate[] {prev.getCoordinates().getCoordinate(), now.getCoordinates().getCoordinate()}))
+                    .node1(prev)
+                    .node2(now)
+                    .univId(univId).build());
+            if(!nodeSet.contains(getNodeKey(new Coordinate(now.getCoordinates().getX(), now.getCoordinates().getY())))){
+                nodeForSave.add(now);
+                nodeSet.add(getNodeKey(new Coordinate(now.getCoordinates().getX(), now.getCoordinates().getY())));
+            }
+        }
+        nodeRepository.saveAll(nodeForSave);
+        routeRepository.saveAll(routeForSave);
+    }
+
+    private double calculateCost(Node prev, Node now) {
+        double lng1 = prev.getCoordinates().getX();
+        double lat1 = prev.getCoordinates().getY();
+        double lng2 = now.getCoordinates().getX();
+        double lat2 = now.getCoordinates().getY();
+
+        double dLat = (lat2 - lat1) * METERS_PER_DEGREE;
+
+        double avgLat = (lat1 + lat2) / 2.0;
+        double dLng = (lng2 - lng1) * METERS_PER_DEGREE * Math.cos(Math.toRadians(avgLat));
+
+        double distance = Math.sqrt(dLat * dLat + dLng * dLng);
+
+        return distance * SECONDS_PER_MITER;
+    }
+
     // TODO: 모든 점이 아니라 request 값의 MBR 영역만 불러오면 좋을 것 같다.  <- 추가 검증 필요
     // TODO: 캐시 사용 검토
-    public List<Node> checkRouteCross(Long univId, Long startNodeId, Long endNodeId, List<CreateRouteServiceReqDTO> requests) {
+    public List<Node> checkRouteCross(Long univId, Long startNodeId, Long endNodeId, List<CreateRouteCoordinates> requests) {
         LinkedList<Node> createdNodes = new LinkedList<>();
 
         Map<String, Node> nodeMap = new HashMap<>();
         STRtree strTree = new STRtree();
-        GeometryFactory geometryFactory = GeoUtils.getInstance();
+        GeometryFactory geometryFactory = getInstance();
 
         int startNodeCount = 0;
         int endNodeCount = 0;
@@ -294,7 +342,7 @@ public class RouteCalculationService {
         // 서브 -> 코어 : 처리 필요
         // 코어 -> 코어 : 처리 필요 X
         // 코어 -> 서브 : 불가한 케이스
-        CreateRouteServiceReqDTO startCoordinate = requests.get(0);
+        CreateRouteCoordinates startCoordinate = requests.get(0);
         Node startNode = nodeMap.get(getNodeKey(new Coordinate(startCoordinate.getX(), startCoordinate.getY())));
 
         if (startNode == null) {
@@ -307,7 +355,7 @@ public class RouteCalculationService {
         createdNodes.add(startNode);
 
         for (int i = 1; i < requests.size(); i++) {
-            CreateRouteServiceReqDTO cur = requests.get(i);
+            CreateRouteCoordinates cur = requests.get(i);
 
             // 정확히 그 점과 일치하는 노드가 있는지 확인
             Node curNode = nodeMap.get(getNodeKey(new Coordinate(cur.getX(), cur.getY())));
@@ -365,7 +413,7 @@ public class RouteCalculationService {
 
     private List<Node> checkSelfRouteCross(List<Node> nodes) {
 
-        GeometryFactory geometryFactory = GeoUtils.getInstance();
+        GeometryFactory geometryFactory = getInstance();
 
         if(nodes.get(0).getCoordinates().equals(nodes.get(nodes.size()-1).getCoordinates())){
             throw new SameStartAndEndPointException("Start and end nodes cannot be the same", SAME_START_AND_END_POINT);
@@ -424,7 +472,7 @@ public class RouteCalculationService {
     }
 
     private LineString findIntersectLineString(Coordinate start, Coordinate end, STRtree strTree) {
-        GeometryFactory geometryFactory = GeoUtils.getInstance();
+        GeometryFactory geometryFactory = getInstance();
         LineString newLine = geometryFactory.createLineString(new Coordinate[] {start, end});
         Envelope searchEnvelope = newLine.getEnvelopeInternal();
 
@@ -473,7 +521,7 @@ public class RouteCalculationService {
     }
 
     private Node getClosestNode(LineString intersectLine, Node start, Node end, Map<String, Node> nodeMap) {
-        GeometryFactory geometryFactory = GeoUtils.getInstance();
+        GeometryFactory geometryFactory = getInstance();
         Coordinate[] coordinates = intersectLine.getCoordinates();
 
         double distance1 = start.getCoordinates().getCoordinate().distance(coordinates[0]) +

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -9,7 +9,7 @@ import com.softeer5.uniro_backend.common.exception.custom.NodeNotFoundException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteCalculationException;
 import com.softeer5.uniro_backend.common.exception.custom.SameStartAndEndPointException;
 import com.softeer5.uniro_backend.common.exception.custom.UnreachableDestinationException;
-import com.softeer5.uniro_backend.node.client.MapClient;
+import com.softeer5.uniro_backend.external.MapClient;
 import com.softeer5.uniro_backend.node.entity.Node;
 import com.softeer5.uniro_backend.node.repository.NodeRepository;
 import com.softeer5.uniro_backend.route.dto.*;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -360,13 +360,12 @@ public class RouteCalculationService {
             // 정확히 그 점과 일치하는 노드가 있는지 확인
             Node curNode = nodeMap.get(getNodeKey(new Coordinate(cur.getX(), cur.getY())));
             if(curNode != null){
-
-                if(i == requests.size() - 1 && endNodeCount < CORE_NODE_CONDITION - 1 && !curNode.getId().equals(startNodeId)){  // 마지막 노드일 경우, 해당 노드가 끝점일 경우
+                createdNodes.add(curNode);
+                if(i == requests.size() - 1 && endNodeCount < CORE_NODE_CONDITION - 1){  // 마지막 노드일 경우, 해당 노드가 끝점일 경우
                     continue;
                 }
 
                 curNode.setCore(true);
-                createdNodes.add(curNode);
                 continue;
             }
 
@@ -463,7 +462,6 @@ public class RouteCalculationService {
 
                 midNode.setCore(true);
 
-                // TODO: Node insert할 때는 좌표값으로 Node 중복 여부 판단 필요
                 nodes.add(midNode);
             }
         }

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/node/client/MapClientImplTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/node/client/MapClientImplTest.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.node.client;
 
+import com.softeer5.uniro_backend.external.MapClientImpl;
 import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;
 import com.softeer5.uniro_backend.node.entity.Node;
 import org.junit.jupiter.api.Assertions;

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/route/RouteCalculationServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/route/RouteCalculationServiceTest.java
@@ -18,7 +18,7 @@ import com.softeer5.uniro_backend.fixture.NodeFixture;
 import com.softeer5.uniro_backend.fixture.RouteFixture;
 import com.softeer5.uniro_backend.node.entity.Node;
 import com.softeer5.uniro_backend.node.repository.NodeRepository;
-import com.softeer5.uniro_backend.route.dto.CreateRouteServiceReqDTO;
+import com.softeer5.uniro_backend.route.dto.CreateRouteCoordinates;
 import com.softeer5.uniro_backend.route.entity.Route;
 import com.softeer5.uniro_backend.route.repository.RouteRepository;
 import com.softeer5.uniro_backend.route.service.RouteCalculationService;
@@ -41,10 +41,10 @@ class RouteCalculationServiceTest {
 		void 기본_경로_생성() {
 			// Given
 			Long univId = 1001L;
-			List<CreateRouteServiceReqDTO> requests = List.of(
-				new CreateRouteServiceReqDTO(0, 0),
-				new CreateRouteServiceReqDTO(1, 1),
-				new CreateRouteServiceReqDTO(2, 2)
+			List<CreateRouteCoordinates> requests = List.of(
+				new CreateRouteCoordinates(0, 0),
+				new CreateRouteCoordinates(1, 1),
+				new CreateRouteCoordinates(2, 2)
 			);
 
 			Node node0 = NodeFixture.createNode(-1, 0);
@@ -70,10 +70,10 @@ class RouteCalculationServiceTest {
 		void 기존_경로와_겹치는_경우_예외발생() {
 			// Given
 			Long univId = 1001L;
-			List<CreateRouteServiceReqDTO> requests = List.of(
-				new CreateRouteServiceReqDTO(0, 0),
-				new CreateRouteServiceReqDTO(1, 1),
-				new CreateRouteServiceReqDTO(2, 2)
+			List<CreateRouteCoordinates> requests = List.of(
+				new CreateRouteCoordinates(0, 0),
+				new CreateRouteCoordinates(1, 1),
+				new CreateRouteCoordinates(2, 2)
 			);
 
 			Node node1 = NodeFixture.createNode(0, 0);
@@ -93,10 +93,10 @@ class RouteCalculationServiceTest {
 		void 연결된_간선이_3개가_된_경우_시작노드가_서브에서_코어노드로_변경된다() {
 			// Given
 			Long univId = 1001L;
-			List<CreateRouteServiceReqDTO> requests = List.of(
-				new CreateRouteServiceReqDTO(0, 0),
-				new CreateRouteServiceReqDTO(3, 3),
-				new CreateRouteServiceReqDTO(5, 3)
+			List<CreateRouteCoordinates> requests = List.of(
+				new CreateRouteCoordinates(0, 0),
+				new CreateRouteCoordinates(3, 3),
+				new CreateRouteCoordinates(5, 3)
 			);
 
 			Node node0 = NodeFixture.createNode(0, -1);
@@ -125,10 +125,10 @@ class RouteCalculationServiceTest {
 		void 출발점과_도착점이_같은_경우_예외처리() {
 			// Given
 			Long univId = 1001L;
-			List<CreateRouteServiceReqDTO> requests = List.of(
-				new CreateRouteServiceReqDTO(0, 0),
-				new CreateRouteServiceReqDTO(1, 1),
-				new CreateRouteServiceReqDTO(0, 0)
+			List<CreateRouteCoordinates> requests = List.of(
+				new CreateRouteCoordinates(0, 0),
+				new CreateRouteCoordinates(1, 1),
+				new CreateRouteCoordinates(0, 0)
 			);
 
 			Node node1 = NodeFixture.createNode(0, 0);
@@ -149,12 +149,12 @@ class RouteCalculationServiceTest {
 		void 기존에_존재하는_노드와_연결할_경우_코어노드가_될_수_있다() {
 			// Given
 			Long univId = 1001L;
-			List<CreateRouteServiceReqDTO> requests = List.of(
-				new CreateRouteServiceReqDTO(0, 0),
-				new CreateRouteServiceReqDTO(2, 1),
-				new CreateRouteServiceReqDTO(2, 2),
-				new CreateRouteServiceReqDTO(0, 2),
-				new CreateRouteServiceReqDTO(-1, 2)
+			List<CreateRouteCoordinates> requests = List.of(
+				new CreateRouteCoordinates(0, 0),
+				new CreateRouteCoordinates(2, 1),
+				new CreateRouteCoordinates(2, 2),
+				new CreateRouteCoordinates(0, 2),
+				new CreateRouteCoordinates(-1, 2)
 			);
 
 			Node node1 = NodeFixture.createNode(0, 0);


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### 길찾기 로직 4,5단계를 구현하였습니다.
- 5단계 노드를 저장하고, route를 생성합니다.
- 중복된 node가 저장되지 않도록 Set을 통해 필터링 하였습니다.
- SRID 4326으로 데이터베이스에 저장하기 위해 다음과 같은 코드를 추가하였습니다.
`new GeometryFactory(new PrecisionModel(), 4326)`

## 특이사항
- 현재 프론트엔드와 협업을 통해 테스트를 진행해야하는 상황입니다.
- 코드 구조와 로직이 미완성인 상태입니다. 추후 테스트를 통해 리팩토링할 예정입니다.

## 🧪 테스트 결과
<img width="666" alt="image" src="https://github.com/user-attachments/assets/3cd43a86-b9e1-4a11-9313-12ac34937313" />
