### PR TITLE
[UNI-193] 모든 길 조회 로직에서 building route를 따로 제공하는 로직 추가

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/BuildingRouteResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/BuildingRouteResDTO.java
@@ -1,0 +1,27 @@
+package com.softeer5.uniro_backend.route.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Schema(name = "BuildingRouteResDTO", description = "빌딩 루트 정보 DTO")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class BuildingRouteResDTO {
+
+    @Schema(description = "코어 노드 1", example = "32")
+    private final Long coreNode1Id;
+
+    @Schema(description = "코어 노드 2", example = "13")
+    private final Long coreNode2Id;
+
+    @Schema(description = "간선 정보", example = "")
+    private final List<RouteCoordinatesInfoResDTO> routes;
+
+    public static BuildingRouteResDTO of(Long startNode, Long endNode, List<RouteCoordinatesInfoResDTO> routes){
+        return new BuildingRouteResDTO(startNode, endNode, routes);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/route/dto/response/GetAllRoutesResDTO.java
@@ -18,8 +18,11 @@ public class GetAllRoutesResDTO {
     private final List<NodeInfoResDTO> nodeInfos;
     @Schema(description = "루트 정보 (id, startNodeId, endNodeId)", example = "")
     private final List<CoreRouteResDTO> coreRoutes;
+    @Schema(description = "빌딩 루트 정보 (id, startNodeId, endNodeId)", example = "")
+    private final List<BuildingRouteResDTO> buildingRoutes;
 
-    public static GetAllRoutesResDTO of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes){
-        return new GetAllRoutesResDTO(nodeInfos, coreRoutes);
+    public static GetAllRoutesResDTO of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
+                                        List<BuildingRouteResDTO> buildingRoutes){
+        return new GetAllRoutesResDTO(nodeInfos, coreRoutes, buildingRoutes);
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
- 특정 대학의 모든 길 조회 로직에서 building과 연결된 루트도 조회되도록 수정하였습니다. (일반 route들과는 다른 배열에 담아서 제공합니다.)


## 🧪 테스트 결과
<img width="586" alt="image" src="https://github.com/user-attachments/assets/7ae2d25a-1018-424d-9171-9c6fb672813c" />

