### PR TITLE
[UNI-188] refactor : 불편한 길 제보 페이지 & 새로운 길 제보 페이지 useMutation -> useMutationError 변경

### DIFF
--- a/uniro_frontend/src/hooks/useMutationError.tsx
+++ b/uniro_frontend/src/hooks/useMutationError.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, useMutation, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
 import { NotFoundError, BadRequestError, ERROR_STATUS } from "../constant/error";
-import React, { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 type Fallback = {
 	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
@@ -9,57 +9,72 @@ type Fallback = {
 	};
 };
 
+type HandleError = {
+	fallback: Fallback;
+	onClose?: () => void;
+}
+
+type UseMutationErrorReturn<TData, TError, TVariables, TContext> = [
+	React.FC,
+	UseMutationResult<TData, TError, TVariables, TContext>
+];
+
 export default function useMutationError<TData, TError, TVariables, TContext>(
 	options: UseMutationOptions<TData, TError, TVariables, TContext>,
 	queryClient?: QueryClient,
-	fallback?: Fallback,
-): [React.FC, UseMutationResult<TData, TError, TVariables, TContext>] {
+	handleError?: HandleError,
+): UseMutationErrorReturn<TData, TError, TVariables, TContext> {
 	const [isOpen, setOpen] = useState<boolean>(false);
-	const [title, setTitle] = useState({
-		mainTitle: "",
-		subTitle: "",
-	});
 	const result = useMutation<TData, TError, TVariables, TContext>(options, queryClient);
 
 	const { isError, error } = result;
 
 	useEffect(() => {
-		if (isError) {
-			setOpen(isError);
-			if (error instanceof NotFoundError && fallback) {
-				setTitle({ ...fallback[404] });
-			} else if (error instanceof BadRequestError && fallback) {
-				setTitle({ ...fallback[400] });
-			} else {
-				throw error;
-			}
-		}
-	}, [error, isError]);
+		setOpen(isError)
+	}, [isError])
 
-	const close = useCallback(() => {
+	const close = () => {
+		if (handleError?.onClose) handleError?.onClose();
 		setOpen(false);
-	}, []);
+	}
 
-	const BaseFallback = (
-		<div className="fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.2)]">
-			<div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden">
-				<div className="flex flex-col justify-center space-y-1 py-[25px]">
-					<p className="text-kor-body1 font-bold text-system-red">{title.mainTitle}</p>
-					<div className="space-y-0">
-						<p className="text-kor-body3 font-regular text-gray-700">{title.subTitle}</p>
+	const Modal: React.FC = () => {
+		if (!isOpen || !handleError || !error) return null;
+
+		const { fallback } = handleError;
+
+		let title = {
+			mainTitle: "",
+			subTitle: "",
+		}
+
+		if (error instanceof NotFoundError) {
+			title = fallback[404] ?? title;
+		}
+		else if (error instanceof BadRequestError) {
+			title = fallback[400] ?? title;
+		}
+		else throw error;
+
+		return (
+			<div className="fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.2)]">
+				<div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden">
+					<div className="flex flex-col justify-center space-y-1 py-[25px]">
+						<p className="text-kor-body1 font-bold text-system-red">{title.mainTitle}</p>
+						<div className="space-y-0">
+							<p className="text-kor-body3 font-regular text-gray-700">{title.subTitle}</p>
+						</div>
 					</div>
+					<button
+						onClick={close}
+						className="h-[58px] border-t-[1px] border-gray-200 text-kor-body2 font-semibold active:bg-gray-200"
+					>
+						확인
+					</button>
 				</div>
-				<button
-					onClick={close}
-					className="h-[58px] border-t-[1px] border-gray-200 text-kor-body2 font-semibold active:bg-gray-200"
-				>
-					확인
-				</button>
 			</div>
-		</div>
-	);
-
-	const Modal: React.FC = () => <>{isOpen && BaseFallback}</>;
+		)
+	}
 
 	return [Modal, result];
 }

--- a/uniro_frontend/src/hooks/useMutationError.tsx
+++ b/uniro_frontend/src/hooks/useMutationError.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 type Fallback = {
 	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
 		mainTitle: string;
-		subTitle: string;
+		subTitle: string[];
 	};
 };
 
@@ -43,9 +43,9 @@ export default function useMutationError<TData, TError, TVariables, TContext>(
 
 		const { fallback } = handleError;
 
-		let title = {
+		let title: { mainTitle: string, subTitle: string[] } = {
 			mainTitle: "",
-			subTitle: "",
+			subTitle: [],
 		}
 
 		if (error instanceof NotFoundError) {
@@ -58,11 +58,12 @@ export default function useMutationError<TData, TError, TVariables, TContext>(
 
 		return (
 			<div className="fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.2)]">
-				<div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden">
+				< div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden" >
 					<div className="flex flex-col justify-center space-y-1 py-[25px]">
 						<p className="text-kor-body1 font-bold text-system-red">{title.mainTitle}</p>
 						<div className="space-y-0">
-							<p className="text-kor-body3 font-regular text-gray-700">{title.subTitle}</p>
+							{title.subTitle.map((_subtitle, index) =>
+								<p key={`error-modal-subtitle-${index}`} className="text-kor-body3 font-regular text-gray-700">{_subtitle}</p>)}
 						</div>
 					</div>
 					<button
@@ -71,8 +72,8 @@ export default function useMutationError<TData, TError, TVariables, TContext>(
 					>
 						확인
 					</button>
-				</div>
-			</div>
+				</div >
+			</div >
 		)
 	}
 

--- a/uniro_frontend/src/pages/errorTest.tsx
+++ b/uniro_frontend/src/pages/errorTest.tsx
@@ -13,44 +13,49 @@ const postReport = (
 };
 
 export default function Errortest() {
-	const [Modal400, result400] = useMutationError(
+	const [Modal400, { mutate: mutate400 }] = useMutationError(
 		{
 			//@ts-expect-error 강제 에러 발생
 			mutationFn: () => postReport(1001, 1, { cautionFactors: ["TEST"], dangerFactors: [] }),
 		},
 		undefined,
 		{
-			400: { mainTitle: "400 제목", subTitle: "400 부제목" },
-			404: { mainTitle: "404 제목", subTitle: "404 부제목" },
-		},
+			fallback: {
+				400: { mainTitle: "400 제목", subTitle: "400 부제목" },
+				404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+			},
+			onClose: () => { alert('close callback') }
+		}
 	);
 
-	const [Modal404, result404] = useMutationError(
+	const [Modal404, { mutate: mutate404 }] = useMutationError(
 		{
 			mutationFn: () => postReport(1, 1, { cautionFactors: [], dangerFactors: [] }),
 		},
 		undefined,
 		{
-			400: { mainTitle: "400 제목", subTitle: "400 부제목" },
-			404: { mainTitle: "404 제목", subTitle: "404 부제목" },
-		},
+			fallback: {
+				400: { mainTitle: "400 제목", subTitle: "400 부제목" },
+				404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+			},
+			onClose: () => { }
+		}
 	);
 
-	const [Modal500, result500] = useMutationError(
+	const [Modal500, { mutate: mutate500 }] = useMutationError(
 		{
 			//@ts-expect-error 강제 에러 발생
-			mutationFn: () => postReportRoute(1001, {}),
+			mutationFn: () => postReportRoute(1001, { startNodeId: 1, endNodeId: 1 }),
 		},
 		undefined,
 		{
-			400: { mainTitle: "400 제목", subTitle: "400 부제목" },
-			404: { mainTitle: "404 제목", subTitle: "404 부제목" },
-		},
+			fallback: {
+				400: { mainTitle: "400 제목", subTitle: "400 부제목" },
+				404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+			},
+			onClose: () => { }
+		}
 	);
-
-	const { mutate: mutate400 } = result400;
-	const { mutate: mutate404 } = result404;
-	const { mutate: mutate500 } = result500;
 
 	return (
 		<div>

--- a/uniro_frontend/src/pages/errorTest.tsx
+++ b/uniro_frontend/src/pages/errorTest.tsx
@@ -21,8 +21,8 @@ export default function Errortest() {
 		undefined,
 		{
 			fallback: {
-				400: { mainTitle: "400 제목", subTitle: "400 부제목" },
-				404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+				400: { mainTitle: "400 제목", subTitle: ["400 부제목"] },
+				404: { mainTitle: "404 제목", subTitle: ["404 부제목"] },
 			},
 			onClose: () => { alert('close callback') }
 		}
@@ -35,8 +35,8 @@ export default function Errortest() {
 		undefined,
 		{
 			fallback: {
-				400: { mainTitle: "400 제목", subTitle: "400 부제목" },
-				404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+				400: { mainTitle: "400 제목", subTitle: ["400 부제목"] },
+				404: { mainTitle: "404 제목", subTitle: ["404 부제목"] },
 			},
 			onClose: () => { }
 		}
@@ -50,8 +50,8 @@ export default function Errortest() {
 		undefined,
 		{
 			fallback: {
-				400: { mainTitle: "400 제목", subTitle: "400 부제목" },
-				404: { mainTitle: "404 제목", subTitle: "404 부제목" },
+				400: { mainTitle: "400 제목", subTitle: ["400 부제목"] },
+				404: { mainTitle: "404 제목", subTitle: ["404 부제목"] },
 			},
 			onClose: () => { }
 		}

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -77,12 +77,14 @@ const NavigationResultPage = () => {
 				},
 				retry: 1,
 				staleTime: 0,
+				gcTime: 0,
 			},
 			{
 				queryKey: [university?.id, "risks"],
 				queryFn: () => getAllRisks(university?.id ?? 1001),
 				retry: 1,
 				staleTime: 0,
+				gcTime: 0,
 			},
 		],
 	});


### PR DESCRIPTION
## #️⃣ 작업 내용

1. useMutationError 리팩토링
2. useMutation -> useMutationError 적용

## 주요 기능

### useMutationError 리팩토링
- #88 에서 생성한 useMutationError를 리팩토링 하였습니다.
```typescript
type Fallback = {
	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
		mainTitle: string;
		subTitle: string[];
	};
};

type HandleError = {
	fallback: Fallback;
	onClose?: () => void;
}

type UseMutationErrorReturn<TData, TError, TVariables, TContext> = [
	React.FC,
	UseMutationResult<TData, TError, TVariables, TContext>
];

export default function useMutationError<TData, TError, TVariables, TContext>(
	options: UseMutationOptions<TData, TError, TVariables, TContext>,
	queryClient?: QueryClient,
	handleError?: HandleError,
): UseMutationErrorReturn<TData, TError, TVariables, TContext> {
	const [isOpen, setOpen] = useState<boolean>(false);
	const result = useMutation<TData, TError, TVariables, TContext>(options, queryClient);

	const { isError, error } = result;

	useEffect(() => {
		setOpen(isError)
	}, [isError])

	const close = () => {
		if (handleError?.onClose) handleError?.onClose();
		setOpen(false);
	}

	const Modal: React.FC = () => {
		if (!isOpen || !handleError || !error) return null;

		const { fallback } = handleError;

		let title: { mainTitle: string, subTitle: string[] } = {
			mainTitle: "",
			subTitle: [],
		}

		if (error instanceof NotFoundError) {
			title = fallback[404] ?? title;
		}
		else if (error instanceof BadRequestError) {
			title = fallback[400] ?? title;
		}
		else throw error;

		return (
			<div className="fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.2)]">
				< div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden" >
					<div className="flex flex-col justify-center space-y-1 py-[25px]">
						<p className="text-kor-body1 font-bold text-system-red">{title.mainTitle}</p>
						<div className="space-y-0">
							{title.subTitle.map((_subtitle, index) =>
								<p key={`error-modal-subtitle-${index}`} className="text-kor-body3 font-regular text-gray-700">{_subtitle}</p>)}
						</div>
					</div>
					<button
						onClick={close}
						className="h-[58px] border-t-[1px] border-gray-200 text-kor-body2 font-semibold active:bg-gray-200"
					>
						확인
					</button>
				</div >
			</div >
		)
	}

	return [Modal, result];
}
```
- fallback으로 보여줄 Modal을 클릭하게 될 경우, 동작이 필요한 경우 (ex. 랜딩으로 이동) 을 고려하여 onClose를 callback으로 받았습니다.
- fallback, onClose로 입력받기보단, 하나의 object로 입력을 받는 것이 코드 가독성에 좋다 판단하여 HandleError 타입을 선언하였습니다.
- HandleError가 존재하는 경우 fallback은 무조건 입력받지만, onClose는 필요시 입력받도록 하였습니다.

-이후 baseFallback으로 Modal을 생성하던 로직을 state를 없애고 rerender시, title을 let으로 선언하여 모달이 재생성이 되도록 하였습니다.
- subTitle을 받는 경우, 줄바꿈이 존재하는 경우가 많이 존재하여, subTitle을 string[]로 받도록 변경하여, 줄 바꿈에 대해서도 subTitle을 렌더링시킬 수 있도록 변경하였습니다.

- useMutation이 적용되었던, reportForm.tsx (불편한 길 제보 폼 페이지)와 reportRoute.tsx (새로운 길 제보 페이지)에 useMutationError로 변경하였습니다.

### reportRisk.tsx
```typescript
const [ErrorModal, { mutate }] = useMutationError({
		mutationFn: ({
			startNodeId,
			coordinates,
			endNodeId,
		}: {
			startNodeId: NodeId;
			endNodeId: NodeId | null;
			coordinates: Coord[];
		}) => postReportRoute(university.id, { startNodeId, endNodeId, coordinates }),
		onSuccess: () => {
                          // 
		},
		onError: () => {
                          // 
		},
	}, undefined, {
		fallback: {
			400: {
				mainTitle: "경로를 생성하는데 실패하였습니다!",
				subTitle: ["선택하신 경로는 생성이 불가능합니다.", "선 위에서 시작하여, 빈 곳을 이어주시기 바랍니다."]
			},
			404: {
				mainTitle: "경로를 생성하는데 실패하였습니다!",
				subTitle: ["선택하신 점이 관리자에 의해 제거되었습니다.", "다른 점을 선택하여 제보 부탁드립니다."]
			}
		}
	});
```
- 기존에 useMutation에 적용되어있던 option들을 그대로 사용하고 fallback에서 400 에러와 404에러에 대해서만 타이틀들을 지정하였습니다.
-

### reportForm.tsx
```typescript
const [ErrorModal, { mutate }] = useMutationError({
		mutationFn: () =>
			postReport(university?.id ?? 1001, routeId, {
				dangerFactors: formData.dangerIssues,
				cautionFactors: formData.cautionIssues,
			}),
		onSuccess: () => {

		},
		onError: () => {

		},
	}, undefined, {
		fallback: {
			400: {
				mainTitle: '불편한 길 제보 실패',
				subTitle: ['잘못된 요청입니다.', '잠시 후 다시 시도 부탁드립니다.'],
			},
			404: {
				mainTitle: '불편한 길 제보 실패',
				subTitle: ['해당 경로는 다른 사용자에 의해 삭제되어,', '지도 화면에서 바로 확인할 수 있어요.']
			}
		},
		onClose: redirectToMap
	});
```
- reportForm페이지의 경우 onClose가 존재하여 실패 모달을 닫을 경우 redirectToMap 함수가 실행됩니다.

### TanStackQuery 길 찾기 결과, gcTime 설정
- 기존에 캐시에 staleTime : 0으로 적용된것에 gcTime : 0을 추가하였습니다.
- 의도한 바는, data 재요청을 의도한 것으로 예상됩니다. @jpark0506 
- [블로그1](https://onetwothreechachacha.tistory.com/160)

- GPT 비교 결과

<h2>✅ staleTime vs gcTime 차이</h2>

| 옵션 | 설명 |
| -- | -- |
| staleTime | 데이터가 "신선한(fresh)" 상태로 유지되는 시간 |
| gcTime | 사용되지 않는 데이터가 캐시에서 제거되기까지의 시간 |

📌 <h2> staleTime </h2>
기본값: 0 (즉시 stale)
이 시간이 지나면 데이터는 stale(오래됨) 상태가 되고, 다음 렌더링 시 다시 refetch됩니다.
staleTime이 크면, 네트워크 요청을 줄이고 캐시된 데이터를 오래 유지할 수 있습니다.
예를 들어 staleTime: 5000을 설정하면, 데이터가 5초 동안 fresh 상태로 유지됩니다.

📌 <h2> gcTime </h2>
기본값: 5 * 60 * 1000 (5분)
캐시에 남아 있는 데이터가 사용되지 않을 때 제거되기까지의 시간
gcTime이 0이면, 데이터가 더 이상 사용되지 않으면 즉시 삭제됨
staleTime과 다르게, 데이터가 오래되었다고 해서 바로 삭제되지는 않음


## 동작확인

### 불편한 길 제보
https://github.com/user-attachments/assets/1191bf65-5a1f-490c-9fd7-5cc90328c757

### 새로운 길 제보
https://github.com/user-attachments/assets/7a96a611-5390-4e4c-b7dd-29c6ab41e492






