### PR TITLE
[UNI-196] feat : 길찾기 결과 경로 없음 에러(422) 화면 및 커스텀 훅 추가

### DIFF
--- a/uniro_frontend/src/components/navigation/navigationDescription.tsx
+++ b/uniro_frontend/src/components/navigation/navigationDescription.tsx
@@ -9,6 +9,8 @@ import { NavigationRouteList } from "../../data/types/route";
 import useRoutePoint from "../../hooks/useRoutePoint";
 import { formatDistance } from "../../utils/navigation/formatDistance";
 import { Link } from "react-router";
+import useUniversityInfo from "../../hooks/useUniversityInfo";
+import { useQueryClient } from "@tanstack/react-query";
 
 const TITLE = "전동휠체어 예상소요시간";
 
@@ -21,12 +23,20 @@ const NavigationDescription = ({ isDetailView, navigationRoute }: TopBarProps) =
 	const { origin, destination } = useRoutePoint();
 	const { totalCost, totalDistance, hasCaution } = navigationRoute;
 
+	const { university } = useUniversityInfo();
+	const queryClient = useQueryClient();
+
+	/** 지도 페이지로 돌아가게 될 경우, 캐시를 삭제하기 */
+	const removeQuery = () => {
+		queryClient.removeQueries({ queryKey: ['fastRoute', university?.id, origin?.nodeId, destination?.nodeId] })
+	}
+
 	return (
 		<div className="w-full p-5">
 			<div className={`w-full flex flex-row items-center ${isDetailView ? "justify-start" : "justify-between"}`}>
 				<span className="text-left text-kor-body3 text-primary-500 flex-1 font-semibold">{TITLE}</span>
 				{!isDetailView && (
-					<Link to="/map">
+					<Link to="/map" onClick={removeQuery}>
 						<Cancel />
 					</Link>
 				)}

--- a/uniro_frontend/src/constant/error.ts
+++ b/uniro_frontend/src/constant/error.ts
@@ -12,8 +12,16 @@ export class BadRequestError extends Error {
 	}
 }
 
+export class UnProcessableError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "UnProcessable";
+	}
+}
+
 export enum ERROR_STATUS {
 	NOT_FOUND = 404,
 	BAD_REQUEST = 400,
 	INTERNAL_ERROR = 500,
+	UNPROCESSABLE = 422,
 }

--- a/uniro_frontend/src/utils/fetch/fetch.ts
+++ b/uniro_frontend/src/utils/fetch/fetch.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, NotFoundError } from "../../constant/error";
+import { BadRequestError, NotFoundError, UnProcessableError } from "../../constant/error";
 
 export default function Fetch() {
 	const baseURL = import.meta.env.VITE_REACT_SERVER_BASE_URL;
@@ -17,6 +17,8 @@ export default function Fetch() {
 				throw new BadRequestError("Bad Request");
 			} else if (response.status === 404) {
 				throw new NotFoundError("Not Found");
+			} else if (response.status === 422) {
+				throw new UnProcessableError("UnProcessable");
 			} else {
 				throw new Error("UnExpected Error");
 			}


### PR DESCRIPTION
## #️⃣ 작업 내용

1. useQueryError 도입 (GET 요청 시, ErrorHandle)
2. 422 에러 추가

## 주요 기능

### 422 에러 추가

- 빠른 길 찾기 기능에서 건물과 건물 사이의 경로를 탐색할 수 없는 경우 422 에러가 return 되어 추가하였습니다.

### useQueryError 도입

- 빠른 길 찾기 422에러가 발생한 경우, 사용자에게 경로를 찾을 수없다는 모달을 제공하기 위해 useQueryError를 도입하였습니다.
- #88 에서 생성한 useMutationError와 동일한 형태로 구현하였습니다.

```typescript
import { QueryClient, useQuery, UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
import { NotFoundError, BadRequestError, ERROR_STATUS, UnProcessableError } from "../constant/error";
import { useEffect, useState } from "react";

type Fallback = {
	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]?: {
		mainTitle: string;
		subTitle: string[];
	};
};

type HandleError = {
	fallback: Fallback;
	onClose?: () => void;
}

type UseQueryErrorReturn<TData, TError> = [
	React.FC,
	UseQueryResult<TData, TError>
];

export default function useQueryError<TQueryFnData, TError, TData>(
	options: UseQueryOptions<TQueryFnData, TError, TData>,
	queryClient?: QueryClient,
	handleSuccess?: () => void,
	handleError?: HandleError,
): UseQueryErrorReturn<TData, TError> {
	const [isOpen, setOpen] = useState<boolean>(false);
	const result = useQuery<TQueryFnData, TError, TData, readonly unknown[]>(options, queryClient);

	const { isError, error, status } = result;

	useEffect(() => {
		setOpen(isError)
	}, [isError])

	/** 페이지 이동하여도 status는 success로 남아있으므로 필요시, removeQueries하여 캐시 삭제 */
	/** 추가적인 로직 고민하기 */
	useEffect(() => {
		if (status === "success" && handleSuccess) handleSuccess();
	}, [status])

	const close = () => {
		if (handleError?.onClose) handleError?.onClose();
		setOpen(false);
	}

	const Modal: React.FC = () => {
		if (!isOpen || !handleError || !error) return null;

		const { fallback } = handleError;

		let title: { mainTitle: string, subTitle: string[] } = {
			mainTitle: "",
			subTitle: [],
		}

		if (error instanceof NotFoundError) {
			title = fallback[404] ?? title;
		}
		else if (error instanceof BadRequestError) {
			title = fallback[400] ?? title;
		}
		else if (error instanceof UnProcessableError) {
			title = fallback[422] ?? title;
		}

		else throw error;

		return (
			<div>
				<div>
					<div>
						<p>{title.mainTitle}</p>
						<div>
							{title.subTitle.map((_subtitle, index) =>
								<p key={`error-modal-subtitle-${index}`} className="text-kor-body3 font-regular text-gray-700">{_subtitle}</p>)}
						</div>
					</div>
					<button
						onClick={close}
					>
						확인
					</button>
				</div >
			</div >
		)
	}

	return [Modal, result];
}
```

- useMutationError와 차이점은 useQuery를 사용하며, handleSuccess를 사용한다는 것입니다.

## 트러블 슈팅

```typescript
const [FailModal, { status, data, refetch: findFastRoute }] = useQueryError({
		queryKey: ['fastRoute', university.id, origin?.nodeId, destination?.nodeId],
		queryFn: () => getNavigationResult(university.id, origin ? origin?.nodeId : -1, destination ? destination?.nodeId : -1),
		enabled: false,
		retry: 0,
	},
		undefined,
		() => { navigate('/result') },
		{
			fallback: {
				400: {
					mainTitle: "잘못된 요청입니다.", subTitle: ["새로고침 후 다시 시도 부탁드립니다."]
				},
				404: {
					mainTitle: "해당 경로를 찾을 수 없습니다.", subTitle: ["해당 건물이 길이랑 연결되지 않았습니다."]
				},
				422: {
					mainTitle: "해당 경로를 찾을 수 없습니다.", subTitle: ["위험 요소 버튼을 클릭하여,", "통행할 수 없는 원인을 파악하실 수 있습니다."]
				}
			}
		}
	)
```


- 다음과 같이, /map 에서 길찾기 버튼을 클릭하여 fetch를 하기 위해서 enabled 속성을 부여하였습니다.
- fetch 성공 시, useEffect에서 status가  navigate('/result')로 넘어가게 됩니다. 
- 그런데, result 페이지에서 map 페이지로 다시 이동하게 될 경우, fetch 성공 status가 아직 success로 남아있어서 다시 /result 페이지로 이동되는 반복이동 문제가 발생하였습니다.
```
/** 지도 페이지로 돌아가게 될 경우, 캐시를 삭제하기 */
	const removeQuery = () => {
		queryClient.removeQueries({ queryKey: ['fastRoute', university?.id, origin?.nodeId, destination?.nodeId] })
	}

	return (
					<Link to="/map" onClick={removeQuery}>
						<Cancel />
					</Link>
        )
```
- 이 문제를 해결하기 위해, Link 태그에 이벤트로 removeQuries를 도입하여, /map 페이지에서 status가 pending으로 남게 되었습니다.
- 기존에 cache된 데이터를 /result 페이지에서 사용하였고 지도로 이동(캐시된 데이터를 사용하지 않음)이 되기 때문에 remove를 해도 괜찮다고 결론을 내렸습니다.


## 동작확인

### 422 에러 화면

https://github.com/user-attachments/assets/d3b6b632-10f0-49fd-970d-ddffd7f9b130

## 연관 이슈
UNI-197, UNI-198
