### PR TITLE
[UNI-143] fix : 스크린 사이즈 dvh로 통일하기

### DIFF
--- a/uniro_frontend/src/pages/buildingSearch.tsx
+++ b/uniro_frontend/src/pages/buildingSearch.tsx
@@ -12,7 +12,7 @@ export default function BuildingSearchPage() {
 	useRedirectUndefined<string | undefined>([university]);
 
 	return (
-		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center">
+		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center">
 			<div className="px-[14px] py-4 border-b-[1px] border-gray-400">
 				<Input onLengthChange={() => {}} handleVoiceInput={() => {}} placeholder="" />
 			</div>

--- a/uniro_frontend/src/pages/error.tsx
+++ b/uniro_frontend/src/pages/error.tsx
@@ -2,7 +2,7 @@ import Error from "../components/error/Error";
 
 export default function ErrorPage() {
 	return (
-		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center items-center">
+		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center items-center">
 			<Error />
 		</div>
 	);

--- a/uniro_frontend/src/pages/landing.tsx
+++ b/uniro_frontend/src/pages/landing.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router";
 
 export default function LandingPage() {
 	return (
-		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center bg-[url(/public/background.png)] bg-cover">
+		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center bg-[url(/public/background.png)] bg-cover">
 			<div>
 				<p className="text-kor-heading1 font-bold">어디든 갈 수 있는 캠퍼스.</p>
 				<p className="text-kor-heading1 font-bold">쉽고 빠르게 이동하세요.</p>

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -70,7 +70,7 @@ const NavigationResultPage = () => {
 	}, []);
 
 	return (
-		<div className="relative h-svh w-full max-w-[450px] mx-auto">
+		<div className="relative h-dvh w-full max-w-[450px] mx-auto">
 			{/* 지도 영역 */}
 			<NavigationMap
 				style={{ width: "100%", height: "100%" }}

--- a/uniro_frontend/src/pages/offline.tsx
+++ b/uniro_frontend/src/pages/offline.tsx
@@ -2,7 +2,7 @@ import Offline from "../components/error/Offline";
 
 export default function OfflinePage() {
 	return (
-		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto justify-center items-center">
+		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center items-center">
 			<Offline />
 		</div>
 	);

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -134,7 +134,7 @@ const ReportForm = () => {
 	});
 
 	return (
-		<div className="flex flex-col h-svh w-full max-w-[450px] mx-auto relative">
+		<div className="flex flex-col h-dvh w-full max-w-[450px] mx-auto relative">
 			<ReportTitle reportMode={reportMode!} />
 			<ReportDivider />
 			<div className="flex-1 overflow-y-auto">

--- a/uniro_frontend/src/pages/universitySearch.tsx
+++ b/uniro_frontend/src/pages/universitySearch.tsx
@@ -10,17 +10,17 @@ import { University } from "../data/types/university";
 
 export default function UniversitySearchPage() {
 	const { data: universityList, status } = useQuery({
-		queryKey: ['university'],
-		queryFn: getUniversityList
-	})
+		queryKey: ["university"],
+		queryFn: getUniversityList,
+	});
 
 	const [selectedUniv, setSelectedUniv] = useState<University>();
 	const { setUniversity } = useUniversityInfo();
 
 	return (
-		<div className="relative flex flex-col h-screen w-full max-w-[450px] mx-auto py-5">
+		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto py-5">
 			<div className="w-full px-[14px] pb-[17px] border-b-[1px] border-gray-400">
-				<Input onLengthChange={() => { }} placeholder="우리 학교를 검색해보세요" handleVoiceInput={() => { }} />
+				<Input onLengthChange={() => {}} placeholder="우리 학교를 검색해보세요" handleVoiceInput={() => {}} />
 			</div>
 			<div className="overflow-y-scroll flex-1">
 				<ul
@@ -29,17 +29,18 @@ export default function UniversitySearchPage() {
 						setSelectedUniv(undefined);
 					}}
 				>
-					{universityList && universityList.map((univ) => (
-						<UniversityButton
-							key={`university-${univ.id}`}
-							selected={selectedUniv?.id === univ.id}
-							onClick={() => {
-								setSelectedUniv(univ);
-							}}
-							name={univ.name}
-							img={univ.imageUrl}
-						/>
-					))}
+					{universityList &&
+						universityList.map((univ) => (
+							<UniversityButton
+								key={`university-${univ.id}`}
+								selected={selectedUniv?.id === univ.id}
+								onClick={() => {
+									setSelectedUniv(univ);
+								}}
+								name={univ.name}
+								img={univ.imageUrl}
+							/>
+						))}
 				</ul>
 			</div>
 			<div className="px-[14px]">


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 현재 있는 화면들 중 h-screen 부분을 h-dvh로 변경했습니다.

## 핵심 기능

### Why Dvh?

<img width="703" alt="스크린샷 2025-02-06 21 35 47" src="https://github.com/user-attachments/assets/c11da84f-6c52-4154-9707-ce0ab9bfc59b" />

일반적인 브라우저 화면에서 사용자에게 보여지는 화면 범위를 viewport라고 정의합니다. 이 viewport는 PC에서는 신경 쓸 일이 없지만, mobile의 경우 화면들의 구성요소들의 밀도가 높고, 화면이 작으면서 브라우저가 보여지는 영역까지 달라져 viewport가 자체 OS나 브라우저에 의해 가려지는 부분이 있습니다.

스마트폰이 보급되고, 많은 사람들이 스마트 기기를 활용해 인터넷을 접속하게 되면서, 매번 기기 정보를 받아와 어떤 화면 범위를 보여주라고 정의를 할 수 없게 되었습니다 그래서 이를 자동으로 전환해주는 CSS 속성이 2019년에 출시되었고, dynamic하게 viewport를 설정할 수 있게 되었습니다.

<img width="771" alt="image" src="https://github.com/user-attachments/assets/c15a391d-5745-4941-a4a3-ac2bfca2a520" />

저희 웹은 지도를 사용하기 때문에 스크롤 경험이 사용성에 중요한 영향을 미치는데, 이를 고려해 더욱 좋은 사용성과 UI를 위해 전환했습니다.

h-screen으로 동작하는 화면은 모두 h-dvh로 전환했습니다.

## 동작 화면

### Landing 화면

![IMG_9576](https://github.com/user-attachments/assets/06dea12e-d740-4a8d-92c5-8167577ecca5)

### 학교 검색 화면

![IMG_9580](https://github.com/user-attachments/assets/b8f8094c-b53c-421b-af13-8d61d79af687)