### PR TITLE
[UNI-185] fix: 기존 선과 동일하거나 겹치는 경우 예외 발생 (일반 크로스 체크와 self 크로스에 따라 분기처리)

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -557,7 +557,7 @@ public class RouteCalculationService {
                     }
                 }
                 else if (intersection instanceof LineString) {
-                    if (isSelfCheck) {
+                    if (isSelfCheck && existingLine.equalsTopo(newLine)) {
                         continue;
                     }
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -453,7 +453,7 @@ public class RouteCalculationService {
         while (iterator.hasNext()) {
             Node cur = iterator.next();
             LineString intersectLine = findIntersectLineString(prev.getCoordinates().getCoordinate(), cur.getCoordinates()
-                .getCoordinate(), strTree);
+                .getCoordinate(), strTree, false);
             if (intersectLine != null) {
                 Node midNode = getClosestNode(intersectLine, prev, cur, nodeMap);
                 midNode.setCore(true);
@@ -492,7 +492,7 @@ public class RouteCalculationService {
             Node nextNode = nodes.get(i + 1);
 
             LineString intersectLine = findIntersectLineString(curNode.getCoordinates().getCoordinate(),
-                nextNode.getCoordinates().getCoordinate(), strTree);
+                nextNode.getCoordinates().getCoordinate(), strTree, true);
 
             if (intersectLine != null) {
                 Coordinate[] coordinates = intersectLine.getCoordinates();
@@ -523,7 +523,7 @@ public class RouteCalculationService {
         return nodes;
     }
 
-    private LineString findIntersectLineString(Coordinate start, Coordinate end, STRtree strTree) {
+    private LineString findIntersectLineString(Coordinate start, Coordinate end, STRtree strTree, boolean isSelfCheck) {
         LineString newLine = geometryFactory.createLineString(new Coordinate[] {start, end});
         Envelope searchEnvelope = newLine.getEnvelopeInternal();
 
@@ -536,11 +536,6 @@ public class RouteCalculationService {
         // 2️⃣ 실제로 선분이 겹치는지 확인
         for (Object obj : candidates) {
             LineString existingLine = (LineString)obj;
-
-            // 동일한 선이면 continue
-            if(existingLine.equalsTopo(newLine)){
-                continue;
-            }
 
             if (existingLine.intersects(newLine)) {
                 Geometry intersection = existingLine.intersection(newLine);
@@ -562,6 +557,10 @@ public class RouteCalculationService {
                     }
                 }
                 else if (intersection instanceof LineString) {
+                    if (isSelfCheck) {
+                        continue;
+                    }
+
                     throw new RouteCalculationException("intersection is only allowed by point", INTERSECTION_ONLY_ALLOWED_POINT);
                 }
 

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/route/RouteCalculationServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/route/RouteCalculationServiceTest.java
@@ -182,6 +182,31 @@ class RouteCalculationServiceTest {
 			assertThat(result.get(3).isCore()).isTrue();
 		}
 
+		@Test
+		void 기존_경로와_동일한_경우_예외발생() {
+			// Given
+			Long univId = 1001L;
+			List<CreateRouteReqDTO> requests = List.of(
+				new CreateRouteReqDTO(0, 0),
+				new CreateRouteReqDTO(1, 1),
+				new CreateRouteReqDTO(2, 2)
+			);
+
+			Node node1 = NodeFixture.createNode(0, 0);
+			Node node2 = NodeFixture.createNode(1, 1);
+			Node node3 = NodeFixture.createNode(2, 2);
+			Route route = RouteFixture.createRoute(node1, node2);
+			Route route2 = RouteFixture.createRoute(node2, node3);
+
+			nodeRepository.saveAll(List.of(node1, node2, node3));
+			routeRepository.saveAll(List.of(route, route2));
+
+			// when, then
+			assertThatThrownBy(() -> routeCalculationService.checkRouteCross(univId, node1.getId(), null, requests))
+				.isInstanceOf(RouteCalculationException.class)
+				.hasMessageContaining("intersection is only allowed by point");
+		}
+
 	}
 
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 기존 선과 동일한 경우 예외 발생하는 부분에서 버그가 있었습니다.
- 기본 크로스 체크와 self 크로스 체크를 구분하기 위해 플래그성 파라미터를 추가했습니다.

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
- 테스트 코드 참고.

## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/