### PR TITLE
[UNI-207] fix : 일부 모바일 브라우저에서 form이 x축으로 스크롤이 가능한 문제

### DIFF
--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -145,7 +145,7 @@ const ReportForm = () => {
 		<div className="flex flex-col h-dvh w-full max-w-[450px] mx-auto relative">
 			<ReportTitle reportMode={reportMode!} />
 			<ReportDivider />
-			<div className="flex-1 overflow-y-auto overflow-x-hidden">2
+			<div className="flex-1 overflow-y-auto overflow-x-hidden">
 				<PrimaryForm
 					reportMode={reportMode!}
 					passableStatus={formData.passableStatus}

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -145,7 +145,7 @@ const ReportForm = () => {
 		<div className="flex flex-col h-dvh w-full max-w-[450px] mx-auto relative">
 			<ReportTitle reportMode={reportMode!} />
 			<ReportDivider />
-			<div className="flex-1 overflow-y-auto">
+			<div className="flex-1 overflow-y-auto overflow-x-hidden">2
 				<PrimaryForm
 					reportMode={reportMode!}
 					passableStatus={formData.passableStatus}


### PR DESCRIPTION
## #️⃣ 작업 내용

1.  일부 모바일 브라우저에서 form이 x축으로 스크롤이 가능한 문제를 해결했습니다.(overflow-x-hidden 추가)

## 동작확인

### AS IS
https://github.com/user-attachments/assets/29b96b86-f4df-4dd7-85ea-215a4a672c98

### TO BE
https://github.com/user-attachments/assets/07e84b2d-dc5f-45de-84e0-ae44ab007946