### PR TITLE
[UNI-120] feat : Tanstack-Query  DevTools 라이브러리 설치 및 적용

### DIFF
--- a/uniro_frontend/package-lock.json
+++ b/uniro_frontend/package-lock.json
@@ -12,6 +12,7 @@
 				"@react-spring/web": "^9.7.5",
 				"@tailwindcss/vite": "^4.0.0",
 				"@tanstack/react-query": "^5.66.0",
+				"@tanstack/react-query-devtools": "^5.66.0",
 				"framer-motion": "^12.0.6",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -1903,6 +1904,16 @@
 				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
+		"node_modules/@tanstack/query-devtools": {
+			"version": "5.65.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.65.0.tgz",
+			"integrity": "sha512-g5y7zc07U9D3esMdqUfTEVu9kMHoIaVBsD0+M3LPdAdD710RpTcLiNvJY1JkYXqkq9+NV+CQoemVNpQPBXVsJg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			}
+		},
 		"node_modules/@tanstack/react-query": {
 			"version": "5.66.0",
 			"resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.66.0.tgz",
@@ -1916,6 +1927,23 @@
 				"url": "https://github.com/sponsors/tannerlinsley"
 			},
 			"peerDependencies": {
+				"react": "^18 || ^19"
+			}
+		},
+		"node_modules/@tanstack/react-query-devtools": {
+			"version": "5.66.0",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.66.0.tgz",
+			"integrity": "sha512-uB57wA2YZaQ2fPcFW0E9O1zAGDGSbRKRx84uMk/86VyU9jWVxvJ3Uzp+zNm+nZJYsuekCIo2opTdgNuvM3cKgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tanstack/query-devtools": "5.65.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/tannerlinsley"
+			},
+			"peerDependencies": {
+				"@tanstack/react-query": "^5.66.0",
 				"react": "^18 || ^19"
 			}
 		},

--- a/uniro_frontend/package.json
+++ b/uniro_frontend/package.json
@@ -14,6 +14,7 @@
 		"@react-spring/web": "^9.7.5",
 		"@tailwindcss/vite": "^4.0.0",
 		"@tanstack/react-query": "^5.66.0",
+		"@tanstack/react-query-devtools": "^5.66.0",
 		"framer-motion": "^12.0.6",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -15,6 +15,7 @@ import OfflinePage from "./pages/offline";
 import useNetworkStatus from "./hooks/useNetworkStatus";
 import ErrorPage from "./pages/error";
 import { Suspense } from "react";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const queryClient = new QueryClient();
 
@@ -39,6 +40,7 @@ function App() {
           <Route path="/error/offline" element={<OfflinePage />} />
         </Routes>
       </Suspense>
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## #️⃣ 작업 내용
1. Tanstack Query DevTools 라이브러리 설치

### 라이브러리 설치 이유
- API 연결을 앞두고 클라이언트에서 데이터 캐싱을 실제로 확인 및 refetch 등 다양한 유틸을 사용하기 위해 라이브러리를 설치하였습니다.

### 적용 결과
<img width="393" alt="스크린샷 2025-02-05 오후 4 42 43" src="https://github.com/user-attachments/assets/340576fa-f55f-4d98-9ed2-11872b2d2c36" />
