### PR TITLE
[UNI-192] QA : 길찾기 로직 예외처리 수정

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -89,6 +89,9 @@ public class RouteCalculationService {
         Node endNode = nodeMap.get(endNodeId);
 
         if(startNode == null){
+            if(buildingRepository.existsByNodeIdAndUnivId(startNodeId, univId)){
+                throw new RouteCalculationException("Unable to find a valid route", ErrorCode.FASTEST_ROUTE_NOT_FOUND);
+            }
             throw new NodeException("Node Not Found", NODE_NOT_FOUND);
         }
         if(endNode == null){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/service/RouteCalculationService.java
@@ -112,6 +112,9 @@ public class RouteCalculationService {
 
         //만약 시작 route가 건물과 이어진 노드라면 해당 route는 결과에서 제외
         if(isBuildingRoute(startRoute)){
+            if(startRoute.getId().equals(endRoute.getId())){
+                throw new RouteCalculationException("Start and end nodes cannot be the same", SAME_START_AND_END_POINT);
+            }
             startNode = startNode.getId().equals(startRoute.getNode1().getId()) ? startRoute.getNode2() : startRoute.getNode1();
             shortestRoutes.remove(0);
         }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
- 길 찾기 로직에서 출발점or도착점이 건물노드이지만, 연결된 간선이 없는 경우 Node Not Found -> Fastest Route Not Found로 변경하였습니다.
- 빌딩과 연결된 루트의 양 끝 노드가 각각 출발점과 도착점인 경우 발생하던 오류를 수정하였습니다.

…-> Fastest Route Not Found로 변경


## 🧪 테스트 결과
- 2번과 36번 노드는 직접 연결되어있으며, 36번노드는 빌딩노드이다.
<img width="662" alt="image" src="https://github.com/user-attachments/assets/e25546a7-29ca-496e-a627-4edf8411985d" />

- 33번 노드 : 아무 노드와도 연결되어있지 않은 빌딩노드
<img width="656" alt="image" src="https://github.com/user-attachments/assets/c691c101-024a-4a3a-af42-30a977cdfa88" />
