### PR TITLE
[UNI-187] fix : Param으로 받지 않고, Building으로 검색했을 때 위치가 변동되지 않는 문제 해결

### DIFF
--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -64,11 +64,18 @@ const NavigationResultPage = () => {
 							requestOriginId,
 							requestDestinationId,
 						);
-						setOriginCoord(response.routes[0].node1.lng, response.routes[0].node1.lat);
-						setDestinationCoord(
-							response.routes[response.routes.length - 1].node1.lng,
-							response.routes[response.routes.length - 1].node1.lat,
-						);
+						// param으로 받아올 수 있는 ID들이 있으면 추가하고, 아니면 기존 Building의 좌표를 넣는다
+						if (originId) {
+							setOriginCoord(response.routes[0].node1.lng, response.routes[0].node1.lat);
+							return response;
+						}
+						if (destinationId) {
+							setDestinationCoord(
+								response.routes[response.routes.length - 1].node2.lng,
+								response.routes[response.routes.length - 1].node2.lat,
+							);
+							return response;
+						}
 						return response;
 					} catch (e) {
 						alert(`경로를 찾을 수 없습니다. (${e})`);


### PR DESCRIPTION
## #️⃣ 작업 내용

1. Param으로 받는 기능을 유지할 필요성을 느껴, 우선 유지하고 길찾기 결과에서 건물을 선택했을 경우 건물로 출발과 도착지 마커가 이동하도록 변경했습니다.

## 동작 확인
<img width="923" alt="image" src="https://github.com/user-attachments/assets/dd10040b-2756-477d-be40-5de23801e98c" />
