### PR TITLE
[UNI-158] fix : 빌딩노드와 연결된 간선은 조회되지 않도록 로직 수정

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/RouteUtils.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/RouteUtils.java
@@ -1,0 +1,16 @@
+package com.softeer5.uniro_backend.common.utils;
+
+import com.softeer5.uniro_backend.route.entity.Route;
+
+import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_COST;
+
+public final class RouteUtils {
+
+    private RouteUtils(){
+        // 인스턴스화 방지
+    }
+
+    public static boolean isBuildingRoute(Route route){
+        return route.getCost() > BUILDING_ROUTE_COST - 1;
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -2,6 +2,7 @@ package com.softeer5.uniro_backend.route.service;
 
 import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
 import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
+import static com.softeer5.uniro_backend.common.utils.RouteUtils.isBuildingRoute;
 
 import com.softeer5.uniro_backend.admin.annotation.RevisionOperation;
 import com.softeer5.uniro_backend.admin.entity.RevisionOperationType;
@@ -147,10 +148,6 @@ public class RouteCalculationService {
         List<RouteDetailResDTO> details = getRouteDetail(startNode, endNode, shortestRoutes);
 
         return FastestRouteResDTO.of(hasCaution, totalDistance, totalCost, routeInfoDTOS, details);
-    }
-
-    private boolean isBuildingRoute(Route route){
-        return route.getCost() > BUILDING_ROUTE_COST - 1;
     }
 
     private Map<Long, Route> findFastestRoute(Node startNode, Node endNode, Map<Long, List<Route>> adjMap){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteService.java
@@ -136,7 +136,6 @@ public class RouteService {
 				routeSet.add(r.getId());
 
 				while (true) {
-					System.out.println(currentNode.getId());
 					//코어노드를 만나면 queue에 넣을지 판단한 뒤 종료 (제자리로 돌아오는 경우도 포함)
 					if (currentNode.isCore() || currentNode.getId().equals(now.getId())) {
 						if (!visitedCoreNodes.contains(currentNode.getId())) {


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### 모든 노드/간선 조회 로직 수정
- 모든 노드와 간선을 조회하는 로직에서 빌딩노드와 연결된 간선은 조회되지 않도록 로직을 수정하였습니다.
- 추가로 사이클이 돌며, 코어노드가 없는 경우 예외처리 하였는데, 처리 가능하도록 로직을 수정하였습니다.

## 💡 To Reviewer
- feat/UNI-156 에서 판 브렌치입니다.

## 🧪 테스트 결과
<img width="639" alt="image" src="https://github.com/user-attachments/assets/1a290f8b-19f6-4872-b2e2-a00b52136176" />

