### PR TITLE
[UNI-134] fix : 분기문 오류로 인한 잘못된 응답 수정

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/CautionListConverter.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/CautionListConverter.java
@@ -21,7 +21,7 @@ public class CautionListConverter implements AttributeConverter<Set<CautionType>
 	public String convertToDatabaseColumn(Set<CautionType> attribute) {
 		try {
 			if (attribute == null) {
-				return null; // List가 null일 경우, DB에 저장할 값도 null
+				return "[]"; // List가 null일 경우, DB에 저장할 값은 []
 			}
 			return mapper.writeValueAsString(attribute);
 		} catch (JsonProcessingException e) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/DangerListConverter.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/resolver/DangerListConverter.java
@@ -19,7 +19,7 @@ public class DangerListConverter implements AttributeConverter<Set<DangerType>, 
 	public String convertToDatabaseColumn(Set<DangerType> attribute) {
 		try {
 			if (attribute == null) {
-				return null; // List가 null일 경우, DB에 저장할 값도 null
+				return "[]"; // List가 null일 경우, DB에 저장할 값은 []
 			}
 			return mapper.writeValueAsString(attribute);
 		} catch (JsonProcessingException e) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/GetCautionResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/GetCautionResDTO.java
@@ -29,7 +29,7 @@ public class GetCautionResDTO {
 	@Schema(description = "위험 요소 타입 리스트", example = "[\"SLOPE\", \"STAIRS\"]")
 	private final List<CautionType> cautionTypes;
 
-	public static GetCautionResDTO of(Node node1, Node node2, Long routeId, List<CautionType> cautionTypes){
-		return new GetCautionResDTO(node1.getXY(), node2.getXY(), routeId, cautionTypes);
+	public static GetCautionResDTO of(Map<String, Double> node1, Map<String, Double> node2, Long routeId, List<CautionType> cautionTypes){
+		return new GetCautionResDTO(node1, node2, routeId, cautionTypes);
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/GetDangerResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/GetDangerResDTO.java
@@ -28,8 +28,8 @@ public class GetDangerResDTO {
 	@Schema(description = "위험 요소 타입 리스트", example = "[\"CURB\", \"STAIRS\"]")
 	private final List<DangerType> dangerTypes;
 
-	public static GetDangerResDTO of(Node node1, Node node2, Long routeId, List<DangerType> dangerTypes){
-		return new GetDangerResDTO(node1.getXY(), node2.getXY(), routeId, dangerTypes);
+	public static GetDangerResDTO of(Map<String, Double> node1, Map<String, Double> node2, Long routeId, List<DangerType> dangerTypes){
+		return new GetDangerResDTO(node1, node2, routeId, dangerTypes);
 	}
 
 	public List<DangerType> getDangerTypes() {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
@@ -79,25 +79,13 @@ public class Route {
 	}
 
 	public void setCautionFactors(List<CautionType> cautionFactors) {
-		if (this.cautionFactors == null) {
-			this.cautionFactors = new HashSet<>();
-		} else {
-			this.cautionFactors.clear();
-		}
-		if (cautionFactors != null) {
-			this.cautionFactors.addAll(cautionFactors);
-		}
+		this.cautionFactors.clear();
+		this.cautionFactors.addAll(cautionFactors);
 	}
 
 	public void setDangerFactors(List<DangerType> dangerFactors) {
-		if (this.dangerFactors == null) {
-			this.dangerFactors = new HashSet<>();
-		} else {
-			this.dangerFactors.clear();
-		}
-		if (dangerFactors != null) {
-			this.dangerFactors.addAll(dangerFactors);
-		}
+		this.dangerFactors.clear();
+		this.dangerFactors.addAll(dangerFactors);
 	}
 
 	@Builder

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/entity/Route.java
@@ -62,11 +62,13 @@ public class Route {
 
 	@Convert(converter = CautionListConverter.class)
 	@Column(name = "caution_factors")
-	private Set<CautionType> cautionFactors;
+	@NotNull
+	private Set<CautionType> cautionFactors = new HashSet<>();
 
 	@Convert(converter = DangerListConverter.class)
 	@Column(name = "danger_factors")
-	private Set<DangerType> dangerFactors;
+	@NotNull
+	private Set<DangerType> dangerFactors = new HashSet<>();
 
 	public List<CautionType> getCautionFactorsByList(){
 		return cautionFactors.stream().toList();

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/repository/RouteRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/repository/RouteRepository.java
@@ -20,7 +20,7 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
 
     @Query(value = "SELECT r.* FROM Route r " +
             "WHERE r.univ_id = :univId " +
-            "AND (r.caution_factors LIKE '[%' OR r.danger_factors LIKE '[%')",
+            "AND (r.caution_factors LIKE '[\"%' OR r.danger_factors LIKE '[\"%')",
             nativeQuery = true)
     List<Route> findRiskRouteByUnivId(@Param("univId") Long univId);
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/repository/RouteRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/repository/RouteRepository.java
@@ -18,14 +18,11 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     @Query("SELECT r FROM Route r WHERE r.univId = :univId")
     List<Route> findAllRouteByUnivIdWithNodes(Long univId);
 
-    @Query("SELECT r "
-            + "FROM Route r "
-            + "JOIN FETCH r.node1 n1 "
-            + "JOIN FETCH r.node2 n2 "
-            + "WHERE r.univId = :univId "
-            + "AND (r.cautionFactors IS NOT NULL OR r.dangerFactors IS NOT NULL)"
-    )
-    List<Route> findRiskRouteByUnivIdWithNode(@Param("univId") Long univId);
+    @Query(value = "SELECT r.* FROM Route r " +
+            "WHERE r.univ_id = :univId " +
+            "AND (r.caution_factors LIKE '[%' OR r.danger_factors LIKE '[%')",
+            nativeQuery = true)
+    List<Route> findRiskRouteByUnivId(@Param("univId") Long univId);
 
     @Query(value = """
     SELECT r.* FROM route r

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
@@ -12,8 +12,8 @@ import com.softeer5.uniro_backend.common.exception.custom.DangerCautionConflictE
 import com.softeer5.uniro_backend.common.exception.custom.InvalidMapException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteNotFoundException;
 import com.softeer5.uniro_backend.node.entity.Node;
-import com.softeer5.uniro_backend.common.utils.GeoUtils;
 
+import org.locationtech.jts.geom.Coordinate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -171,7 +171,7 @@ public class RouteService {
 	}
 
 	public GetRiskRoutesResDTO getRiskRoutes(Long univId) {
-		List<Route> riskRoutes = routeRepository.findRiskRouteByUnivIdWithNode(univId);
+		List<Route> riskRoutes = routeRepository.findRiskRouteByUnivId(univId);
 
 		List<GetDangerResDTO> dangerRoutes = mapRoutesToDangerDTO(riskRoutes);
 		List<GetCautionResDTO> cautionRoutes = mapRoutesToCautionDTO(riskRoutes);
@@ -183,8 +183,8 @@ public class RouteService {
 		return routes.stream()
 			.filter(route -> !route.getDangerFactors().isEmpty() && route.getCautionFactors().isEmpty()) // 위험 요소가 있는 경로만 필터링
 			.map(route -> GetDangerResDTO.of(
-				route.getNode1(),
-				route.getNode2(),
+				getPoint(route.getPath().getCoordinates()[0]),
+				getPoint(route.getPath().getCoordinates()[1]),
 				route.getId(),
 				route.getDangerFactorsByList()
 			)).toList();
@@ -194,11 +194,18 @@ public class RouteService {
 		return routes.stream()
 			.filter(route -> route.getDangerFactors().isEmpty() && !route.getCautionFactors().isEmpty())
 			.map(route -> GetCautionResDTO.of(
-				route.getNode1(),
-				route.getNode2(),
+				getPoint(route.getPath().getCoordinates()[0]),
+				getPoint(route.getPath().getCoordinates()[1]),
 				route.getId(),
 				route.getCautionFactorsByList()
 			)).toList();
+	}
+
+	private Map<String, Double> getPoint(Coordinate c) {
+		Map<String, Double> point = new HashMap<>();
+		point.put("lat", c.getY());
+		point.put("lng", c.getX());
+		return point;
 	}
 
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
@@ -181,7 +181,7 @@ public class RouteService {
 
 	private List<GetDangerResDTO> mapRoutesToDangerDTO(List<Route> routes) {
 		return routes.stream()
-			.filter(route -> route.getDangerFactors() != null) // 위험 요소가 있는 경로만 필터링
+			.filter(route -> !route.getDangerFactors().isEmpty() && route.getCautionFactors().isEmpty()) // 위험 요소가 있는 경로만 필터링
 			.map(route -> GetDangerResDTO.of(
 				route.getNode1(),
 				route.getNode2(),
@@ -192,7 +192,7 @@ public class RouteService {
 
 	private List<GetCautionResDTO> mapRoutesToCautionDTO(List<Route> routes) {
 		return routes.stream()
-			.filter(route -> route.getDangerFactors() == null && route.getCautionFactors() != null)
+			.filter(route -> route.getDangerFactors().isEmpty() && !route.getCautionFactors().isEmpty())
 			.map(route -> GetCautionResDTO.of(
 				route.getNode1(),
 				route.getNode2(),


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [x] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 🚀 변경 사항
### 1. 분기문 오류 수정
- dangerFactors가 비어있는 경우에도 위험 요소로 잘못 판단되어 응답되는 문제를 해결하였습니다.
- dangerFactors만 존재하는 경우를 올바르게 처리하도록 예외 처리를 추가하였습니다.

# issue : dangerFactors, cautionFactors 컨벤션 정리 및 개선
### 🚨 문제상황
- dangerFactors, cautionFactors 필드는 DB에서 JSON 형식의 VARCHAR로 저장되며, converter를 통해 애플리케이션 레벨에서는 Set<T>로 사용되고 있었습니다.
    - 해당 필드가 nullable한 상태여서 매번 null 체크가 필요했으며, 이는 불필요한 런타임 오류 발생 가능성 증가 및 협업 효율 저하로 이어졌습니다.
    - 또한, 데이터 조회 시 빈 배열([])과 null을 구분하기 어려운 문제가 있었습니다.

### ✅ 해결 방법 및 기대 효과
- dangerFactors, cautionFactors를 NOT NULL로 변경하고 기본값을 []로 설정하는 컨벤션을 도입
    - Converter를 활용하여 기본값을 항상 []로 유지하도록 변경
    - 데이터 조회 시 startWith("[\") 조건을 사용할 수 있어 인덱스를 효과적으로 활용 가능
    - null과 []를 구분해야 하는 문제를 해결하여 런타임 오류 방지 및 코드 가독성 향상

결과적으로, 위험 요소가 있는 route 조회 로직이 더욱 직관적이고 안정적으로 동작할 수 있도록 개선되었습니다. 

## 🧪 테스트 결과
<img width="636" alt="image" src="https://github.com/user-attachments/assets/7216ba08-1bf7-44c6-9718-f1bd84c02d85" />
