### PR TITLE
[UNI-145] feat : 에러 바운더리 생성 및 POST 에러 핸들링 로직

### DIFF
--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -16,6 +16,7 @@ import useNetworkStatus from "./hooks/useNetworkStatus";
 import ErrorPage from "./pages/error";
 import { Suspense } from "react";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import ErrorBoundary from "./components/error/ErrorBoundary";
 
 const queryClient = new QueryClient();
 
@@ -24,22 +25,24 @@ function App() {
 	useNetworkStatus();
 	return (
 		<QueryClientProvider client={queryClient}>
-			<Suspense key={location.key} fallback={fallback}>
-				<Routes>
-					<Route path="/demo" element={<Demo />} />
-					<Route path="/" element={<LandingPage />} />
-					<Route path="/university" element={<UniversitySearchPage />} />
-					<Route path="/building" element={<BuildingSearchPage />} />
-					<Route path="/map" element={<MapPage />} />
-					<Route path="/form" element={<ReportForm />} />
-					<Route path="/result" element={<NavigationResultPage />} />
-					<Route path="/report/route" element={<ReportRoutePage />} />
-					<Route path="/report/risk" element={<ReportRiskPage />} />
-					/** 에러 페이지 */
-					<Route path="/error" element={<ErrorPage />} />
-					<Route path="/error/offline" element={<OfflinePage />} />
-				</Routes>
-			</Suspense>
+			<ErrorBoundary fallback={<ErrorPage />}>
+				<Suspense key={location.key} fallback={fallback}>
+					<Routes>
+						<Route path="/demo" element={<Demo />} />
+						<Route path="/" element={<LandingPage />} />
+						<Route path="/university" element={<UniversitySearchPage />} />
+						<Route path="/building" element={<BuildingSearchPage />} />
+						<Route path="/map" element={<MapPage />} />
+						<Route path="/form" element={<ReportForm />} />
+						<Route path="/result" element={<NavigationResultPage />} />
+						<Route path="/report/route" element={<ReportRoutePage />} />
+						<Route path="/report/risk" element={<ReportRiskPage />} />
+						/** 에러 페이지 */
+						<Route path="/error" element={<ErrorPage />} />
+						<Route path="/error/offline" element={<OfflinePage />} />
+					</Routes>
+				</Suspense>
+			</ErrorBoundary>
 			<ReactQueryDevtools initialIsOpen={false} />
 		</QueryClientProvider>
 	);

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -17,6 +17,7 @@ import ErrorPage from "./pages/error";
 import { Suspense } from "react";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ErrorBoundary from "./components/error/ErrorBoundary";
+import Errortest from "./pages/errorTest";
 
 const queryClient = new QueryClient();
 
@@ -40,6 +41,7 @@ function App() {
 						/** 에러 페이지 */
 						<Route path="/error" element={<ErrorPage />} />
 						<Route path="/error/offline" element={<OfflinePage />} />
+						<Route path="/error/test" element={<Errortest />} />
 					</Routes>
 				</Suspense>
 			</ErrorBoundary>

--- a/uniro_frontend/src/components/error/ErrorBoundary.tsx
+++ b/uniro_frontend/src/components/error/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import React, { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+    fallback: ReactNode;
+}
+
+interface ErrorBoundaryState {
+    hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<
+    React.PropsWithChildren<ErrorBoundaryProps>,
+    ErrorBoundaryState
+> {
+    constructor(props: React.PropsWithChildren<ErrorBoundaryProps>) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+        return { hasError: true };
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return this.props.fallback;
+        }
+
+        return this.props.children;
+    }
+}

--- a/uniro_frontend/src/constant/error.ts
+++ b/uniro_frontend/src/constant/error.ts
@@ -1,0 +1,19 @@
+export class NotFoundError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "Not Found";
+	}
+}
+
+export class BadRequestError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "Bad Request";
+	}
+}
+
+export enum ERROR_STATUS {
+	NOT_FOUND = 404,
+	BAD_REQUEST = 400,
+	INTERNAL_ERROR = 500,
+}

--- a/uniro_frontend/src/hooks/useMutationError.tsx
+++ b/uniro_frontend/src/hooks/useMutationError.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, useMutation, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
+import { NotFoundError, BadRequestError, ERROR_STATUS } from "../constant/error";
+import React, { useCallback, useEffect, useState } from "react";
+
+type Fallback = {
+	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
+		mainTitle: string;
+		subTitle: string;
+	};
+};
+
+export default function useMutationError<TData, TError, TVariables, TContext>(
+	options: UseMutationOptions<TData, TError, TVariables, TContext>,
+	queryClient?: QueryClient,
+	fallback?: Fallback,
+): [React.FC, UseMutationResult<TData, TError, TVariables, TContext>] {
+	const [isOpen, setOpen] = useState<boolean>(false);
+	const [title, setTitle] = useState({
+		mainTitle: "",
+		subTitle: "",
+	});
+	const result = useMutation<TData, TError, TVariables, TContext>(options, queryClient);
+
+	const { isError, error } = result;
+
+	useEffect(() => {
+		if (isError) {
+			setOpen(isError);
+			if (error instanceof NotFoundError && fallback) {
+				setTitle({ ...fallback[404] });
+			} else if (error instanceof BadRequestError && fallback) {
+				setTitle({ ...fallback[400] });
+			} else {
+				throw error;
+			}
+		}
+	}, [error, isError]);
+
+	const close = useCallback(() => {
+		setOpen(false);
+	}, []);
+
+	const BaseFallback = (
+		<div className="fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.2)]">
+			<div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden">
+				<div className="flex flex-col justify-center space-y-1 py-[25px]">
+					<p className="text-kor-body1 font-bold text-system-red">{title.mainTitle}</p>
+					<div className="space-y-0">
+						<p className="text-kor-body3 font-regular text-gray-700">{title.subTitle}</p>
+					</div>
+				</div>
+				<button
+					onClick={close}
+					className="h-[58px] border-t-[1px] border-gray-200 text-kor-body2 font-semibold active:bg-gray-200"
+				>
+					확인
+				</button>
+			</div>
+		</div>
+	);
+
+	const Modal: React.FC = () => <>{isOpen && BaseFallback}</>;
+
+	return [Modal, result];
+}

--- a/uniro_frontend/src/pages/errorTest.tsx
+++ b/uniro_frontend/src/pages/errorTest.tsx
@@ -1,0 +1,73 @@
+import useMutationError from "../hooks/useMutationError";
+import { RouteId } from "../data/types/route";
+import { CautionIssueType, DangerIssueType } from "../data/types/enum";
+import { postFetch } from "../utils/fetch/fetch";
+import { postReportRoute } from "../api/route";
+
+const postReport = (
+	univId: number,
+	routeId: RouteId,
+	body: { dangerTypes: DangerIssueType[]; cautionTypes: CautionIssueType[] },
+): Promise<boolean> => {
+	return postFetch<void, string>(`/${univId}/route/risk/${routeId}`, body);
+};
+
+export default function Errortest() {
+	const [Modal400, result400] = useMutationError(
+		{
+			//@ts-expect-error 강제 에러 발생
+			mutationFn: () => postReport(1001, 1, { cautionTypes: ["TEST"], dangerTypes: [] }),
+		},
+		undefined,
+		{
+			400: { mainTitle: "400 제목", subTitle: "400 부제목" },
+			404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+		},
+	);
+
+	const [Modal404, result404] = useMutationError(
+		{
+			mutationFn: () => postReport(1, 1, { cautionTypes: [], dangerTypes: [] }),
+		},
+		undefined,
+		{
+			400: { mainTitle: "400 제목", subTitle: "400 부제목" },
+			404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+		},
+	);
+
+	const [Modal500, result500] = useMutationError(
+		{
+			//@ts-expect-error 강제 에러 발생
+			mutationFn: () => postReportRoute(1001, {}),
+		},
+		undefined,
+		{
+			400: { mainTitle: "400 제목", subTitle: "400 부제목" },
+			404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+		},
+	);
+
+	const { mutate: mutate400 } = result400;
+	const { mutate: mutate404 } = result404;
+	const { mutate: mutate500 } = result500;
+
+	return (
+		<div>
+			<div className="rounded-sm border border-dashed border-[#9747FF] flex flex-col justify-start space-y-5 p-5">
+				<button className="border border-system-red" onClick={mutate400}>
+					400 발생
+				</button>
+				<button className="border border-system-red" onClick={mutate404}>
+					404 발생
+				</button>
+				<button className="border border-system-red" onClick={mutate500}>
+					500 발생
+				</button>
+			</div>
+			<Modal400 />
+			<Modal404 />
+			<Modal500 />
+		</div>
+	);
+}

--- a/uniro_frontend/src/utils/fetch/fetch.ts
+++ b/uniro_frontend/src/utils/fetch/fetch.ts
@@ -1,3 +1,5 @@
+import { BadRequestError, NotFoundError } from "../../constant/error";
+
 export default function Fetch() {
 	const baseURL = import.meta.env.VITE_REACT_SERVER_BASE_URL;
 
@@ -11,7 +13,13 @@ export default function Fetch() {
 		});
 
 		if (!response.ok) {
-			throw new Error(`${response.status}-${response.statusText}`);
+			if (response.status === 400) {
+				throw new BadRequestError("Bad Request");
+			} else if (response.status === 404) {
+				throw new NotFoundError("Not Found");
+			} else {
+				throw new Error("UnExpected Error");
+			}
 		}
 
 		return response.json();
@@ -27,7 +35,13 @@ export default function Fetch() {
 		});
 
 		if (!response.ok) {
-			throw new Error(`${response.status}-${response.statusText}`);
+			if (response.status === 400) {
+				throw new BadRequestError("Bad Request");
+			} else if (response.status === 404) {
+				throw new NotFoundError("Not Found");
+			} else {
+				throw new Error("UnExpected Error");
+			}
 		}
 
 		return response.ok;


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 에러 바운더리 생성
2. POST 요청 시, 에러 핸들링 로직

## 핵심 기능

### 커스텀 에러 바운더리 생성
- Error 발생 시, 보여줘야 할 fallback을 생성하기 위한 Global ErrorBoundary를 구현해야 했습니다.
- 기존 react에서도 [권장](https://react.dev/reference/react/useTransition#displaying-an-error-to-users-with-error-boundary)하는 [react-error-boundary](https://www.npmjs.com/package/react-error-boundary) 라이브러리가 존재하나 조금 더 자유로운 커스텀을 위해 직접 구현하였습니다.
- [getDerivedStateFromError](https://react.dev/reference/react/Component#static-getderivedstatefromerror)를 사용하였습니다.

```typescript
import React, { Component, ReactNode } from 'react';

interface ErrorBoundaryProps {
    fallback: ReactNode;
}

interface ErrorBoundaryState {
    hasError: boolean;
}

export default class ErrorBoundary extends Component<
    React.PropsWithChildren<ErrorBoundaryProps>,
    ErrorBoundaryState
> {
    constructor(props: React.PropsWithChildren<ErrorBoundaryProps>) {
        super(props);
        this.state = { hasError: false };
    }

    static getDerivedStateFromError(error: Error): ErrorBoundaryState {
        return { hasError: true };
    }

    render() {
        if (this.state.hasError) {
            return this.props.fallback;
        }

        return this.props.children;
    }
}
```
- Suspense와 동일하게 fallback을 받아서 에러 발생 시, fallback을 보여줄 수 있도록 하였습니다.
- Global ErrorBoundary 적용 결과입니다.
```typescript
      <ErrorBoundary fallback={<ErrorPage />}>
            <Suspense key={location.key} fallback={fallback}>
	            
            </Suspense>
      </ErrorBoundary>
```

### POST 요청 시, 에러 핸들링 로직
- GET 요청의 경우, useSuspenseQuery를 사용하여 화면을 렌더링하기 위한 데이터를 Get 하지만, POST의 경우, POST의 result로 true, false boolean을 받아오기에, POST 요청에 대한 에러 처리ㅁㅁ 화면을 보여줄 필요가 있습니다.
- 그리하여, POST를 위한 useMutation을 변형하여 새로운 Mutation훅을 생성하였습니다.

```typescript
import { QueryClient, useMutation, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
import { NotFoundError, BadRequestError, ERROR_STATUS } from "../constant/error";
import React, { useCallback, useEffect, useState } from "react";

type Fallback = {
	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
		mainTitle: string;
		subTitle: string;
	};
};

export default function useMutationError<TData, TError, TVariables, TContext>(
	options: UseMutationOptions<TData, TError, TVariables, TContext>,
	queryClient?: QueryClient,
	fallback?: Fallback,
): [React.FC, UseMutationResult<TData, TError, TVariables, TContext>] {
	const [isOpen, setOpen] = useState<boolean>(false);
	const [title, setTitle] = useState({
		mainTitle: "",
		subTitle: "",
	});
	const result = useMutation<TData, TError, TVariables, TContext>(options, queryClient);

	const { isError, error } = result;

	useEffect(() => {
		if (isError) {
			setOpen(isError);
			if (error instanceof NotFoundError && fallback) {
				setTitle({ ...fallback[404] });
			} else if (error instanceof BadRequestError && fallback) {
				setTitle({ ...fallback[400] });
			} else {
				throw error;
			}
		}
	}, [error, isError]);

	const close = useCallback(() => {
		setOpen(false);
	}, []);

	const BaseFallback = (
		<div>
			<div>
				<div>
					<p>{title.mainTitle}</p>
					<div>
						<p>{title.subTitle}</p>
					</div>
				</div>
				<button onClick={close}>
					확인
				</button>
			</div>
		</div>
	);

	const Modal: React.FC = () => <>{isOpen && BaseFallback}</>;

	return [Modal, result];
}

```

- useMutation이 기본적으로 입력받던, queryOptions, queryClient를 받고 추가적으로 fallback을 만들기 위한, 대제목과 소제목을 입력받습니다.
- POST의 에러는 모달 형태로 보여줄 것이기에, mutation결과와 함께, Modal을 return 합니다.
- 현재는 400, 404에 대한 처리만 진행이 되었지만 추후 확장될 수 있습니다.

- useMutationError를  사용하려면 
```typescript
        const [Modal400, result400] = useMutationError(
		{
			//@ts-expect-error 강제 에러 발생
			mutationFn: () => postReport(1001, 1, { cautionTypes: ["TEST"], dangerTypes: [] }),
		},
		undefined,
		{
			400: { mainTitle: "400 제목", subTitle: "400 부제목" },
			404: { mainTitle: "404 제목", subTitle: "404 부제목" },
		},
	);
```
- 다음과 같이, fallback에 400, 404를 key로 하는 오브젝트를 전달합니다.

- 400과 404의 에러는 에러 바운더리에서 잡히는 것이 아닌, useMutationError에서 잡혀야 하기 때문에 fetch에서 response를 통해 다른 타입의 에러를 throw합니다.
```typescript
        const post = async <T, K>(url: string, body?: Record<string, K | K[]>): Promise<boolean> => {
		const response = await fetch(`${baseURL}${url}`, {
			method: "POST",
			body: JSON.stringify(body),
			headers: {
				"Content-Type": "application/json",
			},
		});

		if (!response.ok) {
			if (response.status === 400) {
				throw new BadRequestError("Bad Request");
			} else if (response.status === 404) {
				throw new NotFoundError("Not Found");
			} else {
				throw new Error("UnExpected Error");
			}
		}

		return response.ok;
	};
```
- response가 ok가 아닐 경우, status를 비교합니다. status가 400인 경우, BadRequestError를, 404인 경우, NotFoundError를 throw 합니다. 그 외의 경우에는 일반적은 Error를 throw합니다.

- useMutationError에서는 useEffect 내부에서 mutation결과 error를 instanceof로 비교합니다. 
```typescript
	useEffect(() => {
		if (isError) {
			setOpen(isError);
			if (error instanceof NotFoundError && fallback) {
				setTitle({ ...fallback[404] });
			} else if (error instanceof BadRequestError && fallback) {
				setTitle({ ...fallback[400] });
			} else {
				throw error;
			}
		}
	}, [error, isError]);
``` 

- 에러가 BadRequestError 혹은 NotFoundError인 경우, error 핸들을 내부에서 하기 위해 state를 변경하지만 그 외의 에러는 throw하여 ErrorBoundary에서 감지될 수 있도록 하였습니다.


## 동작 확인

https://github.com/user-attachments/assets/36f291b4-e900-4788-9683-17b0fffaa720