### PR TITLE
[UNI-119] 길찾기 결과 바텀 시트 아래로 내릴 시 스크롤 끝까지 안되는 현상

### DIFF
--- a/uniro_frontend/src/container/animatedSheetContainer.tsx
+++ b/uniro_frontend/src/container/animatedSheetContainer.tsx
@@ -1,0 +1,47 @@
+// container/animatedSheetContainer.tsx
+
+import React from "react";
+import { AnimatePresence, motion, MotionProps } from "framer-motion";
+
+type AnimatedSheetContainerProps = {
+	isVisible: boolean;
+	height: number;
+	children: React.ReactNode;
+	className?: string;
+	transition?: MotionProps["transition"];
+	motionProps?: MotionProps;
+};
+
+const AnimatedSheetContainer = ({
+	isVisible,
+	height,
+	children,
+	className = "",
+	transition = { duration: 0.3, type: "tween" },
+	motionProps = {},
+}: AnimatedSheetContainerProps) => {
+	return (
+		<AnimatePresence>
+			{isVisible && (
+				<motion.div
+					className={className}
+					style={{
+						position: "absolute",
+						left: 0,
+						bottom: 0,
+						width: "100%",
+					}}
+					initial={{ height: 0 }}
+					animate={{ height }}
+					exit={{ height: 0 }}
+					transition={transition}
+					{...motionProps}
+				>
+					{children}
+				</motion.div>
+			)}
+		</AnimatePresence>
+	);
+};
+
+export default AnimatedSheetContainer;


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 길찾기 결과 바텀 시트 아래로 내릴 시 스크롤 끝까지 안되는 현상


### 해결 방식
- 기존에는 position을 이동시켰지만, height로 이동시키는 방식으로 바꿨습니다.

### AS IS

https://github.com/user-attachments/assets/84666fef-09ee-4dc5-a9b1-ba4010e9459d

### TO BE

https://github.com/user-attachments/assets/85bcb223-dbfb-4cd0-ad3d-b4ea3ce33d2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launched a rebranded admin interface with an improved navigation bar for selecting universities.
  - Introduced interactive pages for reporting routes and hazards, including dedicated error and offline screens.
  - Added dynamic log displays and intuitive map interactions for a more engaging user experience.

- **Improvements**
  - Enhanced overall UI responsiveness with smooth animations and updated layouts.
  - Integrated real‑time loading overlays and status updates to improve feedback during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->