### PR TITLE
[UNI-178], [UNI-179] fix : 클라이언트 요청값 검증 로직 구현

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public enum ErrorCode {
 
     // common
-    INVALID_INPUT_VALUE(400, "적절하지 않은 요청입니다."),
+    INVALID_INPUT_VALUE(400, "적절하지 않은 요청값입니다."),
 
     // 길찾기
     FASTEST_ROUTE_NOT_FOUND(422, "경로가 없습니다."),

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -8,6 +8,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
+    // common
+    INVALID_INPUT_VALUE(400, "적절하지 않은 요청입니다."),
+
     // 길찾기
     FASTEST_ROUTE_NOT_FOUND(422, "경로가 없습니다."),
     SAME_START_AND_END_POINT(400, "출발지와 도착지가 같습니다."),

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,13 @@
 package com.softeer5.uniro_backend.common.exception;
 
+import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
+
 import com.softeer5.uniro_backend.common.error.ErrorResponse;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -17,4 +20,12 @@ public class GlobalExceptionHandler {
         ErrorResponse response = new ErrorResponse(ex.getErrorCode());
         return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getErrorCode().getHttpStatus()));
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(MethodArgumentNotValidException ex) {
+        log.error(ex.getMessage());
+        ErrorResponse response = new ErrorResponse(INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(INVALID_INPUT_VALUE.getHttpStatus()));
+    }
+    
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/controller/RouteController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.softeer5.uniro_backend.route.service.RouteService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -49,7 +50,7 @@ public class RouteController implements RouteApi {
 	@PostMapping("/{univId}/route/risk/{routeId}")
 	public ResponseEntity<Void> updateRisk (@PathVariable("univId") Long univId,
 									   @PathVariable("routeId") Long routeId,
-									   @RequestBody PostRiskReqDTO postRiskReqDTO){
+									   @RequestBody @Valid PostRiskReqDTO postRiskReqDTO){
 		routeService.updateRisk(univId,routeId,postRiskReqDTO);
 		return ResponseEntity.ok().build();
 	}
@@ -57,7 +58,7 @@ public class RouteController implements RouteApi {
 	@Override
 	@PostMapping("/{univId}/route")
 	public ResponseEntity<Void> createRoute (@PathVariable("univId") Long univId,
-											 @RequestBody CreateRoutesReqDTO routes){
+											 @RequestBody @Valid CreateRoutesReqDTO routes){
 		routeCalculationService.createRoute(univId, routes);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/request/CreateRoutesReqDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/request/CreateRoutesReqDTO.java
@@ -18,7 +18,6 @@ public class CreateRoutesReqDTO {
     private final Long startNodeId;
 
     @Schema(description = "종료 노드 id", example = "4")
-    @NotNull
     private final Long endNodeId;
 
     @Schema(description = "노드 좌표", example = "")

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/request/CreateRoutesReqDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/request/CreateRoutesReqDTO.java
@@ -3,6 +3,8 @@ package com.softeer5.uniro_backend.route.dto.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,11 +14,14 @@ import lombok.RequiredArgsConstructor;
 public class CreateRoutesReqDTO {
 
     @Schema(description = "시작 노드 id", example = "3")
+    @NotNull
     private final Long startNodeId;
 
     @Schema(description = "종료 노드 id", example = "4")
+    @NotNull
     private final Long endNodeId;
 
     @Schema(description = "노드 좌표", example = "")
+    @NotEmpty
     private final List<CreateRouteReqDTO> coordinates;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/request/PostRiskReqDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/request/PostRiskReqDTO.java
@@ -4,6 +4,7 @@ import com.softeer5.uniro_backend.route.entity.CautionFactor;
 import com.softeer5.uniro_backend.route.entity.DangerFactor;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -15,8 +16,10 @@ import java.util.List;
 public class PostRiskReqDTO {
 
     @Schema(description = "주의 요소 목록", example = "[\"SLOPE\", \"CURB\"]")
+    @NotNull
     private List<CautionFactor> cautionFactors;
 
     @Schema(description = "위험 요소 목록", example = "[\"CURB\", \"STAIRS\"]")
+    @NotNull
     private List<DangerFactor> dangerFactors;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -83,6 +83,10 @@ public class RouteCalculationService {
         Node startNode = nodeMap.get(startNodeId);
         Node endNode = nodeMap.get(endNodeId);
 
+        if(startNode == null || endNode == null){
+            throw new NodeException("Node Not Found", NODE_NOT_FOUND);
+        }
+
         //길찾기 알고리즘 수행
         Map<Long, Route> prevRoute = findFastestRoute(startNode, endNode, adjMap);
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 클라이언트로부터 잘못된 값을 입력 받았을 때 검증하는 로직을 작성했습니다.

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 시작 노드 또는 종료 노드가 올바르지 않은 경우
<img width="747" alt="스크린샷 2025-02-10 오전 11 22 47" src="https://github.com/user-attachments/assets/b37cf7c7-b9e4-4524-9fa3-c1ff431cdb48" />

### 제보 API 또는 길 추가 API 에서 body 값이 비어있는 경우
<img width="739" alt="스크린샷 2025-02-10 오전 11 23 56" src="https://github.com/user-attachments/assets/00c806e1-f9ad-4112-b56a-9ca72e2717aa" />


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/