### PR TITLE
[UNI-149] fix : 중복 포인트 삽입 문제 해결 (1, 2, 3, 4, 5, 5, 6, 7, 8) 문제

### DIFF
--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -202,13 +202,16 @@ export default function ReportRoutePage() {
 		const subNodes = [];
 		const edges = newPoints.coords.map((node, idx) => [node, newPoints.coords[idx + 1]]).slice(0, -1);
 
+		const lastPoint = newPoints.coords[newPoints.coords.length - 1] as Node | Coord;
+
 		for (const edge of edges) {
-			const subNode = createSubNodes(new Polyline({ path: edge }));
+			const subNode = createSubNodes(new Polyline({ path: edge })).slice(0, -1);
 			subNodes.push(...subNode);
 		}
 
+		subNodes.push(lastPoint);
+
 		if (!originPoint.current) return;
-		const lastPoint = newPoints.coords[newPoints.coords.length - 1] as Node | Coord;
 
 		if ("nodeId" in lastPoint) {
 			mutate({


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 지도 페이지 모달을 통한 제보 페이지 이동 라우터 수정

### 수정 내용
- 2개의 꺾인 길 생성 시, (1, 2, 3, 4, 5) , (5, 6, 7, 8)을 그대로 삽입하여 [1, 2, 3, 4, 5, 5, 6, 7, 8] 이 되어 API오류가 발생하는 문제 해결

```typescript
const reportNewRoute = () => {
		if (!newPolyLine.current || !Polyline) return;
		const subNodes = [];
		const edges = newPoints.coords.map((node, idx) => [node, newPoints.coords[idx + 1]]).slice(0, -1);

		for (const edge of edges) {
			const subNode = createSubNodes(new Polyline({ path: edge }));
			subNodes.push(...subNode);
		}

		if (!originPoint.current) return;
		const lastPoint = newPoints.coords[newPoints.coords.length - 1] as Node | Coord;
}
```
- subNode를 그대로 복사하여 삽입하는 것이 아닌

```typescript
const reportNewRoute = () => {
		if (!newPolyLine.current || !Polyline) return;
		const subNodes = [];
		const edges = newPoints.coords.map((node, idx) => [node, newPoints.coords[idx + 1]]).slice(0, -1);

		const lastPoint = newPoints.coords[newPoints.coords.length - 1] as Node | Coord;

		for (const edge of edges) {
			const subNode = createSubNodes(new Polyline({ path: edge })).slice(0, -1);
			subNodes.push(...subNode);
		}

		subNodes.push(lastPoint);
}
```

- subNode의 가장 마지막 요소를 제외하고 병합 후, 기존에 계산된 마지막 점을 삽입하여 최종 배열 생성