### PR TITLE
[UNI-123] feat : 대학 리스트 조회, 지도 건물, 위험 주의 요소 조회 API 연결 및 Enum, type 재정의 및 적용

### DIFF
--- a/uniro_frontend/src/api/nodes.ts
+++ b/uniro_frontend/src/api/nodes.ts
@@ -1,0 +1,19 @@
+import { Building } from "../data/types/node";
+import { getFetch } from "../utils/fetch/fetch";
+
+export const getAllBuildings = (
+	univId: number,
+	params: {
+		leftUpLng: number;
+		leftUpLat: number;
+		rightDownLng: number;
+		rightDownLat: number;
+	},
+): Promise<Building[]> => {
+	return getFetch<Building[]>(`/${univId}/nodes/buildings`, {
+		"left-up-lng": params.leftUpLng,
+		"left-up-lat": params.leftUpLat,
+		"right-down-lng": params.rightDownLng,
+		"right-down-lat": params.rightDownLat,
+	});
+};

--- a/uniro_frontend/src/api/routes.ts
+++ b/uniro_frontend/src/api/routes.ts
@@ -1,0 +1,8 @@
+import { CautionRoute, DangerRoute } from "../data/types/route";
+import { getFetch } from "../utils/fetch/fetch";
+
+export const getAllRisks = (
+	univId: number,
+): Promise<{ dangerRoutes: DangerRoute[]; cautionRoutes: CautionRoute[] }> => {
+	return getFetch<{ dangerRoutes: DangerRoute[]; cautionRoutes: CautionRoute[] }>(`/${univId}/routes/risks`);
+};

--- a/uniro_frontend/src/api/search.ts
+++ b/uniro_frontend/src/api/search.ts
@@ -1,0 +1,6 @@
+import { University } from "../data/types/university";
+import { getFetch } from "../utils/fetch/fetch";
+
+export const getUniversityList = (): Promise<{ data: University[]; nextCursor: number | null; hasNext: boolean }> => {
+	return getFetch<{ data: University[]; nextCursor: number | null; hasNext: boolean }>("/univ/search");
+};

--- a/uniro_frontend/src/api/search.ts
+++ b/uniro_frontend/src/api/search.ts
@@ -1,9 +1,8 @@
 import { University } from "../data/types/university";
 import { getFetch } from "../utils/fetch/fetch";
 import { transformGetUniversityList } from "./transformer/search";
+import { GetUniversityListResponse } from "./type/response/search";
 
 export const getUniversityList = (): Promise<University[]> => {
-	return getFetch<{ data: University[]; nextCursor: number | null; hasNext: boolean }>("/univ/search").then(
-		transformGetUniversityList,
-	);
+	return getFetch<GetUniversityListResponse>("/univ/search").then(transformGetUniversityList);
 };

--- a/uniro_frontend/src/api/search.ts
+++ b/uniro_frontend/src/api/search.ts
@@ -1,6 +1,9 @@
 import { University } from "../data/types/university";
 import { getFetch } from "../utils/fetch/fetch";
+import { transformGetUniversityList } from "./transformer/search";
 
-export const getUniversityList = (): Promise<{ data: University[]; nextCursor: number | null; hasNext: boolean }> => {
-	return getFetch<{ data: University[]; nextCursor: number | null; hasNext: boolean }>("/univ/search");
+export const getUniversityList = (): Promise<University[]> => {
+	return getFetch<{ data: University[]; nextCursor: number | null; hasNext: boolean }>("/univ/search").then(
+		transformGetUniversityList,
+	);
 };

--- a/uniro_frontend/src/api/transformer/search.ts
+++ b/uniro_frontend/src/api/transformer/search.ts
@@ -1,0 +1,6 @@
+import { University } from "../../data/types/university";
+import { GetUniversityListResponse } from "../type/response/search";
+
+export const transformGetUniversityList = (res: GetUniversityListResponse): University[] => {
+	return res.data;
+};

--- a/uniro_frontend/src/api/type/response/search.d.ts
+++ b/uniro_frontend/src/api/type/response/search.d.ts
@@ -1,0 +1,5 @@
+export type GetUniversityListResponse = {
+	data: University[];
+	nextCursor: number | null;
+	hasNext: boolean;
+};

--- a/uniro_frontend/src/components/loading/loading.tsx
+++ b/uniro_frontend/src/components/loading/loading.tsx
@@ -25,7 +25,7 @@ const Loading = ({ isLoading, loadingContent }: Props) => {
 				>
 					<div className="flex flex-row items-center justify-center bg-white rounded-3xl space-x-1">
 						<img src={svgPath} className="h-4 w-4 ml-2 my-2" />
-						<p className="text-kor-body2 mr-2 my-1">{university}</p>
+						<p className="text-kor-body2 mr-2 my-1">{university?.name}</p>
 					</div>
 					<p className="text-kor-body2 mt-3">{loadingContent}</p>
 					<img src="/loading/spinner.gif" className="w-12 h-12 mt-8" />

--- a/uniro_frontend/src/components/map/mapBottomSheet.tsx
+++ b/uniro_frontend/src/components/map/mapBottomSheet.tsx
@@ -12,7 +12,7 @@ interface MapBottomSheetFromListProps {
 export function MapBottomSheetFromList({ building, buttonText, onClick }: MapBottomSheetFromListProps) {
 	if (building.property === undefined) return;
 
-	const { id, lng, lat, isCore, buildingName, buildingImageUrl, phoneNumber, address } = building.property;
+	const { nodeId, lng, lat, buildingName, buildingImageUrl, phoneNumber, address } = building.property;
 
 	return (
 		<div className="h-full px-5 pt-3 pb-6 flex flex-col items-between">
@@ -46,7 +46,7 @@ interface MapBottomSheetProps {
 export function MapBottomSheetFromMarker({ building, onClickLeft, onClickRight }: MapBottomSheetProps) {
 	if (building.property === undefined) return;
 
-	const { id, lng, lat, isCore, buildingName, buildingImageUrl, phoneNumber, address } = building.property;
+	const { nodeId, lng, lat, buildingName, buildingImageUrl, phoneNumber, address } = building.property;
 
 	return (
 		<div className="h-full px-5 pt-3 pb-6 flex flex-col items-between">

--- a/uniro_frontend/src/components/map/mapMarkers.tsx
+++ b/uniro_frontend/src/components/map/mapMarkers.tsx
@@ -1,5 +1,6 @@
-import { MarkerTypes } from "../../data/types/marker";
+
 import { Markers } from "../../constant/enum/markerEnum";
+import { MarkerTypes } from "../../data/types/enum";
 
 const markerImages = import.meta.glob("/src/assets/markers/*.svg", { eager: true });
 

--- a/uniro_frontend/src/components/report/secondaryButton.tsx
+++ b/uniro_frontend/src/components/report/secondaryButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { CautionIssueType, DangerIssueType, PassableStatus } from "../../data/types/report";
 import { getThemeByPassableStatus } from "../../utils/report/getThemeByPassableStatus";
+import { CautionIssue, DangerIssue, PassableStatus } from "../../constant/enum/reportEnum";
 
 export const SecondaryFormButton = ({
 	onClick,
@@ -8,9 +8,9 @@ export const SecondaryFormButton = ({
 	content,
 	isSelected,
 }: {
-	onClick: (answer: DangerIssueType | CautionIssueType) => void;
+	onClick: (answer: DangerIssue | CautionIssue) => void;
 	formPassableStatus: PassableStatus;
-	content: DangerIssueType | CautionIssueType;
+	content: DangerIssue | CautionIssue;
 	isSelected: boolean;
 }) => {
 	return (

--- a/uniro_frontend/src/components/report/secondaryForm.tsx
+++ b/uniro_frontend/src/components/report/secondaryForm.tsx
@@ -1,23 +1,23 @@
-import { CautionIssueType, DangerIssueType, PassableStatus } from "../../constant/enum/reportEnum";
+import { CautionIssue, DangerIssue, PassableStatus } from "../../constant/enum/reportEnum";
 import { IssueQuestionButtons, ReportFormData, ReportModeType } from "../../data/types/report";
 
 import { FormTitle } from "./formTitle";
 import { SecondaryFormButton } from "./secondaryButton";
 
 const buttonConfig = {
-	danger: [DangerIssueType.LOW_STEP, DangerIssueType.CRACK, DangerIssueType.LOW_SLOPE, DangerIssueType.OTHERS],
+	danger: [DangerIssue.CURB, DangerIssue.CRACK, DangerIssue.SLOPE, DangerIssue.ETC],
 	caution: [
-		CautionIssueType.HIGH_STEP,
-		CautionIssueType.STAIRS,
-		CautionIssueType.STEEP_SLOPE,
-		CautionIssueType.OTHERS,
+		CautionIssue.CURB,
+		CautionIssue.STAIRS,
+		CautionIssue.SLOPE,
+		CautionIssue.ETC,
 	],
 } as IssueQuestionButtons;
 
 type SecondaryFormProps = {
 	reportMode: ReportModeType;
 	formData: ReportFormData;
-	handleSecondarySelect: (answer: DangerIssueType | CautionIssueType) => void;
+	handleSecondarySelect: (answer: DangerIssue | CautionIssue) => void;
 };
 
 export const SecondaryForm = ({ formData, handleSecondarySelect, reportMode }: SecondaryFormProps) => {
@@ -25,8 +25,8 @@ export const SecondaryForm = ({ formData, handleSecondarySelect, reportMode }: S
 		<>
 			{(formData.passableStatus === PassableStatus.CAUTION ||
 				formData.passableStatus === PassableStatus.DANGER) && (
-				<FormTitle isPrimary={false} reportMode={reportMode} passableStatus={formData.passableStatus} />
-			)}
+					<FormTitle isPrimary={false} reportMode={reportMode} passableStatus={formData.passableStatus} />
+				)}
 			<div className="flex flex-wrap w-full pt-5 pl-6 pr-4">
 				{formData.passableStatus === PassableStatus.CAUTION &&
 					buttonConfig.caution.map((button, index) => {

--- a/uniro_frontend/src/components/universityButton.tsx
+++ b/uniro_frontend/src/components/universityButton.tsx
@@ -7,15 +7,11 @@ interface UniversityButtonProps {
 	onClick: () => void;
 }
 
-const svgModules = import.meta.glob("/src/assets/university/*.svg", { eager: true });
-
 export default function UniversityButton({ name, img, selected, onClick }: UniversityButtonProps) {
 	const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
 		e.stopPropagation();
 		onClick();
 	};
-
-	const svgPath = (svgModules[`/src/assets/university/${img}`] as { default: string })?.default;
 
 	return (
 		<li className="my-[6px]">
@@ -23,7 +19,7 @@ export default function UniversityButton({ name, img, selected, onClick }: Unive
 				onClick={handleClick}
 				className={`w-full h-full p-6 flex flex-row items-center border rounded-400 ${selected ? "border-primary-400 bg-system-skyblue text-primary-500" : "border-gray-400"} `}
 			>
-				<img src={svgPath} className="mr-4" />
+				<img src={img} className="mr-4" />
 				<span className="text-kor-body2 font-medium leading-[140%]">{name}</span>
 			</button>
 		</li>

--- a/uniro_frontend/src/constant/enum/reportEnum.ts
+++ b/uniro_frontend/src/constant/enum/reportEnum.ts
@@ -6,15 +6,23 @@ export enum PassableStatus {
 }
 
 export enum DangerIssueType {
-	LOW_STEP = "낮은 턱이 있어요",
+	CURB = "낮은 턱이 있어요",
 	CRACK = "도로에 균열이 있어요",
-	LOW_SLOPE = "낮은 비탈길이 있어요",
-	OTHERS = "그 외 요소",
+	SLOPE = "낮은 비탈길이 있어요",
+	ETC = "그 외 요소",
 }
 
 export enum CautionIssueType {
-	HIGH_STEP = "높은 턱이 있어요",
+	CURB = "높은 턱이 있어요",
 	STAIRS = "계단이 있어요",
-	STEEP_SLOPE = "경사가 매우 높아요",
-	OTHERS = "그 외 요소",
+	SLOPE = "경사가 매우 높아요",
+	ETC = "그 외 요소",
+}
+
+export enum IssueTypeKey {
+	CURB = "CURB",
+	CRACK = "CRACK",
+	SLOPE = "SLOPE",
+	ETC = "ETC",
+	STAIRS = "STAIRS",
 }

--- a/uniro_frontend/src/constant/enum/reportEnum.ts
+++ b/uniro_frontend/src/constant/enum/reportEnum.ts
@@ -5,14 +5,14 @@ export enum PassableStatus {
 	INITIAL = "INITIAL",
 }
 
-export enum DangerIssueType {
+export enum DangerIssue {
 	CURB = "낮은 턱이 있어요",
 	CRACK = "도로에 균열이 있어요",
 	SLOPE = "낮은 비탈길이 있어요",
 	ETC = "그 외 요소",
 }
 
-export enum CautionIssueType {
+export enum CautionIssue {
 	CURB = "높은 턱이 있어요",
 	STAIRS = "계단이 있어요",
 	SLOPE = "경사가 매우 높아요",

--- a/uniro_frontend/src/data/types/enum.d.ts
+++ b/uniro_frontend/src/data/types/enum.d.ts
@@ -1,0 +1,6 @@
+import { Markers } from "../../constant/enum/markerEnum";
+import { DangerIssue, CautionIssue } from "../../constant/enum/reportEnum";
+
+export type DangerIssueType = keyof typeof DangerIssue;
+export type CautionIssueType = keyof typeof CautionIssue;
+export type MarkerTypes = (typeof Markers)[keyof typeof Markers];

--- a/uniro_frontend/src/data/types/marker.d.ts
+++ b/uniro_frontend/src/data/types/marker.d.ts
@@ -2,17 +2,6 @@ import { Markers } from "../../constant/enum/markerEnum";
 
 export type AdvancedMarker = google.maps.marker.AdvancedMarkerElement;
 
-export type MarkerTypes =
-	| Markers.BUILDING
-	| Markers.CAUTION
-	| Markers.DANGER
-	| Markers.DESTINATION
-	| Markers.ORIGIN
-	| Markers.NUMBERED_WAYPOINT
-	| Markers.WAYPOINT
-	| Markers.SELECTED_BUILDING
-	| Markers.REPORT;
-
 export type MarkerTypesWithElement = {
 	type: MarkerTypes;
 	element: AdvancedMarker;

--- a/uniro_frontend/src/data/types/report.d.ts
+++ b/uniro_frontend/src/data/types/report.d.ts
@@ -1,4 +1,4 @@
-import { CautionIssueType, DangerIssueType, PassableStatus } from "../../constant/enum/reportEnum";
+import { CautionIssue, DangerIssue, PassableStatus } from "../../constant/enum/reportEnum";
 
 export type ReportModeType = "create" | "update";
 
@@ -9,11 +9,11 @@ export interface PrimaryQuestionButton {
 }
 
 export interface IssueQuestionButtons {
-	danger: DangerIssueType[];
-	caution: CautionIssueType[];
+	danger: DangerIssue[];
+	caution: CautionIssue[];
 }
 export interface ReportFormData {
 	passableStatus: PassableStatus;
-	dangerIssues: DangerIssueType[];
-	cautionIssues: CautionIssueType[];
+	dangerIssues: DangerIssue[];
+	cautionIssues: CautionIssue[];
 }

--- a/uniro_frontend/src/data/types/route.d.ts
+++ b/uniro_frontend/src/data/types/route.d.ts
@@ -3,14 +3,13 @@ import { CautionIssueType, DangerIssueType } from "../../constant/enum/reportEnu
 import { RoutePoint } from "../../constant/enum/routeEnum";
 import { Coord } from "./coord";
 import { MarkerTypes } from "./marker";
-import { Node } from "./node";
 
 export type RouteId = number;
 
 export type Route = {
 	routeId: RouteId;
-	startNode: Node;
-	endNode: Node;
+	node1: Coord;
+	node2: Coord;
 };
 
 export type Direction = "origin" | "right" | "straight" | "left" | "uturn" | "destination" | "caution";

--- a/uniro_frontend/src/data/types/route.d.ts
+++ b/uniro_frontend/src/data/types/route.d.ts
@@ -1,5 +1,8 @@
+import { Markers } from "../../constant/enum/markerEnum";
 import { CautionIssueType, DangerIssueType } from "../../constant/enum/reportEnum";
+import { RoutePoint } from "../../constant/enum/routeEnum";
 import { Coord } from "./coord";
+import { MarkerTypes } from "./marker";
 import { Node } from "./node";
 
 export type RouteId = number;
@@ -23,6 +26,8 @@ export interface DangerRoute extends Route {
 export interface NavigationRoute extends Route {
 	cautionTypes: CautionIssueType[];
 }
+
+export type RoutePointType = RoutePoint.ORIGIN | RoutePoint.DESTINATION;
 
 export type RouteDetail = {
 	dist: number;

--- a/uniro_frontend/src/data/types/university.d.ts
+++ b/uniro_frontend/src/data/types/university.d.ts
@@ -1,0 +1,5 @@
+export type University = {
+	name: string;
+	imageUrl: string;
+	id: number;
+};

--- a/uniro_frontend/src/hooks/useUniversityInfo.tsx
+++ b/uniro_frontend/src/hooks/useUniversityInfo.tsx
@@ -1,9 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { University } from "../data/types/university";
 
 interface UniversityInfoStore {
-	university: string | undefined;
-	setUniversity: (university: string) => void;
+	university: University | undefined;
+	setUniversity: (university: University) => void;
 	resetUniversity: () => void;
 }
 
@@ -11,7 +12,7 @@ const useUniversityInfo = create(
 	persist<UniversityInfoStore>(
 		(set) => ({
 			university: undefined,
-			setUniversity: (newUniversity: string) => {
+			setUniversity: (newUniversity: University) => {
 				set(() => ({ university: newUniversity }));
 			},
 			resetUniversity: () => {

--- a/uniro_frontend/src/pages/universitySearch.tsx
+++ b/uniro_frontend/src/pages/universitySearch.tsx
@@ -29,7 +29,7 @@ export default function UniversitySearchPage() {
 						setSelectedUniv(undefined);
 					}}
 				>
-					{universityList && universityList.data.map((univ) => (
+					{universityList && universityList.map((univ) => (
 						<UniversityButton
 							key={`university-${univ.id}`}
 							selected={selectedUniv?.id === univ.id}

--- a/uniro_frontend/src/pages/universitySearch.tsx
+++ b/uniro_frontend/src/pages/universitySearch.tsx
@@ -1,13 +1,20 @@
 import { useState } from "react";
 import Input from "../components/customInput";
 import UniversityButton from "../components/universityButton";
-import { UniversityList } from "../constant/university";
 import Button from "../components/customButton";
 import { Link } from "react-router";
 import useUniversityInfo from "../hooks/useUniversityInfo";
+import { useQuery } from "@tanstack/react-query";
+import { getUniversityList } from "../api/search";
+import { University } from "../data/types/university";
 
 export default function UniversitySearchPage() {
-	const [selectedUniv, setSelectedUniv] = useState<string>("");
+	const { data: universityList, status } = useQuery({
+		queryKey: ['university'],
+		queryFn: getUniversityList
+	})
+
+	const [selectedUniv, setSelectedUniv] = useState<University>();
 	const { setUniversity } = useUniversityInfo();
 
 	return (
@@ -19,24 +26,24 @@ export default function UniversitySearchPage() {
 				<ul
 					className="w-full h-full px-[14px] py-[6px]"
 					onClick={() => {
-						setSelectedUniv("");
+						setSelectedUniv(undefined);
 					}}
 				>
-					{UniversityList.map(({ name, img }) => (
+					{universityList && universityList.data.map((univ) => (
 						<UniversityButton
-							key={name}
-							selected={selectedUniv === name}
+							key={`university-${univ.id}`}
+							selected={selectedUniv?.id === univ.id}
 							onClick={() => {
-								setSelectedUniv(name);
+								setSelectedUniv(univ);
 							}}
-							name={name}
-							img={img}
+							name={univ.name}
+							img={univ.imageUrl}
 						/>
 					))}
 				</ul>
 			</div>
 			<div className="px-[14px]">
-				{selectedUniv !== "" && (
+				{selectedUniv && (
 					<Link to="/map" onClick={() => setUniversity(selectedUniv)}>
 						<Button variant="primary">다음</Button>
 					</Link>


### PR DESCRIPTION
## #️⃣ 작업 내용

1. API Transform 적용
2. Type 및 Enum 재정의
3. 대학 리스트 조회 API 적용
4. 건물, 위험 주의 요소 조회 API 적용

## 핵심 기능

### API Transform 패턴 적용
#38 에서 생성한 API 인스턴스를 사용하여 API를 조회할 때, BE에서 전달되는 데이터 중에서 불필요한 데이터나, 필드명 등이 적합하지 않은 경우, 추가적인 postProcessing이 필요한 경우를 위해 API 호출 이후 Transform을 진행하는 패턴을 적용하였습니다.

```typescript
export type GetUniversityListResponse = {
	data: University[];
	nextCursor: number | null;
	hasNext: boolean;
};

export const getUniversityList = (): Promise<University[]> => {
	return getFetch<GetUniversityListResponse>("/univ/search").then(transformGetUniversityList);
};
```
- 다음과 같은 GetUniversirtyListResponse 형태로 API가 전달될 때, 렌더링에 필요한 데이터는 data 필드만 필요하기에 data만 추출하여 response로 전달될 수 있도록 다음과 같이 transformer를 적용하였습니다.
```typescript
export const transformGetUniversityList = (res: GetUniversityListResponse): University[] => {
	return res.data;
};
```
- 결과적으로 getUniversityList API는 University[]를 return할 수 있도록 하여 컴포넌트에서는 추가적인 가공을 진행하지 않게 하였습니다.


### Type 및 Enum 재정의
- 타입 및 Enum 재정의는 서면으로 토의 이후에 합의된 결과물입니다.

1. Enum 타입 재정의
```typescript
export type MarkerTypes =
	| Markers.BUILDING
	| Markers.CAUTION
	| Markers.DANGER
	| Markers.DESTINATION
	| Markers.ORIGIN
	| Markers.NUMBERED_WAYPOINT
	| Markers.WAYPOINT
	| Markers.SELECTED_BUILDING
	| Markers.REPORT;
```
- 다음과 같이 | 연산을 통해 직접 값을 할당하던 방식을 keyof typeof를 사용하여 key들을 type에 능동적으로 넣을 수 있도록 변환하였습니다.
``` typescript
export type DangerIssueType = keyof typeof DangerIssue;
export type CautionIssueType = keyof typeof CautionIssue;
export type MarkerTypes = (typeof Markers)[keyof typeof Markers];
```

2. Route 타입 재정의
```typescript
export type Route = {
	routeId: RouteId;
	node1: Coord;
	node2: Coord;
};
```
- 같이 진행한 재검토 과정에서 startNode, endNode를 API에 맞춰 node1, node2로 변경하고 각 Node타입이던 것을 Coord 타입으로 변환하였습니다.

### 대학 리스트 조회 API 적용
- 기존에 GlobalState로 대학교의 이름만 보관하던 것에서 이후 API 호출에서 대학교의 ID가 필요하고, Loading fallback에서 학교 이미지가 필요하여 Unviersity 타입 전체를 globalState로 분리하였습니다.
```typescript
export type University = {
	name: string;
	imageUrl: string;
	id: number;
};

interface UniversityInfoStore {
	university: University | undefined;
	setUniversity: (university: University) => void;
	resetUniversity: () => void;
}
```
- 대학 리스트 화면에서는 매우 짧은기간동안 Suspense 화면을 보여주는 것이 더 이상하게 다가올 수 있을것이라 판단하여 useQuery를 사용하였습니다.
```typescript
        export const getUniversityList = (): Promise<University[]> => {
	        return getFetch<GetUniversityListResponse>("/univ/search").then(transformGetUniversityList);
        };
---------------
	const { data: universityList, status } = useQuery({
		queryKey: ['university'],
		queryFn: getUniversityList
	})
```

### 지도 건물, 위험 주의 요소 조회 API 적용
- 앞에서 재정의된 타입들에 맞춰 Mock 데이터를 제거하고 코드를 변경하였습니다.
```typescript
	const results = useSuspenseQueries({
		queries: [
			{ queryKey: [university.id, 'risks'], queryFn: () => getAllRisks(university.id) },
			{
				queryKey: [university.id, 'buildings'], queryFn: () => getAllBuildings(university.id, {
					leftUpLat: 38,
					leftUpLng: 127,
					rightDownLat: 37,
					rightDownLng: 128
				})
			}
		]
	});

	const [risks, buildings] = results;
```
- 지도 메인화면에서 호출될 API는 2개(건물 조회, 위험 주의 요소 조회) 해당 과정은 useSuspenseQueries를 통해 로딩 화면을 보여주면서 여러 비동기로 queryFn을 실행합니다.

- 앞에서 재정의한 타입에 맞춰서 코드 수정 일부분입니다.
```typescript
      if (marker.type === Markers.DANGER) {
	      const key = marker.factors && marker.factors[0] as DangerIssueType;
	      marker.element.content = createMarkerElement({
		      type: marker.type,
		      title: key && DangerIssue[key],
		      hasTopContent: true,
	      });
      }
      else if (marker.type === Markers.CAUTION) {
	      const key = marker.factors && marker.factors[0] as CautionIssueType;
	      marker.element.content = createMarkerElement({
		      type: marker.type,
		      title: key && CautionIssue[key],
		      hasTopContent: true,
	      });
      }
```
- 마커의 타입을 필수로 체크하여 강제로 위험 주의 요소에 타입을 캐스팅하여 안정적으로 타입이 관리될 수 있도록 하였습니다.
- DangerIssueType과 CautionIssueType은 keyof typeof Issues로 선언되어 Key 형태로 변환되어 Enum에 바로 접근할 수 있도록 구현하였습니다.


## 동작 화면
### 대학 리스트 조회

https://github.com/user-attachments/assets/2405f0a0-af0e-40e1-8814-2334bb73d72a

### 지도 페이지 건물, 위험 주의 요소 조회

https://github.com/user-attachments/assets/93612e70-57a4-41ea-af4c-eeeae9c8d5fc
