### PR TITLE
[UNI-201] fix : (QA 문제 해결) 지도 메인페이지 줌 아웃시 위험 주의 비활성화 로직 제거 / 불편한 길 반영 시, 잔여 캐시로 인한 제보 확인 불가 해결 / 지도 제스쳐 핸들링 방식 변경 / 위험 주의 요소 여러개인 경우 애니메이션 추가

### DIFF
--- a/uniro_frontend/src/components/map/mapMarkers.tsx
+++ b/uniro_frontend/src/components/map/mapMarkers.tsx
@@ -1,5 +1,6 @@
 import { Markers } from "../../constant/enum/markerEnum";
 import { MarkerTypes } from "../../data/types/enum";
+import { animate } from "framer-motion";
 
 const markerImages = import.meta.glob("/src/assets/markers/*.svg", { eager: true });
 
@@ -36,6 +37,83 @@ function createTextElement(type: MarkerTypes, title: string): HTMLElement {
 			return markerTitle;
 	}
 }
+
+
+
+
+function createAnimatedTextElement(type: MarkerTypes, title: string[]): HTMLElement {
+	const markerTitle = document.createElement("div");
+
+	const _titles = [...title, title[0]]
+
+	// 각 title을 factorTitle로 만들어서 markerTitle에 추가
+	const elements: HTMLElement[] = [];
+	for (let _title of _titles) {
+		const factorTitle = document.createElement("p");
+		factorTitle.className = 'block w-[128px] h-[22px] mb-4';
+		factorTitle.innerText = _title;
+		markerTitle.appendChild(factorTitle);
+		elements.push(factorTitle);
+	}
+
+	switch (type) {
+		case Markers.CAUTION:
+			markerTitle.className =
+				"overflow-hidden w-[160px] h-[38px] py-2 px-4 mb-2 text-kor-body3 font-semibold text-gray-100 bg-system-orange text-center rounded-200";
+			break;
+		case Markers.DANGER:
+			markerTitle.className =
+				"overflow-hidden w-[160px] h-[38px] py-2 px-4 mb-2 text-kor-body3 font-semibold text-gray-100 bg-system-red text-center rounded-200";
+			break;
+		case Markers.BUILDING:
+			markerTitle.className =
+				"py-1 px-3 text-kor-caption font-medium text-gray-100 bg-gray-900 text-center rounded-200";
+			break;
+		case Markers.SELECTED_BUILDING:
+			markerTitle.className =
+				"py-1 px-3 text-kor-caption font-medium text-gray-100 bg-primary-500 text-center rounded-200";
+			break;
+		case Markers.ORIGIN:
+			markerTitle.className =
+				"py-1 px-3 text-kor-caption font-medium text-gray-100 bg-primary-500 text-center rounded-200";
+			break;
+		case Markers.DESTINATION:
+			markerTitle.className =
+				"py-1 px-3 text-kor-caption font-medium text-gray-100 bg-primary-500 text-center rounded-200";
+			break;
+		default:
+			break;
+
+	}
+
+	const len = _titles.length;
+
+	if (len > 2) {
+		for (let i = 1; i < len; i++) {
+			elements.forEach((el, index) => {
+				setTimeout(() => {
+					animate(el, {
+						y: [-38 * (i - 1), -38 * i]
+					}, {
+						duration: 0.5,
+					});
+
+					if (i === len - 1) {
+						setTimeout(() => {
+							animate(el, {
+								y: [-38 * (len - 1), 0]
+							},
+								{ duration: 0 })
+						}, 1000)
+					}
+				}, 1000 * i);
+			});
+		}
+	}
+
+	return markerTitle;
+}
+
 
 function getImage(type: MarkerTypes): string {
 	return (markerImages[`/src/assets/markers/${type}.svg`] as { default: string })?.default;
@@ -99,7 +177,7 @@ export default function createMarkerElement({
 }: {
 	type: MarkerTypes;
 	className?: string;
-	title?: string;
+	title?: string | string[];
 	hasTopContent?: boolean;
 	hasAnimation?: boolean;
 	number?: number;
@@ -113,8 +191,10 @@ export default function createMarkerElement({
 	const markerImage = createImageElement(type);
 
 	if (title) {
-		const markerTitle = createTextElement(type, title);
+		const markerTitle = createTextElement(type, title as string);
 		if (hasTopContent) {
+
+			const markerTitle = createAnimatedTextElement(type, title as string[]);
 			container.appendChild(markerTitle);
 			container.appendChild(markerImage);
 			return attachAnimation(container, hasAnimation);

--- a/uniro_frontend/src/hooks/useMutationError.tsx
+++ b/uniro_frontend/src/hooks/useMutationError.tsx
@@ -3,7 +3,7 @@ import { NotFoundError, BadRequestError, ERROR_STATUS } from "../constant/error"
 import { useEffect, useState } from "react";
 
 type Fallback = {
-	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
+	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]?: {
 		mainTitle: string;
 		subTitle: string[];
 	};

--- a/uniro_frontend/src/map/initializer/googleMapInitializer.ts
+++ b/uniro_frontend/src/map/initializer/googleMapInitializer.ts
@@ -1,3 +1,4 @@
+import { HanyangUniversityBounds } from "../../constant/bounds";
 import { HanyangUniversity } from "../../constant/university";
 
 import loadGoogleMapsLibraries from "../loader/googleMapLoader";
@@ -28,7 +29,7 @@ export const initializeMap = async (
 		draggable: true,
 		scrollwheel: true,
 		disableDoubleClickZoom: false,
-		gestureHandling: "auto",
+		gestureHandling: "greedy",
 		clickableIcons: false,
 		disableDefaultUI: true,
 		// restriction: {

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -357,17 +357,15 @@ export default function MapPage() {
 		} else {
 			if (isSelect) {
 				if (marker.type === Markers.DANGER) {
-					const key = marker.factors && (marker.factors[0] as DangerIssueType);
 					marker.element.content = createMarkerElement({
 						type: marker.type,
-						title: key && DangerIssue[key],
+						title: (marker.factors as DangerIssueType[]).map(key => DangerIssue[key]),
 						hasTopContent: true,
 					});
 				} else if (marker.type === Markers.CAUTION) {
-					const key = marker.factors && (marker.factors[0] as CautionIssueType);
 					marker.element.content = createMarkerElement({
 						type: marker.type,
-						title: key && CautionIssue[key],
+						title: (marker.factors as CautionIssueType[]).map(key => CautionIssue[key]),
 						hasTopContent: true,
 					});
 				}

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -468,7 +468,6 @@ export default function MapPage() {
 
 		if (prevZoom.current >= 17 && zoom <= 16) {
 			if (isCautionAcitve) {
-				setIsCautionActive(false);
 				toggleMarkers(
 					false,
 					cautionMarkers.map((marker) => marker.element),
@@ -476,7 +475,6 @@ export default function MapPage() {
 				);
 			}
 			if (isDangerAcitve) {
-				setIsDangerActive(false);
 				toggleMarkers(
 					false,
 					dangerMarkers.map((marker) => marker.element),
@@ -487,6 +485,21 @@ export default function MapPage() {
 			toggleMarkers(true, universityMarker ? [universityMarker] : [], map);
 			toggleMarkers(false, _buildingMarkers, map);
 		} else if (prevZoom.current <= 16 && zoom >= 17) {
+			if (isCautionAcitve) {
+				toggleMarkers(
+					true,
+					cautionMarkers.map((marker) => marker.element),
+					map,
+				);
+			}
+			if (isDangerAcitve) {
+				toggleMarkers(
+					true,
+					dangerMarkers.map((marker) => marker.element),
+					map,
+				);
+			}
+
 			toggleMarkers(false, universityMarker ? [universityMarker] : [], map);
 			toggleMarkers(true, _buildingMarkers, map);
 		}

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -39,8 +39,6 @@ const ReportForm = () => {
 
 	useRedirectUndefined<University | RouteId | undefined>([university, routeId]);
 
-	console.log(routeId);
-
 	if (!routeId) return;
 
 	const { data } = useSuspenseQuery({
@@ -120,7 +118,7 @@ const ReportForm = () => {
 				cautionFactors: formData.cautionIssues,
 			}),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
+			queryClient.removeQueries({ queryKey: [university?.id ?? 1001, 'risks'] });
 			openSuccess();
 		},
 		onError: () => {

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -233,17 +233,15 @@ export default function ReportRiskPage() {
 
 		if (isSelect) {
 			if (marker.type === Markers.DANGER) {
-				const key = marker.factors && (marker.factors[0] as DangerIssueType);
 				marker.element.content = createMarkerElement({
 					type: marker.type,
-					title: key && DangerIssue[key],
+					title: (marker.factors as DangerIssueType[]).map(key => DangerIssue[key]),
 					hasTopContent: true,
 				});
 			} else if (marker.type === Markers.CAUTION) {
-				const key = marker.factors && (marker.factors[0] as CautionIssueType);
 				marker.element.content = createMarkerElement({
 					type: marker.type,
-					title: key && CautionIssue[key],
+					title: (marker.factors as CautionIssueType[]).map(key => CautionIssue[key]),
 					hasTopContent: true,
 				});
 			}

--- a/uniro_frontend/src/utils/fetch/fetch.ts
+++ b/uniro_frontend/src/utils/fetch/fetch.ts
@@ -4,6 +4,8 @@ export default function Fetch() {
 	const baseURL = import.meta.env.VITE_REACT_SERVER_BASE_URL;
 
 	const get = async <T>(url: string, params?: Record<string, string | number | boolean>): Promise<T> => {
+		console.log("GET", url);
+
 		const paramsURL = new URLSearchParams(
 			Object.entries(params || {}).map(([key, value]) => [key, String(value)]),
 		).toString();


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 지도 메인페이지 줌 아웃시 위험 주의 비활성화 로직 제거
2. 불편한 길 반영 시, 잔여 캐시로 인한 제보 확인 불가 해결
3. 지도 제스쳐 핸들링 방식 변경
4. 위험 주의 요소 여러개인 경우 애니메이션 추가

## 버그 수정 및 요청 사항 반영

### 지도 메인페이지 줌 아웃시 위험 주의 비활성화 로직 제거
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/f92d9dd5-6c86-4af9-90c8-579207a2afeb">  | <video src="https://github.com/user-attachments/assets/10a30099-0b02-4f33-836b-de59fb75a71a">|



### 불편한 길 반영 시, 잔여 캐시로 인한 제보 확인 불가 해결
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/6cfff247-186a-4654-abcf-a934652f5e56">  | <video src="https://github.com/user-attachments/assets/c9491101-9d48-4491-9060-fbfe69da0d4c">|

## 신규 기능

### 위험 주의 요소 여러개인 경우 애니메이션 추가
| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/fb54be9c-a033-4cc4-a40b-5f4926292d7d">  | <video src="https://github.com/user-attachments/assets/0915706e-9d5e-485c-92f0-64ed71b8fa31">|









## 연관된 이슈
UNI-202, UNI-203, UNI-204, UNI-205