### PR TITLE
[UNI-175] feat : Router로 페이지별 작업 환경 설정하기

### DIFF
--- a/uniro_admin_frontend/src/App.tsx
+++ b/uniro_admin_frontend/src/App.tsx
@@ -1,17 +1,14 @@
+import { Outlet } from "react-router";
 import "./App.css";
 import NavBar from "./components/navBar";
-import LogListContainer from "./container/logListContainer";
-import MainContainer from "./container/mainContainer";
-import MapContainer from "./container/mapContainer";
+import SubNavBar from "./components/subNavBar";
 
 function App() {
   return (
     <div className="w-full h-screen flex flex-col items-center justify-center space-y-1">
       <NavBar />
-      <MainContainer>
-        <LogListContainer />
-        <MapContainer />
-      </MainContainer>
+      <SubNavBar />
+      <Outlet />
     </div>
   );
 }

--- a/uniro_admin_frontend/src/AppRouter.tsx
+++ b/uniro_admin_frontend/src/AppRouter.tsx
@@ -1,0 +1,22 @@
+import { BrowserRouter, Route, Routes } from "react-router";
+import App from "./App";
+import LogPage from "./page/logPage";
+import BuildingPage from "./page/buildingPage";
+import SimulationPage from "./page/simulationPage";
+
+function AppRouter() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />}>
+          <Route index element={<LogPage />} />
+          <Route path="logs" element={<LogPage />} />
+          <Route path="buildings" element={<BuildingPage />} />
+          <Route path="simulation" element={<SimulationPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+export default AppRouter;

--- a/uniro_admin_frontend/src/components/navBar.tsx
+++ b/uniro_admin_frontend/src/components/navBar.tsx
@@ -3,9 +3,7 @@ import UNIROLOGO from "../assets/navbar/UNIRO_ADMIN.svg?react";
 import DropDownArrow from "../assets/navbar/dropDownArrow.svg?react";
 import useSearchBuilding from "../hooks/useUniversityRecord";
 
-interface Props {}
-
-const NavBar: React.FC<Props> = () => {
+const NavBar: React.FC = () => {
   const { currentUniversity, getUniversityNameList, setCurrentUniversity } =
     useSearchBuilding();
   const [selectedUniversity, setSelectedUniversity] =

--- a/uniro_admin_frontend/src/components/subNavBar.tsx
+++ b/uniro_admin_frontend/src/components/subNavBar.tsx
@@ -1,0 +1,32 @@
+import { Link, useLocation } from "react-router";
+
+const SubNavBar = () => {
+  const location = useLocation(); // 📌 현재 경로 감지
+
+  const getLinkStyle = (path: string) =>
+    location.pathname === path
+      ? "text-blue-700"
+      : "text-gray-700 hover:text-black";
+
+  return (
+    <nav className="flex-1 w-full h-fit flex flex-row items-center justify-start border-b-2 border-gray-300 px-4">
+      <Link to="/logs" className={`px-4 py-2 rounded ${getLinkStyle("/logs")}`}>
+        로그 보기
+      </Link>
+      <Link
+        to="/buildings"
+        className={`px-4 py-2 rounded ${getLinkStyle("/buildings")}`}
+      >
+        건물 관리
+      </Link>
+      <Link
+        to="/simulation"
+        className={`px-4 py-2 rounded ${getLinkStyle("/simulation")}`}
+      >
+        지도 시뮬레이션
+      </Link>
+    </nav>
+  );
+};
+
+export default SubNavBar;

--- a/uniro_admin_frontend/src/main.tsx
+++ b/uniro_admin_frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import AppRouter from "./AppRouter.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <AppRouter />
+  </StrictMode>
+);

--- a/uniro_admin_frontend/src/page/buildingPage.tsx
+++ b/uniro_admin_frontend/src/page/buildingPage.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import MainContainer from "../container/mainContainer";
+
+type Props = {};
+
+const BuildingPage = (props: Props) => {
+  return (
+    <MainContainer>
+      <div>BuildingPage</div>;
+    </MainContainer>
+  );
+};
+
+export default BuildingPage;

--- a/uniro_admin_frontend/src/page/logPage.tsx
+++ b/uniro_admin_frontend/src/page/logPage.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import MainContainer from "../container/mainContainer";
+import LogListContainer from "../container/logListContainer";
+import MapContainer from "../container/mapContainer";
+
+const LogPage = () => {
+  return (
+    <MainContainer>
+      <LogListContainer />
+      <MapContainer />
+    </MainContainer>
+  );
+};
+
+export default LogPage;

--- a/uniro_admin_frontend/src/page/simulationPage.tsx
+++ b/uniro_admin_frontend/src/page/simulationPage.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import MainContainer from "../container/mainContainer";
+
+const SimulationPage = () => {
+  return (
+    <MainContainer>
+      <div>SimulationPage</div>
+    </MainContainer>
+  );
+};
+
+export default SimulationPage;


### PR DESCRIPTION
## #️⃣ 작업 내용
1. Router로 페이지별 작업 환경을 설정했습니다.

## 핵심 기능

### 공통 Layout 활용하기
```typescript

function App() {
  return (
    <div className="w-full h-screen flex flex-col items-center justify-center space-y-1">
      <NavBar />
      <SubNavBar />
      <Outlet />
    </div>
  );
}
```

Outlet을 활용해 NavBar, SubNavBar을 공통으로 사용할 수 있도록 했습니다.

### 동작 확인

https://github.com/user-attachments/assets/6ffa1999-3022-41b1-8d4b-e726e91465c9
