### PR TITLE
[UIN-184] 길찾기 로직에서 좌/우회전이 반대로 적용되던 오류 수정

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/CoreRouteResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/CoreRouteResDTO.java
@@ -16,7 +16,7 @@ public class CoreRouteResDTO {
     private final Long coreNode1Id;
 
     @Schema(description = "코어 노드 2", example = "13")
-    private final Long cordNode2Id;
+    private final Long coreNode2Id;
 
     @Schema(description = "간선 정보", example = "")
     private final List<RouteCoordinatesInfoResDTO> routes;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -231,9 +231,9 @@ public class RouteCalculationService {
         if (angle < 30) {
             return DirectionType.STRAIGHT;
         } else if (angle >= 30 && angle < 150) {
-            return (crossProduct > 0) ? DirectionType.RIGHT : DirectionType.LEFT;
+            return (crossProduct > 0) ? DirectionType.LEFT : DirectionType.RIGHT;
         } else if (angle >= 150 && angle < 180) {
-            return (crossProduct > 0) ? DirectionType.SHARP_RIGHT : DirectionType.SHARP_LEFT;
+            return (crossProduct > 0) ? DirectionType.SHARP_LEFT : DirectionType.SHARP_RIGHT;
         } else {
             return DirectionType.STRAIGHT;
         }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
- 길찾기 로직에서 좌/우회전이 반대로 적용되던 오류 수정
- cord2Node -> core2Node로 오타수정

