### PR TITLE
[UNI-167] feat, fix, refactor : 구글 구면좌표계 도입, QA waypoint 마커 제거, 새로운 길 제보시 되돌리기 기능 구현

### DIFF
--- a/uniro_frontend/src/assets/undo.svg
+++ b/uniro_frontend/src/assets/undo.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.83333 5L3 10.8333M3 10.8333L8.83333 16.6667M3 10.8333L12.3333 10.8333C18.7768 10.8333 24 16.0565 24 22.5V23.6667" stroke="currentColor" stroke-width="2.01667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/uniro_frontend/src/components/map/floatingButtons.tsx
+++ b/uniro_frontend/src/components/map/floatingButtons.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import DangerIcon from "../../assets/danger.svg?react";
 import CautionIcon from "../../assets/caution.svg?react";
+import UndoIcon from "../../assets/undo.svg?react";
 
 interface ToggleButtonProps {
 	isActive: boolean;
@@ -25,6 +25,23 @@ export function CautionToggleButton({ isActive, onClick }: ToggleButtonProps) {
 			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full border-[1.5px] active:bg-gray-200 active:border-gray-400 active:text-gray-700 ${isActive ? "bg-system-orange border-gray-100 text-gray-100" : "bg-gray-100 border-gray-400 text-gray-700"}`}
 		>
 			<CautionIcon />
+		</button>
+	);
+}
+
+interface UndoButtonProps {
+	onClick: () => void;
+	disabled: boolean;
+}
+
+export function UndoButton({ onClick, disabled }: UndoButtonProps) {
+	return (
+		<button
+			disabled={disabled}
+			onClick={onClick}
+			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full border-[1.5px]  bg-gray-100 border-gray-400 text-gray-700 ${disabled ? "bg-gray-300" : "active:bg-gray-200 active:border-gray-400 active:text-gray-700"}`}
+		>
+			<UndoIcon />
 		</button>
 	);
 }

--- a/uniro_frontend/src/hooks/useMap.tsx
+++ b/uniro_frontend/src/hooks/useMap.tsx
@@ -7,6 +7,7 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 	const [overlay, setOverlay] = useState<google.maps.OverlayView | null>(null);
 	const [AdvancedMarker, setAdvancedMarker] = useState<typeof google.maps.marker.AdvancedMarkerElement | null>(null);
 	const [Polyline, setPolyline] = useState<typeof google.maps.Polyline | null>(null);
+	const [spherical, setSpherical] = useState<typeof google.maps.geometry.spherical | null>(null);
 	const [mapLoaded, setMapLoaded] = useState<boolean>(false);
 
 	useEffect(() => {
@@ -14,12 +15,13 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 
 		const initMap = async () => {
 			try {
-				const { map, overlay, AdvancedMarkerElement, Polyline } = await initializeMap(
+				const { map, overlay, AdvancedMarkerElement, Polyline, spherical } = await initializeMap(
 					mapRef.current,
 					mapOptions,
 				);
 				setMap(map);
 				setOverlay(overlay);
+				setSpherical(() => spherical);
 				setAdvancedMarker(() => AdvancedMarkerElement);
 				setPolyline(() => Polyline);
 				setMapLoaded(true);
@@ -37,7 +39,7 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 		};
 	}, []);
 
-	return { mapRef, map, overlay, AdvancedMarker, Polyline, mapLoaded };
+	return { mapRef, map, overlay, AdvancedMarker, Polyline, spherical, mapLoaded };
 };
 
 export default useMap;

--- a/uniro_frontend/src/map/initializer/googleMapInitializer.ts
+++ b/uniro_frontend/src/map/initializer/googleMapInitializer.ts
@@ -7,13 +7,14 @@ interface MapWithOverlay {
 	overlay: google.maps.OverlayView | null;
 	AdvancedMarkerElement: typeof google.maps.marker.AdvancedMarkerElement;
 	Polyline: typeof google.maps.Polyline;
+	spherical: typeof google.maps.geometry.spherical;
 }
 
 export const initializeMap = async (
 	mapElement: HTMLElement | null,
 	mapOptions?: google.maps.MapOptions,
 ): Promise<MapWithOverlay> => {
-	const { Map, OverlayView, AdvancedMarkerElement, Polyline } = await loadGoogleMapsLibraries();
+	const { Map, OverlayView, AdvancedMarkerElement, Polyline, spherical } = await loadGoogleMapsLibraries();
 
 	if (!mapElement) {
 		throw new Error("Map Element is not provided");
@@ -44,5 +45,5 @@ export const initializeMap = async (
 	overlay.onRemove = function () {};
 	overlay.setMap(map);
 
-	return { map, overlay, AdvancedMarkerElement, Polyline };
+	return { map, overlay, AdvancedMarkerElement, Polyline, spherical };
 };

--- a/uniro_frontend/src/map/loader/googleMapLoader.ts
+++ b/uniro_frontend/src/map/loader/googleMapLoader.ts
@@ -9,8 +9,9 @@ const GoogleMapsLoader = new Loader({
 const loadGoogleMapsLibraries = async () => {
 	const { Map, OverlayView, Polyline } = await GoogleMapsLoader.importLibrary("maps");
 	const { AdvancedMarkerElement } = await GoogleMapsLoader.importLibrary("marker");
+	const { spherical } = await GoogleMapsLoader.importLibrary("geometry");
 
-	return { Map, OverlayView, AdvancedMarkerElement, Polyline };
+	return { Map, OverlayView, AdvancedMarkerElement, Polyline, spherical };
 };
 
 export default loadGoogleMapsLibraries;

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -33,7 +33,7 @@ interface reportMarkerTypes extends MarkerTypesWithElement {
 }
 
 export default function ReportRiskPage() {
-	const { map, mapRef, AdvancedMarker, Polyline } = useMap({ zoom: 18, minZoom: 17 });
+	const { map, mapRef, AdvancedMarker, Polyline, spherical } = useMap({ zoom: 18, minZoom: 17 });
 
 	const [reportMarker, setReportMarker] = useState<reportMarkerTypes>();
 
@@ -166,12 +166,12 @@ export default function ReportRiskPage() {
 				});
 
 				const point = LatLngToLiteral(e.latLng);
-				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(edges, point);
+				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(spherical, edges, point);
 
 				const newReportMarker = createAdvancedMarker(
 					AdvancedMarker,
 					map,
-					centerCoordinate(nearestEdge.node1, nearestEdge.node2),
+					centerCoordinate(spherical, nearestEdge.node1, nearestEdge.node2),
 					createMarkerElement({
 						type: Markers.REPORT,
 						className: "translate-routemarker",

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -36,7 +36,7 @@ type SelectedMarkerTypes = {
 export default function ReportRoutePage() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
-	const { map, mapRef, AdvancedMarker, Polyline } = useMap({ zoom: 18, minZoom: 17 });
+	const { map, mapRef, AdvancedMarker, Polyline, spherical } = useMap({ zoom: 18, minZoom: 17 });
 	const originPoint = useRef<{ point: Node; element: AdvancedMarker } | undefined>();
 	const [newPoints, setNewPoints] = useState<{ element: AdvancedMarker | null; coords: (Coord | Node)[] }>({
 		element: null,
@@ -214,7 +214,7 @@ export default function ReportRoutePage() {
 		const lastPoint = newPoints.coords[newPoints.coords.length - 1] as Node | Coord;
 
 		for (const edge of edges) {
-			const subNode = createSubNodes(new Polyline({ path: edge })).slice(0, -1);
+			const subNode = createSubNodes(spherical, new Polyline({ path: edge })).slice(0, -1);
 			subNodes.push(...subNode);
 		}
 
@@ -263,7 +263,7 @@ export default function ReportRoutePage() {
 				});
 
 				const point = LatLngToLiteral(e.latLng);
-				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(edges, point);
+				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(spherical, edges, point);
 
 				const tempWaypointMarker = createAdvancedMarker(
 					AdvancedMarker,

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -25,6 +25,7 @@ import { useNavigate } from "react-router";
 import { getAllRisks } from "../api/routes";
 import { CautionIssueType, DangerIssueType } from "../data/types/enum";
 import { CautionIssue, DangerIssue } from "../constant/enum/reportEnum";
+import removeMarkers from "../utils/markers/removeMarkers";
 
 type SelectedMarkerTypes = {
 	type: Markers.CAUTION | Markers.DANGER;
@@ -59,6 +60,7 @@ export default function ReportRoutePage() {
 		navigate("/map");
 	});
 	const [FailModal, isFailOpen, openFail, closeFail] = useModal();
+	const [tempWaypoints, setTempWayPoints] = useState<AdvancedMarker[]>([]);
 
 	if (!university) return;
 
@@ -95,6 +97,10 @@ export default function ReportRoutePage() {
 				element: null,
 				coords: [],
 			});
+			setTempWayPoints((prevMarkers) => {
+				removeMarkers(prevMarkers);
+				return []
+			})
 			if (newPolyLine.current) newPolyLine.current.setPath([]);
 			queryClient.invalidateQueries({ queryKey: ["routes", university.id] });
 		},
@@ -109,6 +115,10 @@ export default function ReportRoutePage() {
 				element: null,
 				coords: [],
 			});
+			setTempWayPoints((prevMarkers) => {
+				removeMarkers(prevMarkers);
+				return []
+			})
 			if (newPolyLine.current) newPolyLine.current.setPath([]);
 		},
 	});
@@ -274,6 +284,8 @@ export default function ReportRoutePage() {
 						className: "translate-waypoint",
 					}),
 				);
+
+				setTempWayPoints((prevMarkers) => [...prevMarkers, tempWaypointMarker])
 
 				if (originPoint.current) {
 					setNewPoints((prevPoints) => {

--- a/uniro_frontend/src/utils/coordinates/centerCoordinate.ts
+++ b/uniro_frontend/src/utils/coordinates/centerCoordinate.ts
@@ -1,8 +1,17 @@
 import { Coord } from "../../data/types/coord";
+import { LatLngToLiteral } from "./coordinateTransform";
 
-export default function centerCoordinate(point1: Coord, point2: Coord): Coord {
-	return {
-		lat: (point1.lat + point2.lat) / 2,
-		lng: (point1.lng + point2.lng) / 2,
-	};
+export default function centerCoordinate(
+	spherical: typeof google.maps.geometry.spherical | null,
+	point1: Coord,
+	point2: Coord,
+): Coord {
+	if (spherical === null) {
+		return {
+			lat: (point1.lat + point2.lat) / 2,
+			lng: (point1.lng + point2.lng) / 2,
+		};
+	} else {
+		return LatLngToLiteral(spherical.interpolate(point1, point2, 0.5));
+	}
 }

--- a/uniro_frontend/src/utils/coordinates/distance.ts
+++ b/uniro_frontend/src/utils/coordinates/distance.ts
@@ -1,16 +1,23 @@
 /** 하버사인 공식 */
-export default function distance(point1: google.maps.LatLngLiteral, point2: google.maps.LatLngLiteral): number {
+export default function distance(
+	spherical: typeof google.maps.geometry.spherical | null,
+	point1: google.maps.LatLngLiteral,
+	point2: google.maps.LatLngLiteral,
+): number {
 	const { lat: lat1, lng: lng1 } = point1;
 	const { lat: lat2, lng: lng2 } = point2;
 
-	const R = 6371000;
-	const toRad = (angle: number) => (angle * Math.PI) / 180;
+	if (spherical === null) {
+		const R = 6371000;
+		const toRad = (angle: number) => (angle * Math.PI) / 180;
 
-	const dLat = toRad(lat2 - lat1);
-	const dLon = toRad(lng2 - lng1);
+		const dLat = toRad(lat2 - lat1);
+		const dLon = toRad(lng2 - lng1);
 
-	const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
-	const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+		const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+		const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
-	return R * c;
+		return R * c;
+	}
+	return spherical.computeLength([point1, point2]);
 }

--- a/uniro_frontend/src/utils/markers/removeMarkers.ts
+++ b/uniro_frontend/src/utils/markers/removeMarkers.ts
@@ -1,0 +1,5 @@
+import { AdvancedMarker } from "../../data/types/marker";
+
+export default function removeMarkers(markers: AdvancedMarker[]) {
+	markers.forEach((marker) => (marker.map = null));
+}

--- a/uniro_frontend/src/utils/markers/toggleMarkers.ts
+++ b/uniro_frontend/src/utils/markers/toggleMarkers.ts
@@ -1,14 +1,11 @@
 import { AdvancedMarker } from "../../data/types/marker";
+import removeMarkers from "./removeMarkers";
 
 /** Marker 보이기 안보이기 토글 */
 export default function toggleMarkers(isActive: boolean, markers: AdvancedMarker[], map: google.maps.Map) {
 	if (isActive) {
-		for (const marker of markers) {
-			marker.map = map;
-		}
+		markers.forEach((marker) => (marker.map = map));
 	} else {
-		for (const marker of markers) {
-			marker.map = null;
-		}
+		removeMarkers(markers);
 	}
 }

--- a/uniro_frontend/src/utils/polylines/createSubnodes.ts
+++ b/uniro_frontend/src/utils/polylines/createSubnodes.ts
@@ -4,27 +4,41 @@ import { LatLngToLiteral } from "../coordinates/coordinateTransform";
 import distance from "../coordinates/distance";
 
 /** 구면 보간 없이 계산한 결과 */
-export default function createSubNodes(polyLine: google.maps.Polyline): Coord[] {
+export default function createSubNodes(
+	spherical: typeof google.maps.geometry.spherical | null,
+	polyLine: google.maps.Polyline,
+): Coord[] {
 	const paths = polyLine.getPath();
 	const [startNode, endNode] = paths.getArray().map((el) => LatLngToLiteral(el));
 
-	const length = distance(startNode, endNode);
+	const length = distance(spherical, startNode, endNode);
+	console.log("구면 보간", length);
 
 	const subEdgesCount = Math.ceil(length / EDGE_LENGTH);
 
-	const interval = {
-		lat: (endNode.lat - startNode.lat) / subEdgesCount,
-		lng: (endNode.lng - startNode.lng) / subEdgesCount,
-	};
+	const subNodes: Coord[] = [startNode];
 
-	const subNodes = [];
-
-	for (let i = 0; i < subEdgesCount; i++) {
-		const subNode: Coord = {
-			lat: startNode.lat + interval.lat * i,
-			lng: startNode.lng + interval.lng * i,
+	if (spherical === null || !spherical) {
+		const interval = {
+			lat: (endNode.lat - startNode.lat) / subEdgesCount,
+			lng: (endNode.lng - startNode.lng) / subEdgesCount,
 		};
-		subNodes.push(subNode);
+
+		for (let i = 1; i < subEdgesCount; i++) {
+			const subNode: Coord = {
+				lat: startNode.lat + interval.lat * i,
+				lng: startNode.lng + interval.lng * i,
+			};
+			subNodes.push(subNode);
+		}
+
+		subNodes.push(endNode);
+		return subNodes;
+	}
+
+	for (let i = 1; i < subEdgesCount; i++) {
+		const fraction = i / subEdgesCount;
+		subNodes.push(LatLngToLiteral(spherical.interpolate(startNode, endNode, fraction)));
 	}
 
 	subNodes.push(endNode);

--- a/uniro_frontend/src/utils/polylines/findNearestEdge.ts
+++ b/uniro_frontend/src/utils/polylines/findNearestEdge.ts
@@ -5,6 +5,7 @@ import centerCoordinate from "../coordinates/centerCoordinate";
 import distance from "../coordinates/distance";
 
 export default function findNearestSubEdge(
+	spherical: typeof google.maps.geometry.spherical | null,
 	edges: CoreRoute[],
 	point: Coord,
 ): {
@@ -15,7 +16,7 @@ export default function findNearestSubEdge(
 		.map((edge) => {
 			return {
 				edge,
-				distance: distance(point, centerCoordinate(edge.node1, edge.node2)),
+				distance: distance(spherical, point, centerCoordinate(spherical, edge.node1, edge.node2)),
 			};
 		})
 		.sort((a, b) => {
@@ -25,8 +26,8 @@ export default function findNearestSubEdge(
 	const nearestEdge = edgesWithDistance[0].edge;
 
 	const { node1, node2 } = nearestEdge;
-	const distance0 = distance(node1, point);
-	const distance1 = distance(node2, point);
+	const distance0 = distance(spherical, node1, point);
+	const distance1 = distance(spherical, node2, point);
 	const nearestPoint = distance0 > distance1 ? node2 : node1;
 
 	return {


### PR DESCRIPTION
## #️⃣ 작업 내용

1. 구글 구면좌표계 도입
2. (QA 수정 사항) 새로운 길 제보 성공/실패 시 임시 생성 waypoint 마커 제거
3. 새로운 길 제보 시, 되돌리기 기능 구현

## 주요 기능

### 구글 구면좌표계 도입

- #32 에서 언급된, 직선 계산으로 인한 길이 비직선형인 문제를 해결하기 위해서 구글 구면 좌표계를 도입하였습니다.
-[구글맵 SDK](https://developers.google.com/maps/documentation/javascript/geometry?hl=ko) 에서 사용할 함수는 interpolate와 computeLength 입니다.
- interpolate 메소드로 createSubNode, distance 및 centerCoordinate 함수를 대체할 수 있습니다.

```typescript
/** 구면 보간 없이 계산한 결과 */
export default function createSubNodes(
	spherical: typeof google.maps.geometry.spherical | null,
	polyLine: google.maps.Polyline,
): Coord[] {
	const paths = polyLine.getPath();
	const [startNode, endNode] = paths.getArray().map((el) => LatLngToLiteral(el));

	const length = distance(spherical, startNode, endNode);
	console.log("구면 보간", length);

	const subEdgesCount = Math.ceil(length / EDGE_LENGTH);

	const subNodes: Coord[] = [startNode];

	if (spherical === null || !spherical) {
		const interval = {
			lat: (endNode.lat - startNode.lat) / subEdgesCount,
			lng: (endNode.lng - startNode.lng) / subEdgesCount,
		};

		for (let i = 1; i < subEdgesCount; i++) {
			const subNode: Coord = {
				lat: startNode.lat + interval.lat * i,
				lng: startNode.lng + interval.lng * i,
			};
			subNodes.push(subNode);
		}

		subNodes.push(endNode);
		return subNodes;
	}

	for (let i = 1; i < subEdgesCount; i++) {
		const fraction = i / subEdgesCount;
		subNodes.push(LatLngToLiteral(spherical.interpolate(startNode, endNode, fraction)));
	}

	subNodes.push(endNode);

	return subNodes;
}
```
- 구면좌표계 Class를 입력받는데, null일 경우, 기존에 구현되어 있던직선 계산을 그대로 사용하였습니다.
- 그렇지 않을 경우, interpolate 메소드를 사용하여 더 정확한 subNode 생성을 적용하였습니다.

```typescript
/** 하버사인 공식 */
export default function distance(
	spherical: typeof google.maps.geometry.spherical | null,
	point1: google.maps.LatLngLiteral,
	point2: google.maps.LatLngLiteral,
): number {
	const { lat: lat1, lng: lng1 } = point1;
	const { lat: lat2, lng: lng2 } = point2;

	if (spherical === null) {
		const R = 6371000;
		const toRad = (angle: number) => (angle * Math.PI) / 180;

		const dLat = toRad(lat2 - lat1);
		const dLon = toRad(lng2 - lng1);

		const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
		const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));

		return R * c;
	}
	return spherical.computeLength([point1, point2]);
}
```
- distance 함수에서도 구면좌표계 Class를 입력받아 null인 경우, 기존에 구현한 하버사인 공식을 사용하고
- Class가 존재하는 경우, computeLength로 2점 사이의 거리를 계산하였습니다.

```typescript
import { Coord } from "../../data/types/coord";
import { LatLngToLiteral } from "./coordinateTransform";

export default function centerCoordinate(
	spherical: typeof google.maps.geometry.spherical | null,
	point1: Coord,
	point2: Coord,
): Coord {
	if (spherical === null) {
		return {
			lat: (point1.lat + point2.lat) / 2,
			lng: (point1.lng + point2.lng) / 2,
		};
	} else {
		return LatLngToLiteral(spherical.interpolate(point1, point2, 0.5));
	}
}
```
- 위와 동일하게 Class가 없는 경우, 직선으로 보정하여 중점을 계산하였습니다.
- Class가 있는 경우, interpolate를 0.5로 하여 중점을 계산하였습니다.


### 마커 노출 함수 가독성 개선
```
export default function removeMarkers(markers: AdvancedMarker[]) {
	markers.forEach((marker) => (marker.map = null));
}

/** Marker 보이기 안보이기 토글 */
export default function toggleMarkers(isActive: boolean, markers: AdvancedMarker[], map: google.maps.Map) {
	if (isActive) {
		markers.forEach((marker) => (marker.map = map));
	} else {
		removeMarkers(markers);
	}
}
```
- 기존에 마커를 순회하는 로직을 for 문으로 진행하였으나, 코드의 가독성 개선을 위해 forEach로 탐색하였습니다.
- for문과 forEach의 경우, [js 성능 비교](https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/) forEach가 더 빠르다고 알려져 있으나, 가독성 및 유지보수 측면에서 팀원의 동의를 얻고 코드를 변경하였습니다.

### QA 반영 새로운 길 제보 성공/실패 시 임시 생성 waypoint 마커 제거
- 기존에 존재하는 길을 추가시, 임시 waypoint 마커를 생성하였는데 이를 아무 state에서도 관리되지 않아 관리 state를 추가하고 mutation onError, onSuccess에서 실패/성공 시, waypoint 마커를 초기화하였습니다.

```typescript
const { mutate } = useMutation({
	        onSuccess: () => {
	                  setTempWayPoints((prevMarkers) => {
		                  removeMarkers(prevMarkers);
		                  return []
	                  })
		},
		onError: () => {
			setTempWayPoints((prevMarkers) => {
				removeMarkers(prevMarkers);
				return []
			})
		},
	});
```

### 새로운 길 제보시, 되돌리기 기능 추가
- 백엔드에서 새로운 길 추가 기능을 테스트하면서 되돌리기 기능 부재로 인한 불편함을 겪어 이를 해결하기 위해 기획에는 없었던 되돌리기 기능을 추가하였습니다.
- 되돌리기 기능이란, 마지막으로 생성한 점을 취소하는 기능입니다.
- 되돌리기전 Points의 개수의 3가지 Case (1개, 2개, 0개 혹은 3개 이상)로 분리하였습니다.
- **1. 기존에 2개 였던 경우**
기존에 2개였던 경우, 하나를 삭제하게 될 경우, state로 관리되던 도착 마커를 삭제해야 합니다.
- **2. 기존에 1개 였던 경우**
기존에 1개 였던 경우, 출발 마커를 삭제해야합니다.
- **3. 기존에 0개 혹은 3개 이상인 경우**
일반적인 경우, 도착 마커를 옮겨야합니다.
- 또한, 지워야할 마커가 선위에 존재하는 경우, 앞에서 관리된 임시 waypoints 마커도 제거해야합니다.

```typescript
         /** Undo 함수 
	 * 되돌리기 버튼을 누를 경우, 마지막에 생성된 점을 제거
	 * 기존 점의 개수가 1개, 2개, (0개 혹은 3개 이상) 총 3개의 Case를 나눈다.
	 * 1개 : originMarker를 제거하고
	 * 2개 : , 도착마커를 제거한다.
	 * 0개 혹은 3개 이상, 도착마커를 이동시킨다.
	*/
	const undoPoints = () => {
		const deleteNode = [...newPoints.coords].pop();

		if (deleteNode && "nodeId" in deleteNode) {
			setTempWayPoints((prevPoints) => {
				const lastMarker = prevPoints.slice(-1)[0];

				lastMarker.map = null;

				return [...prevPoints.slice(0, -1)]
			})
		}
		
		if (newPoints.coords.length === 2) {
			setNewPoints((prevPoints) => {
				if (prevPoints.element) prevPoints.element.map = null;
				return {
					element: null,
					coords: [prevPoints.coords[0]]
				}
			})
			return;
		}
		else if (newPoints.coords.length === 1) {
			if (originPoint.current) {
				originPoint.current.element.map = null;
			}
			originPoint.current = undefined;
			setNewPoints({
				coords: [],
				element: null
			})
			return;
		}

		setNewPoints((prevPoints) => {
			const tempPoints = prevPoints.coords.slice(0, -1);
			const lastPoint = tempPoints.slice(-1)[0];
			if (prevPoints.element) prevPoints.element.position = lastPoint;
			return {
				element: prevPoints.element,
				coords: tempPoints
			}
		})
	}
```
- 다음과 같이 Case를 나눠서 Undo를 적용하였습니다.

## 동작확인




### 구글 구면좌표계 적용 결과

### createSubNodes

https://github.com/user-attachments/assets/07d93584-1885-40b5-8e54-95f1a48fa346

### CenterCoordinate
<img width="1021" alt="스크린샷 2025-02-10 오후 4 19 16" src="https://github.com/user-attachments/assets/33db47f0-ead4-4b64-b5ef-58be2a56fe6f" />

### Distance 함수
<img width="873" alt="스크린샷 2025-02-10 오후 4 17 48" src="https://github.com/user-attachments/assets/606fdb9b-734e-426d-a734-95a43f354b8b" />


### Waypoint 제거 및 되돌리기 적용 결과

https://github.com/user-attachments/assets/9be14859-7cf3-4777-81bf-c826d4511445


## 연관 이슈
UNI-181, UNI-182, UNI-183
