### PR TITLE
[UNI-140] feat : 제보 Form API 연결

### DIFF
--- a/uniro_frontend/src/api/route.ts
+++ b/uniro_frontend/src/api/route.ts
@@ -1,0 +1,46 @@
+import { IssueTypeKey } from "../constant/enum/reportEnum";
+import { CautionIssueType, DangerIssueType } from "../data/types/enum";
+import { NodeId } from "../data/types/node";
+
+import { CoreRoutesList, NavigationRouteList, RouteId } from "../data/types/route";
+import { getFetch, postFetch } from "../utils/fetch/fetch";
+import { transformAllRoutes } from "./transformer/route";
+import { GetAllRouteRepsonse } from "./type/response/route";
+
+export const getNavigationResult = (
+	univId: number,
+	startNodeId: NodeId,
+	endNodeId: NodeId,
+): Promise<NavigationRouteList> => {
+	return getFetch<NavigationRouteList>(`/${univId}/routes/fastest`, {
+		"start-node-id": startNodeId,
+		"end-node-id": endNodeId,
+	});
+};
+
+export const getAllRoutes = (univId: number): Promise<CoreRoutesList> => {
+	return getFetch<GetAllRouteRepsonse>(`/${univId}/routes`).then((data) => transformAllRoutes(data));
+};
+
+export const getSingleRouteRisk = (
+	univId: number,
+	routeId: RouteId,
+): Promise<{
+	routeId: NodeId;
+	dangerTypes: IssueTypeKey[];
+	cautionTypes: IssueTypeKey[];
+}> => {
+	return getFetch<{
+		routeId: NodeId;
+		dangerTypes: IssueTypeKey[];
+		cautionTypes: IssueTypeKey[];
+	}>(`/${univId}/routes/${routeId}/risk`);
+};
+
+export const postReport = (
+	univId: number,
+	routeId: RouteId,
+	body: { dangerTypes: DangerIssueType[]; cautionTypes: CautionIssueType[] },
+): Promise<boolean> => {
+	return postFetch<void, string>(`/${univId}/route/risk/${routeId}`, body);
+};

--- a/uniro_frontend/src/api/transformer/route.ts
+++ b/uniro_frontend/src/api/transformer/route.ts
@@ -1,0 +1,31 @@
+import { DangerIssueType } from "../../constant/enum/reportEnum";
+import { CoreRoutesList } from "../../data/types/route";
+import { GetAllRouteRepsonse, GetSingleRouteRiskResponse } from "../type/response/route";
+
+export const transformAllRoutes = (data: GetAllRouteRepsonse): CoreRoutesList => {
+	const { nodeInfos, coreRoutes } = data;
+	const nodeInfoMap = new Map(nodeInfos.map((node) => [node.nodeId, node]));
+
+	return coreRoutes.map((coreRoute) => {
+		return {
+			...coreRoute,
+			routes: coreRoute.routes.map((route) => {
+				const node1 = nodeInfoMap.get(route.startNodeId);
+				const node2 = nodeInfoMap.get(route.endNodeId);
+
+				if (!node1) {
+					throw new Error(`Node not found: ${route.startNodeId}`);
+				}
+				if (!node2) {
+					throw new Error(`Node not found: ${route.endNodeId}`);
+				}
+
+				return {
+					routeId: route.routeId,
+					node1,
+					node2,
+				};
+			}),
+		};
+	});
+};

--- a/uniro_frontend/src/api/type/request/route.d.ts
+++ b/uniro_frontend/src/api/type/request/route.d.ts
@@ -1,0 +1,3 @@
+export type getAllRouteRequest = {
+	univId: number;
+};

--- a/uniro_frontend/src/api/type/response/route.d.ts
+++ b/uniro_frontend/src/api/type/response/route.d.ts
@@ -1,0 +1,23 @@
+import { IssueTypeKey } from "../../../constant/enum/reportEnum";
+import { Node, NodeId } from "../../../data/types/node";
+
+type CoreRoutesResponse = {
+	coreNode1Id: NodeId;
+	coreNode2Id: NodeId;
+	routes: {
+		routeId: NodeId;
+		startNodeId: NodeId;
+		endNodeId: NodeId;
+	}[];
+};
+
+export type GetAllRouteRepsonse = {
+	nodeInfos: Node[];
+	coreRoutes: CoreRoutesResponse[];
+};
+
+export type GetSingleRouteRiskResponse = {
+	routeId: NodeId;
+	dangerTypes?: IssueTypeKey[];
+	cautionTypes?: IssueTypeKey[];
+};

--- a/uniro_frontend/src/components/report/secondaryButton.tsx
+++ b/uniro_frontend/src/components/report/secondaryButton.tsx
@@ -1,24 +1,27 @@
 import React from "react";
-import { CautionIssueType, DangerIssueType, PassableStatus } from "../../data/types/report";
 import { getThemeByPassableStatus } from "../../utils/report/getThemeByPassableStatus";
+import { CautionIssue, DangerIssue, IssueTypeKey, PassableStatus } from "../../constant/enum/reportEnum";
+import { CautionIssueType, DangerIssueType } from "../../data/types/enum";
 
 export const SecondaryFormButton = ({
 	onClick,
 	formPassableStatus,
-	content,
 	isSelected,
+	contentKey,
 }: {
-	onClick: (answer: DangerIssueType | CautionIssueType) => void;
+	onClick: (answer: IssueTypeKey) => void;
 	formPassableStatus: PassableStatus;
-	content: DangerIssueType | CautionIssueType;
 	isSelected: boolean;
+	contentKey: IssueTypeKey;
 }) => {
 	return (
 		<button
-			onClick={() => onClick(content)}
+			onClick={() => onClick(contentKey)}
 			className={`mb-3 mr-3 py-[18px] px-[22px] border-[1px] rounded-[20px] w-fit text-kor-body2 border-gray-400 ${isSelected && getThemeByPassableStatus(formPassableStatus)}`}
 		>
-			{content}
+			{formPassableStatus === PassableStatus.CAUTION
+				? CautionIssue[contentKey as CautionIssueType]
+				: DangerIssue[contentKey as DangerIssueType]}
 		</button>
 	);
 };

--- a/uniro_frontend/src/components/report/secondaryForm.tsx
+++ b/uniro_frontend/src/components/report/secondaryForm.tsx
@@ -1,23 +1,18 @@
-import { CautionIssueType, DangerIssueType, PassableStatus } from "../../constant/enum/reportEnum";
+import { IssueTypeKey, PassableStatus } from "../../constant/enum/reportEnum";
 import { IssueQuestionButtons, ReportFormData, ReportModeType } from "../../data/types/report";
 
 import { FormTitle } from "./formTitle";
 import { SecondaryFormButton } from "./secondaryButton";
 
 const buttonConfig = {
-	danger: [DangerIssueType.LOW_STEP, DangerIssueType.CRACK, DangerIssueType.LOW_SLOPE, DangerIssueType.OTHERS],
-	caution: [
-		CautionIssueType.HIGH_STEP,
-		CautionIssueType.STAIRS,
-		CautionIssueType.STEEP_SLOPE,
-		CautionIssueType.OTHERS,
-	],
+	danger: [IssueTypeKey.CURB, IssueTypeKey.STAIRS, IssueTypeKey.SLOPE, IssueTypeKey.ETC],
+	caution: [IssueTypeKey.CURB, IssueTypeKey.CRACK, IssueTypeKey.SLOPE, IssueTypeKey.ETC],
 } as IssueQuestionButtons;
 
 type SecondaryFormProps = {
 	reportMode: ReportModeType;
 	formData: ReportFormData;
-	handleSecondarySelect: (answer: DangerIssueType | CautionIssueType) => void;
+	handleSecondarySelect: (answer: IssueTypeKey) => void;
 };
 
 export const SecondaryForm = ({ formData, handleSecondarySelect, reportMode }: SecondaryFormProps) => {
@@ -35,8 +30,7 @@ export const SecondaryForm = ({ formData, handleSecondarySelect, reportMode }: S
 								onClick={handleSecondarySelect}
 								formPassableStatus={formData.passableStatus}
 								isSelected={formData.cautionIssues.includes(button)}
-								content={button}
-								key={index}
+								contentKey={button}
 							/>
 						);
 					})}
@@ -47,8 +41,7 @@ export const SecondaryForm = ({ formData, handleSecondarySelect, reportMode }: S
 								onClick={handleSecondarySelect}
 								formPassableStatus={formData.passableStatus}
 								isSelected={formData.dangerIssues.includes(button)}
-								content={button}
-								key={index}
+								contentKey={button}
 							/>
 						);
 					})}

--- a/uniro_frontend/src/constant/enum/reportEnum.ts
+++ b/uniro_frontend/src/constant/enum/reportEnum.ts
@@ -4,17 +4,22 @@ export enum PassableStatus {
 	RESTORED = "RESTORED",
 	INITIAL = "INITIAL",
 }
-
-export enum DangerIssueType {
-	LOW_STEP = "낮은 턱이 있어요",
+export enum CautionIssue {
+	CURB = "낮은 턱이 있어요",
 	CRACK = "도로에 균열이 있어요",
-	LOW_SLOPE = "낮은 비탈길이 있어요",
-	OTHERS = "그 외 요소",
+	SLOPE = "낮은 비탈길이 있어요",
+	ETC = "그 외 요소",
 }
-
-export enum CautionIssueType {
-	HIGH_STEP = "높은 턱이 있어요",
+export enum DangerIssue {
+	CURB = "높은 턱이 있어요",
 	STAIRS = "계단이 있어요",
-	STEEP_SLOPE = "경사가 매우 높아요",
-	OTHERS = "그 외 요소",
+	SLOPE = "경사가 매우 높아요",
+	ETC = "그 외 요소",
+}
+export enum IssueTypeKey {
+	CURB = "CURB",
+	CRACK = "CRACK",
+	SLOPE = "SLOPE",
+	ETC = "ETC",
+	STAIRS = "STAIRS",
 }

--- a/uniro_frontend/src/data/types/enum.d.ts
+++ b/uniro_frontend/src/data/types/enum.d.ts
@@ -1,0 +1,4 @@
+import { CautionIssue, DangerIssue } from "../../constant/enum/reportEnum";
+
+export type DangerIssueType = keyof typeof DangerIssue;
+export type CautionIssueType = keyof typeof CautionIssue;

--- a/uniro_frontend/src/data/types/report.d.ts
+++ b/uniro_frontend/src/data/types/report.d.ts
@@ -14,6 +14,6 @@ export interface IssueQuestionButtons {
 }
 export interface ReportFormData {
 	passableStatus: PassableStatus;
-	dangerIssues: DangerIssueType[];
-	cautionIssues: CautionIssueType[];
+	dangerIssues: IssueTypeKey[];
+	cautionIssues: IssueTypeKey[];
 }

--- a/uniro_frontend/src/data/types/route.d.ts
+++ b/uniro_frontend/src/data/types/route.d.ts
@@ -6,8 +6,8 @@ export type RouteId = number;
 
 export type Route = {
 	routeId: RouteId;
-	startNode: Node;
-	endNode: Node;
+	node1: Coord;
+	node2: Coord;
 };
 
 export type Direction = "origin" | "right" | "straight" | "left" | "uturn" | "destination" | "caution";
@@ -23,6 +23,20 @@ export interface DangerRoute extends Route {
 export interface NavigationRoute extends Route {
 	cautionTypes: CautionIssueType[];
 }
+
+export interface CoreRoute {
+	routeId: RouteId;
+	node1: Node;
+	node2: Node;
+}
+
+export interface CoreRoutes {
+	coreNode1Id: NodeId;
+	coreNode2Id: NodeId;
+	routes: CoreRoute[];
+}
+
+export type CoreRoutesList = CoreRoutes[];
 
 export type RouteDetail = {
 	dist: number;

--- a/uniro_frontend/src/data/types/university.d.ts
+++ b/uniro_frontend/src/data/types/university.d.ts
@@ -1,0 +1,5 @@
+export type University = {
+	name: string;
+	imageUrl: string;
+	id: number;
+};

--- a/uniro_frontend/src/hooks/useDynamicSuspense.tsx
+++ b/uniro_frontend/src/hooks/useDynamicSuspense.tsx
@@ -10,8 +10,7 @@ export const useDynamicSuspense = () => {
 	useEffect(() => {
 		const newFallback = fallbackConfig[location.pathname] || fallbackConfig["/"];
 		setFallback(newFallback);
-		console.log("fallback", newFallback);
 	}, [location.pathname, setFallback]);
 
-	return { location, fallback }
+	return { location, fallback };
 };

--- a/uniro_frontend/src/hooks/useModal.tsx
+++ b/uniro_frontend/src/hooks/useModal.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode, useCallback, useState } from "react";
 
-export default function useModal(): [React.FC<{ children: ReactNode }>, boolean, () => void, () => void] {
+export default function useModal(
+	onClose?: () => void,
+): [React.FC<{ children: ReactNode }>, boolean, () => void, () => void] {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
 
 	const open = useCallback(() => {
@@ -8,6 +10,9 @@ export default function useModal(): [React.FC<{ children: ReactNode }>, boolean,
 	}, []);
 
 	const close = useCallback(() => {
+		if (onClose) {
+			onClose();
+		}
 		setIsOpen(false);
 	}, []);
 

--- a/uniro_frontend/src/hooks/useUniversityInfo.tsx
+++ b/uniro_frontend/src/hooks/useUniversityInfo.tsx
@@ -1,17 +1,16 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-
+import { University } from "../data/types/university";
 interface UniversityInfoStore {
-	university: string | undefined;
-	setUniversity: (university: string) => void;
+	university: University | undefined;
+	setUniversity: (university: University) => void;
 	resetUniversity: () => void;
 }
-
 const useUniversityInfo = create(
 	persist<UniversityInfoStore>(
 		(set) => ({
 			university: undefined,
-			setUniversity: (newUniversity: string) => {
+			setUniversity: (newUniversity: University) => {
 				set(() => ({ university: newUniversity }));
 			},
 			resetUniversity: () => {
@@ -23,5 +22,4 @@ const useUniversityInfo = create(
 		},
 	),
 );
-
 export default useUniversityInfo;

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -13,7 +13,7 @@ import useScrollControl from "../hooks/useScrollControl";
 import useModal from "../hooks/useModal";
 import useUniversityInfo from "../hooks/useUniversityInfo";
 import useRedirectUndefined from "../hooks/useRedirectUndefined";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { getSingleRouteRisk, postReport } from "../api/route";
 import { University } from "../data/types/university";
 import { useNavigate } from "react-router";
@@ -23,6 +23,7 @@ const ReportForm = () => {
 
 	const navigate = useNavigate();
 	const redirectToMap = () => navigate("/map");
+	const queryClient = useQueryClient();
 
 	const [disabled, setDisabled] = useState<boolean>(true);
 
@@ -38,7 +39,7 @@ const ReportForm = () => {
 	const routeId = 1;
 
 	const { data } = useSuspenseQuery({
-		queryKey: ["user", university?.id ?? 1001, routeId],
+		queryKey: ["report", university?.id ?? 1001, routeId],
 		queryFn: async () => {
 			try {
 				const data = await getSingleRouteRisk(university?.id ?? 1001, routeId);
@@ -57,6 +58,7 @@ const ReportForm = () => {
 	// 임시 Error 처리
 	useEffect(() => {
 		if (data.routeId === -1) {
+			queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
 			setErrorTitle("존재하지 않은 경로예요");
 			openFail();
 		}
@@ -122,6 +124,7 @@ const ReportForm = () => {
 				cautionTypes: formData.cautionIssues,
 			}),
 		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
 			openSuccess();
 		},
 		onError: () => {

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import { PassableStatus, DangerIssueType, CautionIssueType } from "../constant/enum/reportEnum";
+import { PassableStatus, IssueTypeKey } from "../constant/enum/reportEnum";
 import { ReportModeType, ReportFormData } from "../data/types/report";
 
 import { ReportTitle } from "../components/report/reportTitle";
@@ -11,38 +11,71 @@ import Button from "../components/customButton";
 
 import useScrollControl from "../hooks/useScrollControl";
 import useModal from "../hooks/useModal";
-import useReportHazard from "../hooks/useReportHazard";
 import useUniversityInfo from "../hooks/useUniversityInfo";
 import useRedirectUndefined from "../hooks/useRedirectUndefined";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { getSingleRouteRisk, postReport } from "../api/route";
+import { University } from "../data/types/university";
+import { useNavigate } from "react-router";
 
 const ReportForm = () => {
 	useScrollControl();
 
-	const [reportMode, setReportMode] = useState<ReportModeType | null>(null);
-
-	const [formData, setFormData] = useState<ReportFormData>({
-		passableStatus: PassableStatus.INITIAL,
-		dangerIssues: [],
-		cautionIssues: [],
-	});
+	const navigate = useNavigate();
+	const redirectToMap = () => navigate("/map");
 
 	const [disabled, setDisabled] = useState<boolean>(true);
 
-	const [FailModal, isFailOpen, openFail, closeFail] = useModal();
-	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal();
+	const [FailModal, isFailOpen, openFail, closeFail] = useModal(redirectToMap);
+	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal(redirectToMap);
 
-	const { reportType, startNode, endNode } = useReportHazard();
+	const [errorTitle, setErrorTitle] = useState<string>("");
 
 	const { university } = useUniversityInfo();
-	useRedirectUndefined<string | undefined>([university, reportType]);
 
+	useRedirectUndefined<University | undefined>([university]);
+
+	const routeId = 1;
+
+	const { data } = useSuspenseQuery({
+		queryKey: ["user", university?.id ?? 1001, routeId],
+		queryFn: async () => {
+			try {
+				const data = await getSingleRouteRisk(university?.id ?? 1001, routeId);
+				return data;
+			} catch (e) {
+				return {
+					routeId: -1,
+					dangerTypes: [],
+					cautionTypes: [],
+				};
+			}
+		},
+		retry: 1,
+	});
+
+	// 임시 Error 처리
 	useEffect(() => {
-		console.log(reportType, startNode, endNode);
+		if (data.routeId === -1) {
+			setErrorTitle("존재하지 않은 경로예요");
+			openFail();
+		}
+	}, [data]);
 
-		setTimeout(() => {
-			setReportMode("update");
-		}, 2000);
-	}, []);
+	const [reportMode, setReportMode] = useState<ReportModeType | null>(
+		data.cautionTypes.length > 0 || data.dangerTypes.length > 0 ? "update" : "create",
+	);
+
+	const [formData, setFormData] = useState<ReportFormData>({
+		passableStatus:
+			reportMode === "create"
+				? PassableStatus.INITIAL
+				: data.cautionTypes.length > 0
+					? PassableStatus.CAUTION
+					: PassableStatus.DANGER,
+		dangerIssues: data.dangerTypes,
+		cautionIssues: data.cautionTypes,
+	});
 
 	useEffect(() => {
 		if (
@@ -59,55 +92,62 @@ const ReportForm = () => {
 	const handlePrimarySelect = (status: PassableStatus) => {
 		setFormData((prev) => ({
 			passableStatus: status === prev.passableStatus ? PassableStatus.INITIAL : status,
-			dangerIssues: status === PassableStatus.DANGER ? [] : prev.dangerIssues,
-			cautionIssues: status === PassableStatus.CAUTION ? [] : prev.cautionIssues,
+			dangerIssues: status === prev.passableStatus ? prev.dangerIssues : [],
+			cautionIssues: status === prev.passableStatus ? prev.cautionIssues : [],
 		}));
 	};
 
-	const handleSecondarySelect = (answerType: DangerIssueType | CautionIssueType) => {
+	const handleSecondarySelect = (answerType: IssueTypeKey) => {
 		if (formData.passableStatus === PassableStatus.DANGER) {
 			setFormData((prev) => ({
 				...prev,
-				dangerIssues: prev.dangerIssues.includes(answerType as DangerIssueType)
+				dangerIssues: prev.dangerIssues.includes(answerType)
 					? prev.dangerIssues.filter((issue) => issue !== answerType)
-					: [...prev.dangerIssues, answerType as DangerIssueType],
+					: [...prev.dangerIssues, answerType],
 			}));
 		} else if (formData.passableStatus === PassableStatus.CAUTION) {
 			setFormData((prev) => ({
 				...prev,
-				cautionIssues: prev.cautionIssues.includes(answerType as CautionIssueType)
+				cautionIssues: prev.cautionIssues.includes(answerType)
 					? prev.cautionIssues.filter((issue) => issue !== answerType)
-					: [...prev.cautionIssues, answerType as CautionIssueType],
+					: [...prev.cautionIssues, answerType],
 			}));
 		}
 	};
 
-	const onReportSubmitSuccess = () => {
-		openSuccess();
-	};
+	const { mutate } = useMutation({
+		mutationFn: () =>
+			postReport(university?.id ?? 1001, routeId, {
+				dangerTypes: formData.dangerIssues,
+				cautionTypes: formData.cautionIssues,
+			}),
+		onSuccess: () => {
+			openSuccess();
+		},
+		onError: () => {
+			setErrorTitle("제보에 실패하였습니다");
+			openFail();
+		},
+	});
 
-	const onReportSubmitFail = () => {
-		openFail();
-	};
-
-	return reportMode ? (
+	return (
 		<div className="flex flex-col h-svh w-full max-w-[450px] mx-auto relative">
-			<ReportTitle reportMode={reportMode} />
+			<ReportTitle reportMode={reportMode!} />
 			<ReportDivider />
 			<div className="flex-1 overflow-y-auto">
 				<PrimaryForm
-					reportMode={reportMode}
+					reportMode={reportMode!}
 					passableStatus={formData.passableStatus}
 					handlePrimarySelect={handlePrimarySelect}
 				/>
 				<SecondaryForm
-					reportMode={reportMode}
+					reportMode={reportMode!}
 					formData={formData}
 					handleSecondarySelect={handleSecondarySelect}
 				/>
 			</div>
 			<div className="mb-4 w-full px-4">
-				<Button onClick={onReportSubmitSuccess} variant={disabled ? "disabled" : "primary"}>
+				<Button onClick={() => mutate()} variant={disabled ? "disabled" : "primary"}>
 					제보하기
 				</Button>
 			</div>
@@ -121,7 +161,7 @@ const ReportForm = () => {
 				</div>
 			</SuccessModal>
 			<FailModal>
-				<p className="text-kor-body1 font-bold text-system-red">이미 삭제된 경로예요</p>
+				<p className="text-kor-body1 font-bold text-system-red">{errorTitle}</p>
 				<div className="space-y-0">
 					<p className="text-kor-body3 font-regular text-gray-700">
 						해당 경로는 다른 사용자에 의해 삭제되어,
@@ -130,8 +170,6 @@ const ReportForm = () => {
 				</div>
 			</FailModal>
 		</div>
-	) : (
-		<div>로딩중...</div>
 	);
 };
 

--- a/uniro_frontend/src/utils/fetch/fetch.ts
+++ b/uniro_frontend/src/utils/fetch/fetch.ts
@@ -17,17 +17,20 @@ export default function Fetch() {
 		return response.json();
 	};
 
-	const post = async <T, K>(url: string, body?: Record<string, K>): Promise<T> => {
+	const post = async <T, K>(url: string, body?: Record<string, K | K[]>): Promise<boolean> => {
 		const response = await fetch(`${baseURL}${url}`, {
 			method: "POST",
 			body: JSON.stringify(body),
+			headers: {
+				"Content-Type": "application/json",
+			},
 		});
 
 		if (!response.ok) {
 			throw new Error(`${response.status}-${response.statusText}`);
 		}
 
-		return response.json();
+		return response.ok;
 	};
 
 	const put = async <T, K>(url: string, body?: Record<string, K>): Promise<T> => {


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 제보 Form API를 연결했습니다
2. fallback의 console.log을 삭제했습니다.

## 핵심 기능

### Form State를 Enum Key Type으로 변경했습니다.

백엔드 요청이 전부 Key값으로 요청이 전달되어, Key값으로 State가 저장되도록 변경했습니다. 
```typescript
export const SecondaryFormButton = ({
	onClick,
	formPassableStatus,
	isSelected,
	contentKey,
}: {
	onClick: (answer: IssueTypeKey) => void;
	formPassableStatus: PassableStatus;
	isSelected: boolean;
	contentKey: IssueTypeKey;
}) => {
	return (
		<button
			onClick={() => onClick(contentKey)}
			className={`mb-3 mr-3 py-[18px] px-[22px] border-[1px] rounded-[20px] w-fit text-kor-body2 border-gray-400 ${isSelected && getThemeByPassableStatus(formPassableStatus)}`}
		>
			{formPassableStatus === PassableStatus.CAUTION
				? CautionIssue[contentKey as CautionIssueType]
				: DangerIssue[contentKey as DangerIssueType]}
		</button>
	);
};
```

### Form 로직 이슈 해결
- 수정 상태에서 danger, caution state들이 서로 왔다갔다 할 때, 값이 보존되는 버그가 있어 해결했습니다
```typescript
const handlePrimarySelect = (status: PassableStatus) => {
		setFormData((prev) => ({
			passableStatus: status === prev.passableStatus ? PassableStatus.INITIAL : status,
			dangerIssues: status === prev.passableStatus ? prev.dangerIssues : [],
			cautionIssues: status === prev.passableStatus ? prev.cautionIssues : [],
		}));
	};
```

### useSuspenseQuery를 사용해 Form 데이터 Initialize
```typescript
	const { data } = useSuspenseQuery({
		queryKey: ["user", university?.id ?? 1001, routeId],
		queryFn: async () => {
			try {
				const data = await getSingleRouteRisk(university?.id ?? 1001, routeId);
				return data;
			} catch (e) {
				return {
					routeId: -1,
					dangerTypes: [],
					cautionTypes: [],
				};
			}
		},
		retry: 1,
	});

	// 임시 Error 처리
	useEffect(() => {
		if (data.routeId === -1) {
			queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
			setErrorTitle("존재하지 않은 경로예요");
			openFail();
		}
	}, [data]);
```
우선 길이 존재하지 않을 경우 케이스는 data.routeId를 -1 처리해 존재하지 않는 경로라고 처리했습니다.

### post fetch 배열에 맞게 변경 및 response를 boolean으로 통일
```typescript
const post = async <T, K>(url: string, body?: Record<string, K | K[]>): Promise<boolean> => {
		const response = await fetch(`${baseURL}${url}`, {
			method: "POST",
			body: JSON.stringify(body),
			headers: {
				"Content-Type": "application/json",
			},
		});

		if (!response.ok) {
			throw new Error(`${response.status}-${response.statusText}`);
		}

		return response.ok;
	};
```

### 제보 등록시 Mutation
```typescript
	const { mutate } = useMutation({
		mutationFn: () =>
			postReport(university?.id ?? 1001, routeId, {
				dangerTypes: formData.dangerIssues,
				cautionTypes: formData.cautionIssues,
			}),
		onSuccess: () => {
			queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
			openSuccess();
		},
		onError: () => {
			setErrorTitle("제보에 실패하였습니다");
			openFail();
		},
	});
```

## 동작 화면

### 데이터가 존재하고, 수정해야할 때

https://github.com/user-attachments/assets/860950a1-ea1d-4132-939f-732ae811f1b9

### 존재하지 않은 경로일 때 

https://github.com/user-attachments/assets/98e06899-b827-4e69-9670-c5f247cdbc76