### PR TITLE
[UNI-195] Post 요청에 대한 debounce 적용

### DIFF
--- a/uniro_frontend/src/hooks/useDebounceMutation.tsx
+++ b/uniro_frontend/src/hooks/useDebounceMutation.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, useMutation, UseMutationOptions } from "@tanstack/react-query";
+import { useCallback, useRef } from "react";
+
+export function useDebounceMutation<TData, TError, TVariables, TContext>(
+	options: UseMutationOptions<TData, TError, TVariables, TContext>,
+	delay: number,
+	immediate: boolean,
+	queryClient?: QueryClient,
+) {
+	const mutation = useMutation<TData, TError, TVariables, TContext>(options, queryClient);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const debouncedMutate = useCallback(
+		(...args: Parameters<typeof mutation.mutate>) => {
+			const later = () => {
+				timeoutRef.current = null;
+				if (!immediate) {
+					mutation.mutate(...args);
+				}
+			};
+
+			const callNow = immediate && !timeoutRef.current;
+
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+			timeoutRef.current = setTimeout(later, delay);
+
+			if (callNow) {
+				mutation.mutate(...args);
+			}
+		},
+		[mutation.mutate, delay, immediate],
+	);
+
+	return {
+		...mutation,
+		mutate: debouncedMutate,
+	};
+}

--- a/uniro_frontend/src/hooks/useMutationError.tsx
+++ b/uniro_frontend/src/hooks/useMutationError.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, useMutation, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
 import { NotFoundError, BadRequestError, ERROR_STATUS } from "../constant/error";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useDebounceMutation } from "./useDebounceMutation";
 
 type Fallback = {
 	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
@@ -12,11 +13,11 @@ type Fallback = {
 type HandleError = {
 	fallback: Fallback;
 	onClose?: () => void;
-}
+};
 
 type UseMutationErrorReturn<TData, TError, TVariables, TContext> = [
 	React.FC,
-	UseMutationResult<TData, TError, TVariables, TContext>
+	UseMutationResult<TData, TError, TVariables, TContext>,
 ];
 
 export default function useMutationError<TData, TError, TVariables, TContext>(
@@ -25,45 +26,49 @@ export default function useMutationError<TData, TError, TVariables, TContext>(
 	handleError?: HandleError,
 ): UseMutationErrorReturn<TData, TError, TVariables, TContext> {
 	const [isOpen, setOpen] = useState<boolean>(false);
-	const result = useMutation<TData, TError, TVariables, TContext>(options, queryClient);
+	const result = useDebounceMutation<TData, TError, TVariables, TContext>(options, 1000, true, queryClient);
 
 	const { isError, error } = result;
 
 	useEffect(() => {
-		setOpen(isError)
-	}, [isError])
+		setOpen(isError);
+	}, [isError]);
 
 	const close = () => {
 		if (handleError?.onClose) handleError?.onClose();
 		setOpen(false);
-	}
+	};
 
 	const Modal: React.FC = () => {
 		if (!isOpen || !handleError || !error) return null;
 
 		const { fallback } = handleError;
 
-		let title: { mainTitle: string, subTitle: string[] } = {
+		let title: { mainTitle: string; subTitle: string[] } = {
 			mainTitle: "",
 			subTitle: [],
-		}
+		};
 
 		if (error instanceof NotFoundError) {
 			title = fallback[404] ?? title;
-		}
-		else if (error instanceof BadRequestError) {
+		} else if (error instanceof BadRequestError) {
 			title = fallback[400] ?? title;
-		}
-		else throw error;
+		} else throw error;
 
 		return (
 			<div className="fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.2)]">
-				< div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden" >
+				<div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden">
 					<div className="flex flex-col justify-center space-y-1 py-[25px]">
 						<p className="text-kor-body1 font-bold text-system-red">{title.mainTitle}</p>
 						<div className="space-y-0">
-							{title.subTitle.map((_subtitle, index) =>
-								<p key={`error-modal-subtitle-${index}`} className="text-kor-body3 font-regular text-gray-700">{_subtitle}</p>)}
+							{title.subTitle.map((_subtitle, index) => (
+								<p
+									key={`error-modal-subtitle-${index}`}
+									className="text-kor-body3 font-regular text-gray-700"
+								>
+									{_subtitle}
+								</p>
+							))}
 						</div>
 					</div>
 					<button
@@ -72,10 +77,10 @@ export default function useMutationError<TData, TError, TVariables, TContext>(
 					>
 						확인
 					</button>
-				</div >
-			</div >
-		)
-	}
+				</div>
+			</div>
+		);
+	};
 
 	return [Modal, result];
 }

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -113,33 +113,36 @@ const ReportForm = () => {
 		}
 	};
 
-	const [ErrorModal, { mutate }] = useMutationError({
-		mutationFn: () =>
-			postReport(university?.id ?? 1001, routeId, {
-				dangerFactors: formData.dangerIssues,
-				cautionFactors: formData.cautionIssues,
-			}),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
-			openSuccess();
-		},
-		onError: () => {
-			setErrorTitle("제보에 실패하였습니다");
-		},
-	}, undefined, {
-		fallback: {
-			400: {
-				mainTitle: '불편한 길 제보 실패',
-				subTitle: ['잘못된 요청입니다.', '잠시 후 다시 시도 부탁드립니다.'],
+	const [ErrorModal, { mutate, status }] = useMutationError(
+		{
+			mutationFn: () =>
+				postReport(university?.id ?? 1001, routeId, {
+					dangerFactors: formData.dangerIssues,
+					cautionFactors: formData.cautionIssues,
+				}),
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
+				openSuccess();
 			},
-			404: {
-				mainTitle: '불편한 길 제보 실패',
-				subTitle: ['해당 경로는 다른 사용자에 의해 삭제되어,', '지도 화면에서 바로 확인할 수 있어요.']
-			}
+			onError: () => {
+				setErrorTitle("제보에 실패하였습니다");
+			},
 		},
-		onClose: redirectToMap
-
-	});
+		undefined,
+		{
+			fallback: {
+				400: {
+					mainTitle: "불편한 길 제보 실패",
+					subTitle: ["잘못된 요청입니다.", "잠시 후 다시 시도 부탁드립니다."],
+				},
+				404: {
+					mainTitle: "불편한 길 제보 실패",
+					subTitle: ["해당 경로는 다른 사용자에 의해 삭제되어,", "지도 화면에서 바로 확인할 수 있어요."],
+				},
+			},
+			onClose: redirectToMap,
+		},
+	);
 
 	return (
 		<div className="flex flex-col h-dvh w-full max-w-[450px] mx-auto relative">
@@ -158,8 +161,11 @@ const ReportForm = () => {
 				/>
 			</div>
 			<div className="mb-4 w-full px-4">
-				<Button onClick={mutate} variant={disabled ? "disabled" : "primary"}>
-					제보하기
+				<Button
+					onClick={mutate}
+					variant={status === "pending" || status === "success" || disabled ? "disabled" : "primary"}
+				>
+					{status === "pending" ? "제보하는 중.." : "제보하기"}
 				</Button>
 			</div>
 			<SuccessModal>

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -254,11 +254,6 @@ export default function ReportRoutePage() {
 			endNodeId: "nodeId" in lastPoint ? lastPoint.nodeId : null,
 			coordinates: subNodes,
 		});
-		mutate({
-			startNodeId: originPoint.current.point.nodeId,
-			endNodeId: "nodeId" in lastPoint ? lastPoint.nodeId : null,
-			coordinates: subNodes,
-		});
 	};
 
 	const drawRoute = (coreRouteList: CoreRoutesList) => {


### PR DESCRIPTION
## #️⃣ 작업 내용

1. Post 요청에 대해 debounce를 적용했습니다.
2. debounce를 custom hook으로 변경해, 동현님이 제작한 useMutationError hook에 병합했습니다.

## 장애 리포트(백엔드 죄송합니다..)

### 문제 상황
제작한 debounce를 검증하기 위해 mock과 console을 활용해 테스트하다가, 길 생성 API의 실제 테스트를 하기 위해서 실제 API로 따닥 테스트를 했습니다.
그 결과, 백엔드의 길 조회 API에 장애를 일으켜 잠깐 백엔드 개발 서버의 응답이 느려지는 결과가 있었습니다. 알고보니, debounce를 테스트하고 있었던 개발 환경이 아니라, debounce가 배포되지 않은 배포 사이트에서 테스트하고 있었습니다.

### 해결 방법
따닥 테스트로 추가된 똑같은 두가지 길을 제거하고, 서버를 재배포해 해결되었습니다.

### 깨달은 점
멘토님과 팀원들과 이야기하며, 현업에서는 절대 이런 식으로 테스트 안된다는 것을 깨달았고, 다음에는 꼭 백엔드와 협의하고, 안전한 상황에서 테스트를 할 수 있도록 하려고 합니다.
또한, 테스트 코드도 이런 부분들은 꼭 작성해야 한다는 것을 깨달았고, 개발환경에서 테스트를 하고 있는지도 꼭 확인해보겠습니다.

## 이 기능을 제작한 이유

백엔드가 QA에서 말씀해주시기도 해서 도입한 이유도 있지만, 저는 이전 프로젝트에서 같은 요청을 빠른 따닥(?)으로 중복 요청해 게시물이 여러개가 올라가는 경험을 했었습니다. 그럴 때마다 해결할 때 라이브러리를 사용하거나,loading(pending) 상태일 때 버튼을 비활성화하는 방법을 사용했습니다.
하지만 state를 변경하면서 loading이나 pending 상태로 전환되는 그 찰나에 작동하는 따딱이 있었고, 그런 부분들을 보완하지 못해 항상 아쉬웠습니다. 이런 이유로 이번 프로젝트를 통해 꼭 그런 동작을 막아보고 싶었습니다.

## 주요 기능

debounce 코드를 제작했습니다.
기초가 된 debounce 코드는 다음과 같이 제작했습니다.
```typescript
// this context는 제외했습니다.
function debounce(func, time, isImmediate){
    let timeout = null;
    return function(args){
  
            const later = () => {
                       timeout = null;
                       if(!immediate){
                              return func(...args);
                        }
            const callNow = immediate && !timeout;
            if(timeout) clearTimeout(timeout);
            timeout = setTimeout(later, timeout);
            
            if(callNow){
                       func(...args);
            }
}
```
동작 방식(버튼 클릭 기준)
버튼을 클릭할 때의 조건은, time = 1000, 즉시 실행되어야하기 때문에 isImmediate를 true로 놓는 시나리오입니다.

1. 첫번째 실행
-> later 함수를 선언 받고, callNow가 true가 됩니다(timeout이 선언된 것이 없고, immediate는 true이기 때문에)
-> timeout이 없기 때문에, clearTimeout을 넘어간 이후, later를 callback으로 넣은 새로운 timeout을 만들어줍니다.
-> callNow가 true였기 때문에, 넣었던 함수를 인자들과 함께 실행해줍니다.
2. 따닥 실행
-> later 함수를 다시 선언받고,  callNow는 false가 됩니다.
-> timeout을 클리어 해준 이후, 다시 later의 Timeout을 선언해줍니다.
-> later의 시간이 이미 지난 시간 + time 만큼 지연되게 됩니다.
=> 결국 func는 처음 한번만 실행되게 되고, time 시간안에 debounce에 들어오게 되면 이미 실행되고 있는 timeout closure가 있기 때문에 아무 동작도 못하게 됩니다. (만약 실행을 지연시켜야 한다면, isImmediate = false를 통해 later가 debounce를 그만 실행할 때까지 지연이 가능합니다.)

이런 동작으로 인해, 만약 state가 바뀌는데 걸리는 시간이 50ms정도 걸린다면(혹은 컴포넌트가 무거워 그 이상의 시간이 걸린다면) debounce로 원하는 동작을 실행후 다시 실행을 막거나, 그만할 때까지 막는 동작을 할 수 있습니다.

이 방식을 useMutation과 결합해서 사용 방법을 찾아보았습니다.
맨 처음에는 mutate를 실행하는 함수 자체를 debounce로 감싸는 시도를 해보았습니다.
const reportRoute = debounce(()=>{}, 1000, true);
이런 시도가 잘 되었지만, reportRoute를 실행할 때 리렌더링이 발생해 매번 다른 timeout을 바라보는 문제가 생겼고, useCallback 사용하는 변수들로 감싸주어 참조를 통제해야하는 현상이 발생했습니다. (closure를 활용해야하기 때문에).
useCallback을 사용하면서 두가지 사고의 흐름이 다음과 같았습니다.
1. useCallback을 둘러싸야한다면, debounce를 react의 생명주기와 맞게 custom hook으로 변형할 수 있지 않을까?
2. 동현님이 만들어놓은 useMutationError를 사용하는 메서드들이 모두 debounce를 사용해야한다면, 비슷하게 useMutation을 override(?) 하는 방식으로 useDebounceMutation을 구현할 수 있지 않을까 생각했습니다.

그래서 나온 결과물이 다음과 같습니다.
```typescript
export function useDebounceMutation<TData, TError, TVariables, TContext>(
	options: UseMutationOptions<TData, TError, TVariables, TContext>,
	delay: number,
	immediate: boolean,
	queryClient?: QueryClient,
) {
	const mutation = useMutation<TData, TError, TVariables, TContext>(options, queryClient);
	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

	const debouncedMutate = useCallback(
		(...args: Parameters<typeof mutation.mutate>) => {
			const later = () => {
				timeoutRef.current = null;
				if (!immediate) {
					mutation.mutate(...args);
				}
			};

			const callNow = immediate && !timeoutRef.current;

			if (timeoutRef.current) {
				clearTimeout(timeoutRef.current);
			}
			timeoutRef.current = setTimeout(later, delay);

			if (callNow) {
				mutation.mutate(...args);
			}
		},
		[mutation.mutate, delay, immediate],
	);

	return {
		...mutation,
		mutate: debouncedMutate,
	};
}

```
useRef가 HTMLElement를 저장하는 것뿐만 아니라, 이런 식으로 값이나 참조를 유지할 수 있는 용도로도 사용이 가능하다고 해서, 적용해보았습니다.
형태는 유사하지만, react의 동작에 맞춰 여러가지 hook을 사용했습니다.

이 hook을 기존에 useMutationError hook가 이런 방식으로 결합했습니다.
```typescript
export default function useMutationError<TData, TError, TVariables, TContext>(
	options: UseMutationOptions<TData, TError, TVariables, TContext>,
	queryClient?: QueryClient,
	handleError?: HandleError,
): UseMutationErrorReturn<TData, TError, TVariables, TContext> {
	const [isOpen, setOpen] = useState<boolean>(false);
	const result = useDebounceMutation<TData, TError, TVariables, TContext>(options, 1000, true, queryClient);
```

이후 백엔드 팀원들과 동현님과 정상동작을 N번정도 확인한 이후에,, PR을 올리게 되었습니다 감사합니다 팀원 여러분..!!!

## 동작확인

동작을 제작한 영상을 녹화해 올려놓았었는데, 확인해보니 다른 영상을 올렸습니다. 내일 아침에 원래 녹화한 영상으로 바꿔놓겠습니다.
