### PR TITLE
[UNI-66] feat: 로깅 aop 구현

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -43,22 +43,22 @@ public class ExecutionLoggingAop {
 		Object target = pjp.getTarget();
 		Annotation[] declaredAnnotations = target.getClass().getDeclaredAnnotations();
 
-		for(Annotation annotation : declaredAnnotations){
-			if(annotation instanceof RestController){
-				logHttpRequest(userId);
-			}
-		}
-
-		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
-		RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
-
 		String className = pjp.getSignature().getDeclaringType().getSimpleName();
 		String methodName = pjp.getSignature().getName();
 		String task = className + "." + methodName;
 
-		log.info("");
-		log.info("🚨 [ userId = {} ] {} Start", userId, className);
-		log.info("[ userId = {} ] [Call Method] {}: {}", userId, httpMethod, task);
+		for(Annotation annotation : declaredAnnotations){
+			if(annotation instanceof RestController){
+				logHttpRequest(userId);
+
+				HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
+				RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
+
+				log.info("");
+				log.info("🚨 [ userId = {} ] {} Start", userId, className);
+				log.info("[ userId = {} ] [Call Method] {}: {}", userId, httpMethod, task);
+			}
+		}
 
 		Object[] paramArgs = pjp.getArgs();
 		for (Object object : paramArgs) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -58,8 +58,8 @@ public class ExecutionLoggingAop {
 		String task = className + "." + methodName;
 
 		log.info("");
-		log.info("🚨 userId = {} {} Start", userId, className);
-		log.info("userId = {} [Call Method] {}: {}", userId, httpMethod, task);
+		log.info("🚨 [ userId = {} ] {} Start", userId, className);
+		log.info("[ userId = {} ] [Call Method] {}: {}", userId, httpMethod, task);
 
 		Object[] paramArgs = pjp.getArgs();
 		for (Object object : paramArgs) {
@@ -91,7 +91,7 @@ public class ExecutionLoggingAop {
 		try {
 			result = pjp.proceed();
 		} catch (Exception e) {
-			log.warn("[ERROR] userId = {} {} 메서드 예외 발생 : {}", userId, task, e.getMessage());
+			log.warn("[ERROR] [ userId = {} ] {} 메서드 예외 발생 : {}", userId, task, e.getMessage());
 			throw e;
 		} finally {
 			// Controller 클래스일 때만 ThreadLocal 값 삭제
@@ -106,7 +106,7 @@ public class ExecutionLoggingAop {
 		long executionTime = sw.getTotalTimeMillis();
 
 		log.info("[ExecutionTime] {} --> {} (ms)", task, executionTime);
-		log.info("🚨 userId = {} {} End", userId, className);
+		log.info("🚨 [ userId = {} ] {} End", userId, className);
 		log.info("");
 
 		return result;
@@ -154,6 +154,6 @@ public class ExecutionLoggingAop {
 
 		// 요청 메시지 출력
 		log.info("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅ New request");
-		log.info("HTTP Request: [ userId = "+ userId + " ]\n" + httpMessage);
+		log.info("[ userId = "+ userId + " ] HTTP Request: \n" + httpMessage);
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -30,7 +30,6 @@ public class ExecutionLoggingAop {
 
 	@Around("execution(* com.softeer5.uniro_backend..*(..)) "
 		+ "&& !within(com.softeer5.uniro_backend.common..*) "
-		+ "&& !within(com.softeer5.uniro_backend.external..*)"
 		+ "&& !within(com.softeer5.uniro_backend.resolver..*) "
 	)
 	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -1,0 +1,159 @@
+package com.softeer5.uniro_backend.common.logging;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.Enumeration;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.log4j.Log4j2;
+
+@Aspect
+@Component
+@Log4j2
+@Profile("!test")
+public class ExecutionLoggingAop {
+
+	private static final ThreadLocal<String> userIdThreadLocal = new ThreadLocal<>();
+
+	@Around("execution(* com.softeer5.uniro_backend..*(..)) "
+		+ "&& !within(com.softeer5.uniro_backend.common..*) "
+		+ "&& !within(com.softeer5.uniro_backend.external..*)"
+		+ "&& !within(com.softeer5.uniro_backend.resolver..*) "
+	)
+	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
+		// 요청에서 userId 가져오기 (ThreadLocal 사용)
+		String userId = userIdThreadLocal.get();
+		if (userId == null) {
+			userId = UUID.randomUUID().toString().substring(0, 12);
+			userIdThreadLocal.set(userId);
+		}
+
+		Object target = pjp.getTarget();
+		Annotation[] declaredAnnotations = target.getClass().getDeclaredAnnotations();
+
+		for(Annotation annotation : declaredAnnotations){
+			if(annotation instanceof RestController){
+				logHttpRequest(userId);
+			}
+		}
+
+		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
+		RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
+
+		String className = pjp.getSignature().getDeclaringType().getSimpleName();
+		String methodName = pjp.getSignature().getName();
+		String task = className + "." + methodName;
+
+		log.info("");
+		log.info("🚨 userId = {} {} Start", userId, className);
+		log.info("userId = {} [Call Method] {}: {}", userId, httpMethod, task);
+
+		Object[] paramArgs = pjp.getArgs();
+		for (Object object : paramArgs) {
+			if (Objects.nonNull(object)) {
+				log.info("[Parameter] {} {}", object.getClass().getSimpleName(), object);
+
+				String packageName = object.getClass().getPackage().getName();
+				if (packageName.contains("java")) {
+					break;
+				}
+
+				Field[] fields = object.getClass().getDeclaredFields();
+				for (Field field : fields) {
+					field.setAccessible(true);
+					try {
+						Object value = field.get(object);
+						log.info("[Field] {} = {}", field.getName(), value);
+					} catch (IllegalAccessException e) {
+						log.warn("[Field Access Error] Cannot access field: {}", field.getName());
+					}
+				}
+			}
+		}
+
+		StopWatch sw = new StopWatch();
+		sw.start();
+
+		Object result = null;
+		try {
+			result = pjp.proceed();
+		} catch (Exception e) {
+			log.warn("[ERROR] userId = {} {} 메서드 예외 발생 : {}", userId, task, e.getMessage());
+			throw e;
+		} finally {
+			// Controller 클래스일 때만 ThreadLocal 값 삭제
+			for(Annotation annotation : declaredAnnotations){
+				if(annotation instanceof RestController){
+					userIdThreadLocal.remove();
+				}
+			}
+		}
+
+		sw.stop();
+		long executionTime = sw.getTotalTimeMillis();
+
+		log.info("[ExecutionTime] {} --> {} (ms)", task, executionTime);
+		log.info("🚨 userId = {} {} End", userId, className);
+		log.info("");
+
+		return result;
+	}
+
+
+	private void logHttpRequest(String userId) {
+		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+		// HTTP Request 메시지 출력 (RFC 2616 형식)
+		StringBuilder httpMessage = new StringBuilder();
+
+		// 1. Start-Line (Request Line)
+		String method = request.getMethod();
+		String requestURI = request.getRequestURI();
+		String httpVersion = "HTTP/1.1"; // 대부분의 요청은 HTTP/1.1 버전 사용
+		httpMessage.append(method).append(" ").append(requestURI).append(" ").append(httpVersion).append("\r\n");
+
+		// 2. Field-Lines (Headers)
+		Enumeration<String> headerNames = request.getHeaderNames();
+		while (headerNames.hasMoreElements()) {
+			String headerName = headerNames.nextElement();
+			String headerValue = request.getHeader(headerName);
+			httpMessage.append(headerName).append(": ").append(headerValue).append("\r\n");
+		}
+
+		// 헤더 끝을 나타내는 빈 라인 추가
+		httpMessage.append("\r\n");
+
+		// 3. Message Body (있다면 추가)
+		if (request.getMethod().equals("POST") || request.getMethod().equals("PUT")) {
+			// POST/PUT 메서드인 경우, 메시지 본문이 있을 수 있음
+			// 예시로 요청 파라미터를 출력합니다.
+			StringBuilder body = new StringBuilder();
+			request.getParameterMap().forEach((key, value) -> {
+				body.append(key).append("=").append(String.join(",", value)).append("&");
+			});
+
+			// 마지막 "&" 제거
+			if (body.length() > 0) {
+				body.deleteCharAt(body.length() - 1);
+				httpMessage.append(body);
+			}
+		}
+
+		// 요청 메시지 출력
+		log.info("✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅ New request");
+		log.info("HTTP Request: [ userId = "+ userId + " ]\n" + httpMessage);
+	}
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 로깅 aop를 구현했습니다.
- 로깅 내용은 아래와 같습니다.
    - userId (스레드 로컬마다 고유하게 있는 id)
    - 요청 클래스, 요청 메서드
    - 요청 파라미터
    - 실행시간
    - 시작점, 종료점 표시
    - 최초 요청에는 다른 요청과 구분하기 위해 ✅ 표시를 해뒀습니다.

- 추가로 controller 단에서는 HTTP request 메세지 원문 그대로를 로깅합니다. 저희 웹서버 구현하면서 rfc 문서와도 많이 친해졌으니 해당 값을 로깅하면 많은 도움이 될 것 같았습니다! 그래서 해당 메세지를 로깅했습니다.
- 스레드는 재사용되기 때문에 controller 단에서 userId를 할당 및 해제 해줬습니다.

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="1398" alt="스크린샷 2025-02-06 오후 1 36 08" src="https://github.com/user-attachments/assets/977e3ec3-f188-485e-8ac6-0c403703e1e8" />
<img width="1422" alt="스크린샷 2025-02-06 오후 1 36 27" src="https://github.com/user-attachments/assets/1e8e8a19-dcf3-43bc-9b1a-a4e8fcf14c9f" />



## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/