### PR TITLE
[UNI-141] feat : 길 조회 API 연결

### DIFF
--- a/uniro_frontend/src/data/types/route.d.ts
+++ b/uniro_frontend/src/data/types/route.d.ts
@@ -3,6 +3,7 @@ import { CautionIssueType, DangerIssueType } from "../../constant/enum/reportEnu
 import { RoutePoint } from "../../constant/enum/routeEnum";
 import { Coord } from "./coord";
 import { MarkerTypes } from "./marker";
+import { Node } from "./node";
 
 export type RouteId = number;
 


### PR DESCRIPTION


## #️⃣ 작업 내용

1. 길 조회 API를 연결했습니다.

## 소통을 위해 잠깐 필요한 부분

![image](https://github.com/user-attachments/assets/be287757-7447-4fe9-9583-5b463629ab62)

제가 길을 백엔드에 잘못 줘서.. 아마 꺾이는 길에서 계속 5번 라우트가 뜰 예정입니다. 정상이니까 당황하지 마시고, 오히려 제보 테스트에 사용하면 좋을 거 같습니다~!

## 핵심 기능

### 길 조회 API 연결

https://github.com/softeer5th/Team2-Getit/pull/65 이 PR에서 길 조회 API를 만들어 놓았었는데, transformer까지 적용시켜 잘 만들어놓았습니다. 좀 불편한 부분은 nodeId를 다이렉트로 map 형태로 가져올 수 있는 데이터가 없는데 처음 시작과 끝에서 그릴 때 처음 index와 마지막 index를 활용해야 한다는 점이 cost입니다.

연결한 페이지는
1. 제보 페이지
2. 길 추가 페이지

두가지 페이지에 모두 다 연결했습니다.

#### 적용한 방식
기존 로직은 하나의 Path에 대해서 그리는 방식이었는데, 조금 응용해서 2중 for문을 사용했습니다.
데이터 불러오는 속도 자체는 매우 빨라서, 사용자 입장에서 Overhead가 적은 것 같습니다. 나중에 개발자 창으로 Data가 얼마나 오는지 같이 확인해보면 좋을 것 같습니다.

```typescript
const drawRoute = (coreRouteList: CoreRoutesList) => {
		if (!Polyline || !AdvancedMarker || !map) return;

		for (const coreRoutes of coreRouteList) {
			// 가장 끝쪽 Core Node 그리기
			const endNode = coreRoutes.routes[coreRoutes.routes.length - 1].node2;

			createAdvancedMarker(
				AdvancedMarker,
				map,
				endNode,
				createMarkerElement({ type: Markers.WAYPOINT, className: "translate-waypoint" }),
			);

			for (const coreRoute of coreRoutes.routes) {
				const routePolyLine = new Polyline({
					map: map,
					path: [coreRoute.node1, coreRoute.node2],
					strokeColor: "#808080",
				});

				routePolyLine.addListener("click", (e: ClickEvent) => {
					const subNodes = createSubNodes(routePolyLine);

					alert(coreRoute.routeId);

					const edges = subNodes
						.map(
							(node, idx) =>
								[node, subNodes[idx + 1]] as [google.maps.LatLngLiteral, google.maps.LatLngLiteral],
						)
						.slice(0, -1);

					const point = LatLngToLiteral(e.latLng);

					const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(edges, point);

					const newReportMarker = createAdvancedMarker(
						AdvancedMarker,
						map,
						centerCoordinate(nearestEdge[0], nearestEdge[1]),
						createMarkerElement({
							type: Markers.REPORT,
							className: "translate-routemarker",
							hasAnimation: true,
						}),
					);

					setMessage(ReportHazardMessage.CREATE);

					setReportMarker((prevMarker) => {
						if (prevMarker) {
							resetMarker(prevMarker);
						}

						return {
							type: Markers.REPORT,
							element: newReportMarker,
							edge: nearestEdge,
						};
					});
				});
			}
			// 시작하는 쪽의 Core Node 그리기
			const startNode = coreRoutes.routes[0].node1;
			createAdvancedMarker(
				AdvancedMarker,
				map,
				startNode,
				createMarkerElement({ type: Markers.WAYPOINT, className: "translate-waypoint" }),
			);
		}
	};
```
2중 for문을 돌며, 동현님이 만들어놓으신 그대로 endNode부터 marker를 찍고 Polyline을 그린 후 event를 걸고, startNode를 그렸습니다.
근데 이렇게 2중 for문을 도는 것보다, coreNode들만 마커를 따로 찍고, 나머지들에 대해서 Polyline을 그리는 방식으로 변경하는 것도 좋을 것 같습니다. 우선은 만드신 로직 그대로 적용하고 싶어서 유지했습니다. (제보 페이지도 그대로 로직은 남겨둔채 2중 For문으로 변경했습니다.)

## 동작 화면

### 제보 화면

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/215044dc-a07f-4e72-aa7e-c758db48e51a" />

### 길 추가 화면

역시.. 잘 만들어놓으셔서  바로 적용이 되네요

<img width="562" alt="image" src="https://github.com/user-attachments/assets/46befa08-5607-4110-b454-77efd47c10b5" />

<img width="577" alt="image" src="https://github.com/user-attachments/assets/1a40eda9-aaf9-4a72-8c15-4283b4a93ada" />