### PR TITLE
[UNI-111] fix, feat, refactor : QA 문제 해결 (지도 페이지 뷰포트, 마커  동적 스타일 변경, 지도 줌 레벨 감지, 제보하기 모달 PC 환경 스타일)

### DIFF
--- a/uniro_frontend/src/assets/markers/university.svg
+++ b/uniro_frontend/src/assets/markers/university.svg
@@ -1,0 +1,13 @@
+<svg width="14" height="11" viewBox="0 0 14 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_f_4158_10677)">
+<ellipse cx="7.00014" cy="7.42846" rx="5.99989" ry="2.14282" fill="black" fill-opacity="0.2"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.3976 0H0.602295L5.97473 7.34341C6.09034 7.50211 6.24386 7.63163 6.4223 7.72104C6.60074 7.81046 6.79887 7.85714 6.99996 7.85714C7.20104 7.85714 7.39917 7.81046 7.57761 7.72104C7.75605 7.63163 7.90957 7.50211 8.02518 7.34341L13.3976 0Z" fill="#0367FB"/>
+<defs>
+<filter id="filter0_f_4158_10677" x="0.0321077" y="4.31751" width="13.936" height="6.22192" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.484068" result="effect1_foregroundBlur_4158_10677"/>
+</filter>
+</defs>
+</svg>

--- a/uniro_frontend/src/components/map/reportModal.tsx
+++ b/uniro_frontend/src/components/map/reportModal.tsx
@@ -13,7 +13,7 @@ export default function ReportModal({ close }: ReportModalProps) {
 		>
 			<Link
 				to={"/report/route"}
-				className="w-full h-[58px] flex items-center justify-between px-5 bg-gray-100 rounded-400 text-kor-body2 font-semibold text-primary-500"
+				className="w-full max-w-[418px] h-[58px] flex items-center justify-between px-5 bg-gray-100 rounded-400 text-kor-body2 font-semibold text-primary-500"
 			>
 				<p>새로운 길 제보</p>
 				<ChevronRight fill="none" />
@@ -21,7 +21,7 @@ export default function ReportModal({ close }: ReportModalProps) {
 
 			<Link
 				to={"/report/hazard"}
-				className="w-full h-[58px] flex items-center justify-between px-5 bg-gray-100 rounded-400 text-kor-body2 font-semibold text-primary-500"
+				className="w-full max-w-[418px] h-[58px] flex items-center justify-between px-5 bg-gray-100 rounded-400 text-kor-body2 font-semibold text-primary-500"
 			>
 				<p>불편한 길 제보</p>
 				<ChevronRight fill="none" />

--- a/uniro_frontend/src/data/types/node.d.ts
+++ b/uniro_frontend/src/data/types/node.d.ts
@@ -1,5 +1,5 @@
 export interface CustomNode {
-	id?: string;
+	id: string;
 	lng: number;
 	lat: number;
 	isCore?: boolean;

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -290,7 +290,7 @@ export default function MapPage() {
 	}, [destination]);
 
 	return (
-		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center">
+		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center">
 			<TopSheet open={!sheetOpen} />
 			<div ref={mapRef} className="w-full h-full" />
 			<BottomSheet

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -289,7 +289,7 @@ export default function MapPage() {
 			originMarker.content = createMarkerElement({
 				type: Markers.BUILDING,
 				title: origin.buildingName,
-				className: "translate-routemarker",
+				className: "translate-marker",
 			});
 		};
 	}, [origin]);
@@ -311,7 +311,7 @@ export default function MapPage() {
 			destinationMarker.content = createMarkerElement({
 				type: Markers.BUILDING,
 				title: destination.buildingName,
-				className: "translate-routemarker",
+				className: "translate-marker",
 			});
 		};
 	}, [destination]);

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -153,6 +153,12 @@ export default function MapPage() {
 
 	const toggleCautionButton = () => {
 		if (!map) return;
+		if (zoom <= 16) {
+			map.setOptions({
+				zoom: 17,
+				center: HanyangUniversity,
+			});
+		}
 		setIsCautionActive((isActive) => {
 			toggleMarkers(!isActive, cautionMarkers, map);
 			return !isActive;
@@ -160,6 +166,12 @@ export default function MapPage() {
 	};
 	const toggleDangerButton = () => {
 		if (!map) return;
+		if (zoom <= 16) {
+			map.setOptions({
+				zoom: 17,
+				center: HanyangUniversity,
+			});
+		}
 		setIsDangerActive((isActive) => {
 			toggleMarkers(!isActive, dangerMarkers, map);
 			return !isActive;

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -151,9 +151,11 @@ export default function MapPage() {
 		if (selectedMarker.from === "Marker" && type) {
 			switch (type) {
 				case RoutePoint.ORIGIN:
+					if (selectedMarker.id === destination?.id) setDestination(undefined);
 					setOrigin(selectedMarker.property);
 					break;
 				case RoutePoint.DESTINATION:
+					if (selectedMarker.id === origin?.id) setOrigin(undefined);
 					setDestination(selectedMarker.property);
 					break;
 			}
@@ -171,11 +173,13 @@ export default function MapPage() {
 		if (!map || !marker) return;
 
 		if (marker.property && (marker.id === origin?.id || marker.id === destination?.id)) {
-			map.setOptions({
-				center: { lat: marker.property.lat, lng: marker.property.lng },
-				zoom: 19,
-			})
-			setSheetOpen(true);
+			if (isSelect) {
+				map.setOptions({
+					center: { lat: marker.property.lat, lng: marker.property.lng },
+					zoom: 19,
+				})
+				setSheetOpen(true);
+			}
 
 			return;
 		}

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -39,6 +39,8 @@ export type SelectedMarkerTypes = {
 export default function MapPage() {
 	const { mapRef, map, AdvancedMarker } = useMap();
 	const [zoom, setZoom] = useState<number>(16);
+	const prevZoom = useRef<number>(16);
+
 	const [selectedMarker, setSelectedMarker] = useState<SelectedMarkerTypes>();
 	const bottomSheetRef = useRef<BottomSheetRef>(null);
 	const [sheetOpen, setSheetOpen] = useState<boolean>(false);
@@ -65,7 +67,12 @@ export default function MapPage() {
 			setSelectedMarker(undefined);
 		});
 		map.addListener("zoom_changed", () => {
-			setZoom(map.getZoom() as number);
+			setZoom((prev) => {
+				const curZoom = map.getZoom() as number;
+				prevZoom.current = prev;
+
+				return curZoom
+			});
 		})
 	};
 
@@ -326,13 +333,15 @@ export default function MapPage() {
 
 	useEffect(() => {
 		if (!map) return;
+
 		const _buildingMarkers = buildingMarkers.map(buildingMarker => buildingMarker.element);
-		if (zoom === 15 || zoom === 16) {
+
+		if (prevZoom.current >= 17 && zoom <= 16) {
 			toggleMarkers(false, cautionMarkers, map);
 			toggleMarkers(false, dangerMarkers, map);
 			toggleMarkers(false, _buildingMarkers, map);
 		}
-		else {
+		else if ((prevZoom.current <= 16 && zoom >= 17)) {
 			toggleMarkers(true, cautionMarkers, map);
 			toggleMarkers(true, dangerMarkers, map);
 			toggleMarkers(true, _buildingMarkers, map);

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -170,6 +170,16 @@ export default function MapPage() {
 	const changeMarkerStyle = (marker: SelectedMarkerTypes | undefined, isSelect: boolean) => {
 		if (!map || !marker) return;
 
+		if (marker.property && (marker.id === origin?.id || marker.id === destination?.id)) {
+			map.setOptions({
+				center: { lat: marker.property.lat, lng: marker.property.lng },
+				zoom: 19,
+			})
+			setSheetOpen(true);
+
+			return;
+		}
+
 		if (marker.type == Markers.BUILDING && marker.property) {
 			if (isSelect) {
 				marker.element.content = createMarkerElement({
@@ -184,6 +194,23 @@ export default function MapPage() {
 				setSheetOpen(true);
 
 				return;
+			}
+
+			if (marker.id === origin?.id) {
+				marker.element.content = createMarkerElement({
+					type: Markers.ORIGIN,
+					title: marker.property.buildingName,
+					className: "translate-routemarker",
+				});
+			}
+
+			else if (marker.id === destination?.id) {
+				marker.element.content = createMarkerElement({
+					type: Markers.DESTINATION,
+					title: destination.buildingName,
+					className: "translate-routemarker",
+				});
+
 			}
 
 			marker.element.content = createMarkerElement({

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -38,6 +38,7 @@ export type SelectedMarkerTypes = {
 
 export default function MapPage() {
 	const { mapRef, map, AdvancedMarker } = useMap();
+	const [zoom, setZoom] = useState<number>(16);
 	const [selectedMarker, setSelectedMarker] = useState<SelectedMarkerTypes>();
 	const bottomSheetRef = useRef<BottomSheetRef>(null);
 	const [sheetOpen, setSheetOpen] = useState<boolean>(false);
@@ -63,6 +64,9 @@ export default function MapPage() {
 			setSheetOpen(false);
 			setSelectedMarker(undefined);
 		});
+		map.addListener("zoom_changed", () => {
+			setZoom(map.getZoom() as number);
+		})
 	};
 
 	const addBuildings = () => {
@@ -74,7 +78,7 @@ export default function MapPage() {
 
 			const buildingMarker = createAdvancedMarker(
 				AdvancedMarker,
-				map,
+				null,
 				new google.maps.LatLng(lat, lng),
 				createMarkerElement({ type: Markers.BUILDING, title: buildingName, className: "translate-marker" }),
 				() => {
@@ -100,7 +104,7 @@ export default function MapPage() {
 			const { id, startNode, endNode, dangerFactors, cautionFactors } = edge;
 			const hazardMarker = createAdvancedMarker(
 				AdvancedMarker,
-				map,
+				null,
 				new google.maps.LatLng({
 					lat: (startNode.lat + endNode.lat) / 2,
 					lng: (startNode.lng + endNode.lng) / 2,
@@ -319,6 +323,21 @@ export default function MapPage() {
 			});
 		};
 	}, [destination]);
+
+	useEffect(() => {
+		if (!map) return;
+		const _buildingMarkers = buildingMarkers.map(buildingMarker => buildingMarker.element);
+		if (zoom === 15 || zoom === 16) {
+			toggleMarkers(false, cautionMarkers, map);
+			toggleMarkers(false, dangerMarkers, map);
+			toggleMarkers(false, _buildingMarkers, map);
+		}
+		else {
+			toggleMarkers(true, cautionMarkers, map);
+			toggleMarkers(true, dangerMarkers, map);
+			toggleMarkers(true, _buildingMarkers, map);
+		}
+	}, [map, zoom])
 
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center">

--- a/uniro_frontend/src/utils/markers/createAdvanedMarker.ts
+++ b/uniro_frontend/src/utils/markers/createAdvanedMarker.ts
@@ -1,6 +1,6 @@
 export default function createAdvancedMarker(
 	AdvancedMarker: typeof google.maps.marker.AdvancedMarkerElement,
-	map: google.maps.Map,
+	map: google.maps.Map | null,
 	position: google.maps.LatLng | google.maps.LatLngLiteral,
 	content: HTMLElement,
 	onClick?: () => void,

--- a/uniro_frontend/src/utils/markers/createAdvanedMarker.ts
+++ b/uniro_frontend/src/utils/markers/createAdvanedMarker.ts
@@ -15,3 +15,30 @@ export default function createAdvancedMarker(
 
 	return newMarker;
 }
+
+export function createUniversityMarker(
+	AdvancedMarker: typeof google.maps.marker.AdvancedMarkerElement,
+	map: google.maps.Map | null,
+	position: google.maps.LatLng | google.maps.LatLngLiteral,
+	university: string,
+) {
+	const container = document.createElement("div");
+	container.className = `flex flex-col items-center`;
+	const markerTitle = document.createElement("p");
+	markerTitle.innerText = university ? university : "";
+	markerTitle.className =
+		"py-1 px-3 text-kor-caption font-medium text-gray-100 bg-primary-500 text-center rounded-200";
+	container.appendChild(markerTitle);
+	const markerImage = document.createElement("img");
+	markerImage.className = "border-0 translate-y-[-1px]";
+	markerImage.src = "/src/assets/markers/university.svg";
+	container.appendChild(markerImage);
+
+	const newMarker = new AdvancedMarker({
+		map: map,
+		position: position,
+		content: container,
+	});
+
+	return newMarker;
+}


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 지도 페이지 뷰포트 조정
2. 마커 동적 스타일 변경 로직 오류 해결
3. 한 건물을 출발, 도착 동시 지정 불가 적용
4. 제보하기 모달 PC환경 스타일 조정
5. 줌 레벨 변화에 따른 마커 노출 로직 신규 적용

### 지도 페이지 뷰포트 조정
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/f92d9dd5-6c86-4af9-90c8-579207a2afeb">  | <video src="https://github.com/user-attachments/assets/10a30099-0b02-4f33-836b-de59fb75a71a">|



## 마커 스타일 동적 변경 문제 해결

- 기존에는 위험 주의 요소 마커의 콘텐츠를 변경하는 로직이 addListener로 여러 곳에 분산이 되어 있는 로직을 건물 마커 컨텐츠를 수정하는 useEffect의 로직으로 통일하였습니다.
- before
```typescript
      const initMap = () => {
		if (map === null) return;
		map.addListener("click", (e: unknown) => {
			setSheetOpen(false);
			setSelectedMarker((marker) => {
				if (marker) {
					const { type, element } = marker;

					if (type === Markers.BUILDING) return undefined;

					element.content = createMarkerElement({ type });
				}
				return undefined;
			});
		});
	};
	() => {
	                hazardMarker.content = createMarkerElement({
		                type: dangerFactors ? Markers.DANGER : Markers.CAUTION,
		                title: dangerFactors ? dangerFactors[0] : cautionFactors && cautionFactors[0],
		                hasTopContent: true,
	                });
	                setSelectedMarker({
		                type: dangerFactors ? Markers.DANGER : Markers.CAUTION,
		                element: hazardMarker,
		                from: "Marker",
	                });
                },
```
- 위와 같은 모든 로직을 전부 setSelectedMarker로 통일하여 useEffect에서 cleanup과 함께 동작하여 하나의 로직으로 처리할 수 있도록 변경하였습니다.
- 또한, 선택된 마커가 출발, 도착 마커여부를 판단하여 스타일 초기화 시, 출발 마커가 일반 마커로 변경되는 문제를 해결했습니다.
```typescript
/** isSelect(Marker 선택 시) Marker Content 변경, 지도 이동, BottomSheet 열기 */
	const changeMarkerStyle = (marker: SelectedMarkerTypes | undefined, isSelect: boolean) => {
		if (!map || !marker) return;

		if (marker.property && (marker.id === origin?.id || marker.id === destination?.id)) {
			if (isSelect) {
				map.setOptions({
					center: { lat: marker.property.lat, lng: marker.property.lng },
					zoom: 19,
				})
				setSheetOpen(true);
			}

			return;
		}

		if (marker.type == Markers.BUILDING && marker.property) {
			if (isSelect) {
				marker.element.content = createMarkerElement({
					type: Markers.SELECTED_BUILDING,
					title: marker.property.buildingName,
					className: "translate-marker",
				});
				map.setOptions({
					center: { lat: marker.property.lat, lng: marker.property.lng },
					zoom: 19,
				});
				setSheetOpen(true);

				return;
			}

			if (marker.id === origin?.id) {
				marker.element.content = createMarkerElement({
					type: Markers.ORIGIN,
					title: marker.property.buildingName,
					className: "translate-routemarker",
				});
			}

			else if (marker.id === destination?.id) {
				marker.element.content = createMarkerElement({
					type: Markers.DESTINATION,
					title: destination.buildingName,
					className: "translate-routemarker",
				});

			}

			marker.element.content = createMarkerElement({
				type: Markers.BUILDING,
				title: marker.property.buildingName,
				className: "translate-marker",
			});
		} else {
			if (isSelect) {
				marker.element.content = createMarkerElement({
					type: marker.type,
					title: marker.factors && marker.factors[0],
					hasTopContent: true,
				});

				return;
			}

			marker.element.content = createMarkerElement({
				type: marker.type,
			});
		}
	};

```
### 여러 위험 주의 요소 마커 클릭 시, 스타일 초기화 오류
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/6cfff247-186a-4654-abcf-a934652f5e56">  | <video src="https://github.com/user-attachments/assets/c9491101-9d48-4491-9060-fbfe69da0d4c">|

### 출발 도착 마커 선택 후 해제 시, 스타일 초기화 오류
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/eb3dfc46-2982-4e0a-aa6d-6670a766d006">  | <video src="https://github.com/user-attachments/assets/b3c58d02-a664-4699-9e37-894ef0b58a08">|

##

### 한 건물을 출발, 도착 동시 지정 불가 적용
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/8daf953f-6c93-440a-ae3c-8b5e297f3716">  | <video src="https://github.com/user-attachments/assets/cb190d83-ef96-47d7-9e44-24bd130e6505">|


### 제보 선택 모달 최대 크기 조절
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/18ff015e-64d3-471d-9cc7-8d8ec6356182">  | <video src="https://github.com/user-attachments/assets/11f50069-1063-484a-8db9-954ddcddfccc">|



## 신규 기능

### 기본 학교 중심 마커 생성 및 줌 레벨 변경에 따른 마커 노출 로직 적용
- Zoom 레벨이 15, 16인 경우에는 학교 중심에 학교 이름이 있는 마커를 만들었습니다.
- Figma로 직접 학교 중심 마커를 위해 만든 결과입니다.
<img width="447" alt="스크린샷 2025-02-05 오후 3 38 24" src="https://github.com/user-attachments/assets/73602f02-e909-4db5-80a4-1376c40015b8" />

```typescript
        const [zoom, setZoom] = useState<number>(16);
        const initMap = () => {
		if (map === null) return;
		map.addListener("click", (e: unknown) => {
			setSheetOpen(false);
			setSelectedMarker(undefined);
		});
		map.addListener("zoom_changed", () => {
			setZoom(map.getZoom() as number);
		})
	};


	useEffect(() => {
		if (!map) return;
		const _buildingMarkers = buildingMarkers.map(buildingMarker => buildingMarker.element);
		if (zoom === 15 || zoom === 16) {
			toggleMarkers(false, cautionMarkers, map);
			toggleMarkers(false, dangerMarkers, map);
			toggleMarkers(false, _buildingMarkers, map);
		}
		else {
			toggleMarkers(true, cautionMarkers, map);
			toggleMarkers(true, dangerMarkers, map);
			toggleMarkers(true, _buildingMarkers, map);
		}
	}, [map, zoom])
```
- 지도에 줌 Change 이벤트를 등록하여 변경된 zoom을 state로 관리하여, 15, 16인 경우에는 모든 마커를 off하고 17 이상인 경우에는 모든 마커를 on하는 로직을 생성하였습니다.

#### 리팩토링
- 위의 로직을 짜고 원하는 대로 동작이 수행됐으나, 최적화가 되지 못했다 생각하였습니다.
- Zoom이 18 -> 19, 15 -> 16 이렇게 경계선에 있지 않은 경우에도 toggleMarkers가 실행이되어
```
      // marker의 map은 map이지만 같은 값을 재할당
      marker.map = map;
      // marker의 null은 null이지만 같은 값을 재할당
      marker.map = null;
```
- 위와 같은 불필요한 동작이 일어날 것이라 생각하여 이를 개선하고자 하였습니다.

```typescript
	const [zoom, setZoom] = useState<number>(16);
	const prevZoom = useRef<number>(16);
        const initMap = () => {
		if (map === null) return;
		map.addListener("click", (e: unknown) => {
			setSheetOpen(false);
			setSelectedMarker(undefined);
		});
		map.addListener("zoom_changed", () => {
			setZoom((prev) => {
				const curZoom = map.getZoom() as number;
				prevZoom.current = prev;

				return curZoom
			});
		})
	};
	
	useEffect(() => {
		if (!map) return;

		const _buildingMarkers = buildingMarkers.map(buildingMarker => buildingMarker.element);

		if (prevZoom.current >= 17 && zoom <= 16) {
			toggleMarkers(false, cautionMarkers, map);
			toggleMarkers(false, dangerMarkers, map);
			toggleMarkers(false, _buildingMarkers, map);
		}
		else if ((prevZoom.current <= 16 && zoom >= 17)) {
			toggleMarkers(true, cautionMarkers, map);
			toggleMarkers(true, dangerMarkers, map);
			toggleMarkers(true, _buildingMarkers, map);
		}
	}, [map, zoom])
```
- 그래서 다음과 같이, prevZoom을 ref로 저장하여 이전 Zoom과 현재 Zoom을 비교하여 16, 17 경계 값을 측정하였습니다.
- 경계에 대해서만 Marker를 toggle할 수 있도록 최적화 진행하였습니다.

| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/9759f728-66d0-4d1e-9941-8c3c92ff9df2">  | <video src="https://github.com/user-attachments/assets/11a214e1-4824-4737-a7fa-91744c20053d">|

## 연관된 이슈
UNI-112, UNI-113, UNI-114