### PR TITLE
[UNI-168] feat : 백엔드 API 변경사항 적용 및 코드 리팩토링

### DIFF
--- a/uniro_frontend/src/api/transformer/route.ts
+++ b/uniro_frontend/src/api/transformer/route.ts
@@ -1,6 +1,5 @@
-import { DangerIssueType } from "../../constant/enum/reportEnum";
 import { CoreRoutesList } from "../../data/types/route";
-import { GetAllRouteRepsonse, GetSingleRouteRiskResponse } from "../type/response/route";
+import { GetAllRouteRepsonse } from "../type/response/route";
 
 export const transformAllRoutes = (data: GetAllRouteRepsonse): CoreRoutesList => {
 	const { nodeInfos, coreRoutes } = data;

--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -39,8 +39,6 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 
 		if (routeResult.routes.length === 0) return;
 
-		const cautionFactor: Coord[] = [];
-
 		const { routes, routeDetails } = routeResult;
 
 		// 하나의 길 완성
@@ -55,7 +53,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 			strokeWeight: 2.0,
 		});
 
-		// waypoint 마커 찍기
+		// [간선] 마커 찍기
 		routeDetails.forEach((routeDetail) => {
 			const { coordinates } = routeDetail;
 			bounds.extend(coordinates);
@@ -63,7 +61,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 				type: Markers.WAYPOINT,
 				className: "translate-waypoint",
 			});
-			// 만약 routeDetail에 cautionTypes가 있다면 caution 마커 찍기
+			// routeDetail에 cautionTypes가 있다면 [주의] 마커를 넣기
 			if (routeDetail.cautionTypes && routeDetail.cautionTypes.length > 0) {
 				const markerElement = createMarkerElement({
 					type: Markers.CAUTION,
@@ -75,7 +73,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 			createAdvancedMarker(AdvancedMarker, map, coordinates, markerElement);
 		});
 
-		// 시작 마커는 출발지 빌딩
+		// [시작] 마커는 출발지 (건물 기준)
 		const startMarkerElement = createMarkerElement({
 			type: Markers.ORIGIN,
 			title: origin?.buildingName,
@@ -87,7 +85,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 		createAdvancedMarker(AdvancedMarker, map, originCoord, startMarkerElement);
 		bounds.extend(originCoord);
 
-		// 끝 마커는 도착지 빌딩
+		// [끝] 마커는 도착지 빌딩 (건물 기준)
 		const endMarkerElement = createMarkerElement({
 			type: Markers.DESTINATION,
 			title: destination?.buildingName,
@@ -95,7 +93,12 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 			hasAnimation: true,
 		});
 
-		// Cache 혹은 API에서 불러온 위험요소 마커 찍기
+		const { lat: destinationLat, lng: destinationLng }: google.maps.LatLngLiteral = destination!;
+		const destinationCoord = { lat: destinationLat, lng: destinationLng };
+		createAdvancedMarker(AdvancedMarker, map, destinationCoord, endMarkerElement);
+		bounds.extend(destinationCoord);
+
+		// React Query Cache 혹은 API에서 불러온 [위험] 마커 찍기
 		risks.dangerRoutes.forEach((route) => {
 			const { node1, node2 } = route;
 			const type = Markers.DANGER;
@@ -108,19 +111,6 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 				}),
 				createMarkerElement({ type }),
 			);
-		});
-
-		const { lat: destinationLat, lng: destinationLng }: google.maps.LatLngLiteral = destination!;
-		const destinationCoord = { lat: destinationLat, lng: destinationLng };
-		createAdvancedMarker(AdvancedMarker, map, destinationCoord, endMarkerElement);
-		bounds.extend(destinationCoord);
-
-		cautionFactor.forEach((coord) => {
-			const markerElement = createMarkerElement({
-				type: Markers.CAUTION,
-				hasAnimation: true,
-			});
-			createAdvancedMarker(AdvancedMarker, map, coord, markerElement);
 		});
 
 		boundsRef.current = bounds;
@@ -149,7 +139,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 		if (isDetailView) {
 			const { routeDetails } = routeResult;
 			markersRef.current = [];
-			// 그림 마커 찍기
+			// [그림] 마커 찍기
 			routeDetails.forEach((routeDetail, index) => {
 				const { coordinates } = routeDetail;
 				const markerElement = createMarkerElement({

--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -56,17 +56,26 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 		});
 
 		// waypoint 마커 찍기
-		routeDetails.forEach((routeDetail, index) => {
+		routeDetails.forEach((routeDetail) => {
 			const { coordinates } = routeDetail;
 			bounds.extend(coordinates);
 			const markerElement = createMarkerElement({
 				type: Markers.WAYPOINT,
 				className: "translate-waypoint",
 			});
+			// 만약 routeDetail에 cautionTypes가 있다면 caution 마커 찍기
+			if (routeDetail.cautionTypes && routeDetail.cautionTypes.length > 0) {
+				const markerElement = createMarkerElement({
+					type: Markers.CAUTION,
+					className: "traslate-marker",
+					hasAnimation: true,
+				});
+				createAdvancedMarker(AdvancedMarker, map, coordinates, markerElement);
+			}
 			createAdvancedMarker(AdvancedMarker, map, coordinates, markerElement);
 		});
 
-		// 시작 마커는 출발지 빌딩 표시
+		// 시작 마커는 출발지 빌딩
 		const startMarkerElement = createMarkerElement({
 			type: Markers.ORIGIN,
 			title: origin?.buildingName,
@@ -78,7 +87,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 		createAdvancedMarker(AdvancedMarker, map, originCoord, startMarkerElement);
 		bounds.extend(originCoord);
 
-		// 끝 마커는 도착지 빌딩 표시
+		// 끝 마커는 도착지 빌딩
 		const endMarkerElement = createMarkerElement({
 			type: Markers.DESTINATION,
 			title: destination?.buildingName,
@@ -86,21 +95,20 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 			hasAnimation: true,
 		});
 
-		// 위험요소 마커 찍기
-		// risks.dangerRoutes.forEach((route) => {
-		// 	const { node1, node2, dangerTypes } = route;
-		// 	const type = Markers.DANGER;
-
-		// 	createAdvancedMarker(
-		// 		AdvancedMarker,
-		// 		map,
-		// 		new google.maps.LatLng({
-		// 			lat: (node1.lat + node2.lat) / 2,
-		// 			lng: (node1.lng + node2.lng) / 2,
-		// 		}),
-		// 		createMarkerElement({ type }),
-		// 	);
-		// });
+		// Cache 혹은 API에서 불러온 위험요소 마커 찍기
+		risks.dangerRoutes.forEach((route) => {
+			const { node1, node2 } = route;
+			const type = Markers.DANGER;
+			createAdvancedMarker(
+				AdvancedMarker,
+				map,
+				new google.maps.LatLng({
+					lat: (node1.lat + node2.lat) / 2,
+					lng: (node1.lng + node2.lng) / 2,
+				}),
+				createMarkerElement({ type }),
+			);
+		});
 
 		const { lat: destinationLat, lng: destinationLng }: google.maps.LatLngLiteral = destination!;
 		const destinationCoord = { lat: destinationLat, lng: destinationLng };
@@ -141,7 +149,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 		if (isDetailView) {
 			const { routeDetails } = routeResult;
 			markersRef.current = [];
-
+			// 그림 마커 찍기
 			routeDetails.forEach((routeDetail, index) => {
 				const { coordinates } = routeDetail;
 				const markerElement = createMarkerElement({
@@ -170,7 +178,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 			});
 			markersRef.current = [];
 		};
-	}, [isDetailView, AdvancedMarker, map]);
+	}, [isDetailView, AdvancedMarker, map, routeResult]);
 
 	return <div id="map" ref={mapRef} style={style} />;
 };

--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -4,7 +4,6 @@ import { CautionRoute, DangerRoute, NavigationRouteList } from "../data/types/ro
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
 import createMarkerElement from "../components/map/mapMarkers";
 import { Markers } from "../constant/enum/markerEnum";
-import { Coord } from "../data/types/coord";
 import useRoutePoint from "../hooks/useRoutePoint";
 import { AdvancedMarker } from "../data/types/marker";
 
@@ -62,7 +61,7 @@ const NavigationMap = ({ style, routeResult, risks, isDetailView, topPadding = 0
 				className: "translate-waypoint",
 			});
 			// routeDetail에 cautionTypes가 있다면 [주의] 마커를 넣기
-			if (routeDetail.cautionTypes && routeDetail.cautionTypes.length > 0) {
+			if (routeDetail.cautionFactors && routeDetail.cautionFactors.length > 0) {
 				const markerElement = createMarkerElement({
 					type: Markers.CAUTION,
 					className: "traslate-marker",

--- a/uniro_frontend/src/components/navigation/route/routeCard.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeCard.tsx
@@ -7,6 +7,7 @@ import CautionText from "../../../assets/icon/cautionText.svg?react";
 import { RouteDetail } from "../../../data/types/route";
 import useRoutePoint from "../../../hooks/useRoutePoint";
 import { formatDistance } from "../../../utils/navigation/formatDistance";
+import { CautionIssue } from "../../../constant/enum/reportEnum";
 
 const NumberIcon = ({ index }: { index: number }) => {
 	return (
@@ -17,7 +18,7 @@ const NumberIcon = ({ index }: { index: number }) => {
 };
 
 export const RouteCard = ({ index, route }: { index: number; route: RouteDetail }) => {
-	const { dist: distance, directionType, cautionTypes } = route;
+	const { dist: distance, directionType, cautionFactors } = route;
 	const formattedDistance = formatDistance(distance);
 	const { origin, destination } = useRoutePoint();
 	switch (directionType.toLocaleLowerCase()) {
@@ -133,9 +134,14 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 						<div className="text-system-orange text-kor-body3 text-[12px]">{formattedDistance}</div>
 					</div>
 					<div className="flex flex-row items-center justify-center ml-4 space-x-[14px]">
+						{/* TODO: Auto Resize Text 적용 */}
 						<NumberIcon index={index} />
-						<div className="text-kor-body1 text-gray-900">
-							{cautionTypes && cautionTypes.length > 0 ? cautionTypes.join() : "주의 요소가 없습니다."}
+						<div className="text-[clamp(0.8rem, 4ch, 2rem)] text-left text-kor-body1 text-gray-900">
+							{cautionFactors && cautionFactors.length > 0
+								? cautionFactors
+										.map((factor) => CautionIssue[factor as keyof typeof CautionIssue])
+										.join(", ")
+								: "주의 요소가 없습니다."}
 						</div>
 					</div>
 				</div>

--- a/uniro_frontend/src/components/navigation/route/routeCard.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeCard.tsx
@@ -4,7 +4,6 @@ import StraightIcon from "../../../assets/route/straight.svg?react";
 import RightIcon from "../../../assets/route/right.svg?react";
 import LeftIcon from "../../../assets/route/left.svg?react";
 import CautionText from "../../../assets/icon/cautionText.svg?react";
-import { Building } from "../../../data/types/node";
 import { RouteDetail } from "../../../data/types/route";
 import useRoutePoint from "../../../hooks/useRoutePoint";
 import { formatDistance } from "../../../utils/navigation/formatDistance";
@@ -17,18 +16,8 @@ const NumberIcon = ({ index }: { index: number }) => {
 	);
 };
 
-export const RouteCard = ({
-	index,
-	route,
-	originBuilding,
-	destinationBuilding,
-}: {
-	index: number;
-	route: RouteDetail;
-	originBuilding: Building;
-	destinationBuilding: Building;
-}) => {
-	const { dist: distance, directionType } = route;
+export const RouteCard = ({ index, route }: { index: number; route: RouteDetail }) => {
+	const { dist: distance, directionType, cautionTypes } = route;
 	const formattedDistance = formatDistance(distance);
 	const { origin, destination } = useRoutePoint();
 	switch (directionType.toLocaleLowerCase()) {
@@ -67,7 +56,7 @@ export const RouteCard = ({
 					</div>
 					<div className="flex flex-row items-center justify-center ml-4 space-x-[14px]">
 						<NumberIcon index={index} />
-						<div className="text-kor-body1 text-gray-900">우회전</div>
+						<div className="text-kor-body1 text-gray-900">급격한 우회전</div>
 					</div>
 				</div>
 			);
@@ -93,7 +82,7 @@ export const RouteCard = ({
 					</div>
 					<div className="flex flex-row items-center justify-center ml-4 space-x-[14px]">
 						<NumberIcon index={index} />
-						<div className="text-kor-body1 text-gray-900">좌회전</div>
+						<div className="text-kor-body1 text-gray-900">급격한 좌회전</div>
 					</div>
 				</div>
 			);
@@ -145,7 +134,9 @@ export const RouteCard = ({
 					</div>
 					<div className="flex flex-row items-center justify-center ml-4 space-x-[14px]">
 						<NumberIcon index={index} />
-						<div className="text-kor-body1 text-gray-900"></div>
+						<div className="text-kor-body1 text-gray-900">
+							{cautionTypes && cautionTypes.length > 0 ? cautionTypes.join() : "주의 요소가 없습니다."}
+						</div>
 					</div>
 				</div>
 			);

--- a/uniro_frontend/src/components/navigation/route/routeList.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeList.tsx
@@ -20,14 +20,14 @@ const RouteList = ({ routes }: RouteListProps) => {
 				dist: 0,
 				directionType: "origin" as Direction,
 				coordinates: { lat: origin!.lat, lng: origin!.lng },
-				cautionTypes: [],
+				cautionFactors: [],
 			},
 			...routes.slice(0, -1),
 			{
 				dist: 0,
 				directionType: "finish" as Direction,
 				coordinates: { lat: destination!.lat, lng: destination!.lng },
-				cautionTypes: [],
+				cautionFactors: [],
 			},
 		];
 	};

--- a/uniro_frontend/src/components/navigation/route/routeList.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeList.tsx
@@ -1,43 +1,44 @@
-import { Fragment, useEffect } from "react";
+import { Fragment } from "react";
 import { RouteCard } from "./routeCard";
 import useRoutePoint from "../../../hooks/useRoutePoint";
 import { RouteDetail } from "../../../data/types/route";
 import { Direction } from "../../../data/types/route";
+import { CautionIssue } from "../../../constant/enum/reportEnum";
 
 type RouteListProps = {
 	routes: RouteDetail[];
 };
-
-// export type RouteDetail = {
-// 	dist: number;
-// 	directionType: Direction;
-// 	coordinates: Coord;
-// };
 
 const Divider = () => <div className="border-[0.5px] border-gray-200 w-full"></div>;
 
 const RouteList = ({ routes }: RouteListProps) => {
 	const { origin, destination } = useRoutePoint();
 
+	const addOriginAndDestination = (routes: RouteDetail[]) => {
+		return [
+			{
+				dist: 0,
+				directionType: "origin" as Direction,
+				coordinates: { lat: origin!.lat, lng: origin!.lng },
+				cautionTypes: [],
+			},
+			...routes,
+			{
+				dist: 0,
+				directionType: "destination" as Direction,
+				coordinates: { lat: destination!.lat, lng: destination!.lng },
+				cautionTypes: [],
+			},
+		];
+	};
+
 	return (
 		<div className="w-full">
-			{[
-				{
-					dist: 0,
-					directionType: "origin" as Direction,
-					coordinates: { lat: origin!.lat, lng: origin!.lng },
-				},
-				...routes,
-			].map((route, index) => (
+			{addOriginAndDestination(routes).map((route, index) => (
 				<Fragment key={`${route.coordinates.lat}-fragment`}>
 					<Divider />
 					<div className="flex flex-col">
-						<RouteCard
-							index={index}
-							route={route}
-							originBuilding={origin!}
-							destinationBuilding={destination!}
-						/>
+						<RouteCard index={index} route={route} />
 					</div>
 				</Fragment>
 			))}

--- a/uniro_frontend/src/components/navigation/route/routeList.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeList.tsx
@@ -22,10 +22,10 @@ const RouteList = ({ routes }: RouteListProps) => {
 				coordinates: { lat: origin!.lat, lng: origin!.lng },
 				cautionTypes: [],
 			},
-			...routes,
+			...routes.slice(0, -1),
 			{
 				dist: 0,
-				directionType: "destination" as Direction,
+				directionType: "finish" as Direction,
 				coordinates: { lat: destination!.lat, lng: destination!.lng },
 				cautionTypes: [],
 			},
@@ -35,7 +35,7 @@ const RouteList = ({ routes }: RouteListProps) => {
 	return (
 		<div className="w-full">
 			{addOriginAndDestination(routes).map((route, index) => (
-				<Fragment key={`${route.coordinates.lat}-fragment`}>
+				<Fragment key={`${route.dist}-${route.coordinates.lat}-fragment`}>
 					<Divider />
 					<div className="flex flex-col">
 						<RouteCard index={index} route={route} />

--- a/uniro_frontend/src/data/types/route.d.ts
+++ b/uniro_frontend/src/data/types/route.d.ts
@@ -43,7 +43,7 @@ export type RouteDetail = {
 	dist: number;
 	directionType: Direction;
 	coordinates: Coord;
-	cautionTypes: CautionIssueType[];
+	cautionFactors: CautionIssueType[];
 };
 
 export type NavigationRouteList = {

--- a/uniro_frontend/src/data/types/route.d.ts
+++ b/uniro_frontend/src/data/types/route.d.ts
@@ -23,10 +23,6 @@ export interface DangerRoute extends Route {
 	dangerTypes: DangerIssueType[];
 }
 
-export interface NavigationRoute extends Route {
-	cautionTypes: CautionIssueType[];
-}
-
 export interface CoreRoute {
 	routeId: RouteId;
 	node1: Node;
@@ -47,12 +43,13 @@ export type RouteDetail = {
 	dist: number;
 	directionType: Direction;
 	coordinates: Coord;
+	cautionTypes: CautionIssueType[];
 };
 
 export type NavigationRouteList = {
 	hasCaution: boolean;
 	totalDistance: number;
 	totalCost: number;
-	routes: NavigationRoute[];
+	routes: Route[];
 	routeDetails: RouteDetail[];
 };

--- a/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
+++ b/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 const MAX_SHEET_HEIGHT = window.innerHeight * 0.7;
 const MIN_SHEET_HEIGHT = window.innerHeight * 0.35;
 const CLOSED_SHEET_HEIGHT = 0;
-const ERROR_MARGIN_OF_SCROLL = 0.95;
+const ERROR_MARGIN_OF_DRAG = 0.95;
 
 export const useNavigationBottomSheet = () => {
 	const [sheetHeight, setSheetHeight] = useState(CLOSED_SHEET_HEIGHT);
@@ -21,7 +21,7 @@ export const useNavigationBottomSheet = () => {
 
 	const preventScroll = useCallback(
 		(event: React.UIEvent<HTMLDivElement>) => {
-			if (sheetHeight < MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_SCROLL) {
+			if (sheetHeight < MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_DRAG) {
 				event.preventDefault();
 				if (scrollRef.current) {
 					scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });
@@ -32,7 +32,7 @@ export const useNavigationBottomSheet = () => {
 	);
 	useEffect(() => {
 		if (scrollRef.current) {
-			if (sheetHeight > MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_SCROLL) {
+			if (sheetHeight > MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_DRAG) {
 				scrollRef.current.style.overflowY = "auto";
 			} else {
 				scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });

--- a/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
+++ b/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
@@ -1,0 +1,49 @@
+import { PanInfo, useDragControls } from "framer-motion";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const MAX_SHEET_HEIGHT = window.innerHeight * 0.7;
+const MIN_SHEET_HEIGHT = window.innerHeight * 0.35;
+const CLOSED_SHEET_HEIGHT = 0;
+const ERROR_MARGIN_OF_SCROLL = 0.95;
+
+export const useNavigationBottomSheet = () => {
+	const [sheetHeight, setSheetHeight] = useState(CLOSED_SHEET_HEIGHT);
+	const dragControls = useDragControls();
+
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	const handleDrag = useCallback((event: Event, info: PanInfo) => {
+		setSheetHeight((prev) => {
+			const newHeight = prev - info.delta.y;
+			return Math.min(Math.max(newHeight, MIN_SHEET_HEIGHT), MAX_SHEET_HEIGHT);
+		});
+	}, []);
+
+	const preventScroll = useCallback(
+		(event: React.UIEvent<HTMLDivElement>) => {
+			if (sheetHeight < MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_SCROLL) {
+				event.preventDefault();
+				if (scrollRef.current) {
+					scrollRef.current.scrollTo({ top: 0, behavior: "smooth" }); // ✅ 부드러운 스크롤 적용
+				}
+			}
+		},
+		[sheetHeight],
+	);
+	useEffect(() => {
+		if (scrollRef.current) {
+			if (sheetHeight > MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_SCROLL) {
+				scrollRef.current.style.overflowY = "auto";
+			} else {
+				scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });
+				setTimeout(() => {
+					if (scrollRef.current) {
+						scrollRef.current.style.overflowY = "hidden";
+					}
+				}, 300);
+			}
+		}
+	}, [sheetHeight]);
+
+	return { sheetHeight, setSheetHeight, dragControls, handleDrag, preventScroll, scrollRef };
+};

--- a/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
+++ b/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
@@ -24,7 +24,7 @@ export const useNavigationBottomSheet = () => {
 			if (sheetHeight < MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_SCROLL) {
 				event.preventDefault();
 				if (scrollRef.current) {
-					scrollRef.current.scrollTo({ top: 0, behavior: "smooth" }); // ✅ 부드러운 스크롤 적용
+					scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });
 				}
 			}
 		},

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -146,35 +146,34 @@ const NavigationResultPage = () => {
 				<BackButton onClick={hideDetailView} />
 			</AnimatedContainer>
 
-			<AnimatedSheetContainer
+			<AnimatedContainer
 				isVisible={isDetailView}
-				height={sheetHeight}
-				className="bg-white rounded-t-2xl shadow-xl"
-				transition={{ type: "tween", duration: 0.3 }}
+				className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto"
+				positionDelta={MAX_SHEET_HEIGHT}
+				transition={{ type: "spring", damping: 20, duration: 0.3 }}
 				motionProps={{
 					drag: "y",
 					dragControls,
 					dragListener: false,
 					dragConstraints: {
 						top: 0,
-						bottom: 0,
+						bottom: MIN_SHEET_HEIGHT,
 					},
 					onDrag: handleDrag,
 					onDragEnd: handleDrag,
 				}}
 			>
 				<BottomSheetHandle dragControls={dragControls} />
-
 				<div
 					className="w-full overflow-y-auto"
 					style={{
-						height: sheetHeight - BOTTOM_SHEET_HANDLE_HEIGHT,
+						height: MAX_SHEET_HEIGHT - BOTTOM_SHEET_HANDLE_HEIGHT,
 					}}
 				>
 					<NavigationDescription isDetailView={true} navigationRoute={result[0].data!} />
 					<RouteList routes={result[0].data!.routeDetails} />
 				</div>
-			</AnimatedSheetContainer>
+			</AnimatedContainer>
 		</div>
 	);
 };

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { PanInfo, useDragControls } from "framer-motion";
 import { useSuspenseQueries } from "@tanstack/react-query";
 
@@ -9,8 +9,6 @@ import BottomSheetHandle from "../components/navigation/bottomSheet/bottomSheetH
 import NavigationMap from "../component/NavgationMap";
 import BackButton from "../components/map/backButton";
 import AnimatedContainer from "../container/animatedContainer";
-import { mockNavigationRoute } from "../data/mock/hanyangRoute";
-import { NavigationRoute } from "../data/types/route";
 
 import useScrollControl from "../hooks/useScrollControl";
 import useUniversityInfo from "../hooks/useUniversityInfo";
@@ -35,7 +33,6 @@ const NavigationResultPage = () => {
 	const [isDetailView, setIsDetailView] = useState(false);
 	const [sheetHeight, setSheetHeight] = useState(CLOSED_SHEET_HEIGHT);
 	const [topBarHeight, setTopBarHeight] = useState(INITIAL_TOP_BAR_HEIGHT);
-	const [route, setRoute] = useState<NavigationRoute>(mockNavigationRoute);
 	const location = useLocation();
 
 	const { university } = useUniversityInfo();
@@ -74,7 +71,11 @@ const NavigationResultPage = () => {
 						);
 						return response;
 					} catch (e) {
-						return null;
+						alert("경로를 찾을 수 없습니다.");
+						return {
+							routes: [],
+							routeDetails: [],
+						};
 					}
 				},
 				retry: 1,

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -71,11 +71,7 @@ const NavigationResultPage = () => {
 						);
 						return response;
 					} catch (e) {
-						alert("경로를 찾을 수 없습니다.");
-						return {
-							routes: [],
-							routeDetails: [],
-						};
+						return alert("경로를 찾을 수 없습니다.");
 					}
 				},
 				retry: 1,

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -31,13 +31,14 @@ const PADDING_FOR_MAP_BOUNDARY = 50;
 const NavigationResultPage = () => {
 	const [isDetailView, setIsDetailView] = useState(false);
 	const [topBarHeight, setTopBarHeight] = useState(INITIAL_TOP_BAR_HEIGHT);
-	const location = useLocation();
+
 	const { sheetHeight, setSheetHeight, dragControls, handleDrag, preventScroll, scrollRef } =
 		useNavigationBottomSheet();
 	const { university } = useUniversityInfo();
 	const { origin, destination, setOriginCoord, setDestinationCoord } = useRoutePoint();
 
 	// TEST용 Link
+	const location = useLocation();
 	const { search } = location;
 	const params = new URLSearchParams(search);
 

--- a/uniro_frontend/src/utils/navigation/formatDistance.ts
+++ b/uniro_frontend/src/utils/navigation/formatDistance.ts
@@ -3,6 +3,10 @@ export const formatDistance = (distance: number) => {
 		return `${Math.ceil(distance * 1000) / 1000}m`;
 	}
 
+	if (distance < 1000) {
+		return `${Math.ceil(distance)}m`;
+	}
+
 	return distance >= 1000
 		? `${(distance / 1000).toFixed(1)} km` // 1000m 이상이면 km 단위로 변환
 		: `${distance} m`; // 1000m 미만이면 m 단위 유지


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 금요일에 백엔드에 요청드린 API 변경사항에 맞춰, 프런트의 코드를 변경했습니다.
2. 백엔드가 예외나 에러를 리턴할 때, 내용을 볼 수 있도록 alert를 임시로 추가했습니다.
3. m단위일때의 포맷 변환 처리를 해놓지 않아, 그 부분을 처리했습니다.
4. 길 찾기의 바텀시트 디자인 요구사항에 맞게 하단으로 드래그 했을 때 스크롤이 불가능하도록 했습니다.
5. 바텀 시트 관련 기능들이 너무 많아, 따로 hook으로 분리했습니다.
6. cautionFactors로 내비게이션 관련 type을 변경했습니다.
7. 우회전, 좌회전 텍스트에서 급격한 우회전, 급격한 좌회전 텍스트를 추가했습니다.

## 핵심 기능

### m단위 변환하는 로직 추가
```typescript
export const formatDistance = (distance: number) => {
	if (distance < 1) {
		return `${Math.ceil(distance * 1000) / 1000}m`;
	}

	if (distance < 1000) {
		return `${Math.ceil(distance)}m`;
	}

	return distance >= 1000
		? `${(distance / 1000).toFixed(1)} km` // 1000m 이상이면 km 단위로 변환
		: `${distance} m`; // 1000m 미만이면 m 단위 유지
};

```

### 바텀 시트 스크롤 통제
```typescript
const preventScroll = useCallback(
		(event: React.UIEvent<HTMLDivElement>) => {
			if (sheetHeight < MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_DRAG) {
				event.preventDefault();
				if (scrollRef.current) {
					scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });
				}
			}
		},
		[sheetHeight],
	);
	useEffect(() => {
		if (scrollRef.current) {
			if (sheetHeight > MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_DRAG) {
				scrollRef.current.style.overflowY = "auto";
			} else {
				scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });
				setTimeout(() => {
					if (scrollRef.current) {
						scrollRef.current.style.overflowY = "hidden";
					}
				}, 300);
			}
		}
	}, [sheetHeight]);
```
바텀시트를 내렸을 때 드래그를 통제해야 한다고 Figma에 나와있어, 이 방식을 구현했습니다. 내렸을 때 안의 내용이 어떤 동작을 해야한다고 나와있진 않았지만, 내리려고 할 때 자연스럽게 맨 위로 올라가면 좋을 것 같아서 이 부분을 구현했습니다.
드래그가 되었을 때, 완전히 올라가는걸 인식하지 못하는 경우나, 완전히 올라가지지 않는 경우가 가끔 있어 edge 케이스에 대한 에러를 통제하기 위해서 ERROR_MARGIN_OF_DRAG 변수를 추가했습니다.

## 동작 확인

https://github.com/user-attachments/assets/da9e401c-a493-4cbf-8707-eda585c14a43
