### PR TITLE
[UNI-201] fix : (QA 수정 사항) 지도 메인페이지 줌 아웃시 위험 주의 비활성화 로직 제거 / 불편한 길 반영 시, 캐시 초기화 적용 / 지도 제스쳐 핸들링 방식 변경

### DIFF
--- a/uniro_frontend/src/hooks/useMutationError.tsx
+++ b/uniro_frontend/src/hooks/useMutationError.tsx
@@ -3,7 +3,7 @@ import { NotFoundError, BadRequestError, ERROR_STATUS } from "../constant/error"
 import { useEffect, useState } from "react";
 
 type Fallback = {
-	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]: {
+	[K in Exclude<ERROR_STATUS, ERROR_STATUS.INTERNAL_ERROR>]?: {
 		mainTitle: string;
 		subTitle: string[];
 	};
@@ -12,11 +12,11 @@ type Fallback = {
 type HandleError = {
 	fallback: Fallback;
 	onClose?: () => void;
-}
+};
 
 type UseMutationErrorReturn<TData, TError, TVariables, TContext> = [
 	React.FC,
-	UseMutationResult<TData, TError, TVariables, TContext>
+	UseMutationResult<TData, TError, TVariables, TContext>,
 ];
 
 export default function useMutationError<TData, TError, TVariables, TContext>(
@@ -30,40 +30,44 @@ export default function useMutationError<TData, TError, TVariables, TContext>(
 	const { isError, error } = result;
 
 	useEffect(() => {
-		setOpen(isError)
-	}, [isError])
+		setOpen(isError);
+	}, [isError]);
 
 	const close = () => {
 		if (handleError?.onClose) handleError?.onClose();
 		setOpen(false);
-	}
+	};
 
 	const Modal: React.FC = () => {
 		if (!isOpen || !handleError || !error) return null;
 
 		const { fallback } = handleError;
 
-		let title: { mainTitle: string, subTitle: string[] } = {
+		let title: { mainTitle: string; subTitle: string[] } = {
 			mainTitle: "",
 			subTitle: [],
-		}
+		};
 
 		if (error instanceof NotFoundError) {
 			title = fallback[404] ?? title;
-		}
-		else if (error instanceof BadRequestError) {
+		} else if (error instanceof BadRequestError) {
 			title = fallback[400] ?? title;
-		}
-		else throw error;
+		} else throw error;
 
 		return (
 			<div className="fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.2)] z-100">
-				< div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden" >
+				<div className="w-full max-w-[365px] flex flex-col bg-gray-100 rounded-400 overflow-hidden">
 					<div className="flex flex-col justify-center space-y-1 py-[25px]">
 						<p className="text-kor-body1 font-bold text-system-red">{title.mainTitle}</p>
 						<div className="space-y-0">
-							{title.subTitle.map((_subtitle, index) =>
-								<p key={`error-modal-subtitle-${index}`} className="text-kor-body3 font-regular text-gray-700">{_subtitle}</p>)}
+							{title.subTitle.map((_subtitle, index) => (
+								<p
+									key={`error-modal-subtitle-${index}`}
+									className="text-kor-body3 font-regular text-gray-700"
+								>
+									{_subtitle}
+								</p>
+							))}
 						</div>
 					</div>
 					<button
@@ -72,10 +76,10 @@ export default function useMutationError<TData, TError, TVariables, TContext>(
 					>
 						확인
 					</button>
-				</div >
-			</div >
-		)
-	}
+				</div>
+			</div>
+		);
+	};
 
 	return [Modal, result];
 }

--- a/uniro_frontend/src/map/initializer/googleMapInitializer.ts
+++ b/uniro_frontend/src/map/initializer/googleMapInitializer.ts
@@ -28,7 +28,7 @@ export const initializeMap = async (
 		draggable: true,
 		scrollwheel: true,
 		disableDoubleClickZoom: false,
-		gestureHandling: "auto",
+		gestureHandling: "greedy",
 		clickableIcons: false,
 		disableDefaultUI: true,
 		// restriction: {

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -73,28 +73,39 @@ export default function MapPage() {
 	const navigate = useNavigate();
 	if (!university) return;
 
-	const [FailModal, { status, data, refetch: findFastRoute }] = useQueryError({
-		queryKey: ['fastRoute', university.id, origin?.nodeId, destination?.nodeId],
-		queryFn: () => getNavigationResult(university.id, origin ? origin?.nodeId : -1, destination ? destination?.nodeId : -1),
-		enabled: false,
-		retry: 0,
-	},
+	const [FailModal, { status, data, refetch: findFastRoute }] = useQueryError(
+		{
+			queryKey: ["fastRoute", university.id, origin?.nodeId, destination?.nodeId],
+			queryFn: () =>
+				getNavigationResult(
+					university.id,
+					origin ? origin?.nodeId : -1,
+					destination ? destination?.nodeId : -1,
+				),
+			enabled: false,
+			retry: 0,
+		},
 		undefined,
-		() => { navigate('/result') },
+		() => {
+			navigate("/result");
+		},
 		{
 			fallback: {
 				400: {
-					mainTitle: "잘못된 요청입니다.", subTitle: ["새로고침 후 다시 시도 부탁드립니다."]
+					mainTitle: "잘못된 요청입니다.",
+					subTitle: ["새로고침 후 다시 시도 부탁드립니다."],
 				},
 				404: {
-					mainTitle: "해당 경로를 찾을 수 없습니다.", subTitle: ["해당 건물이 길이랑 연결되지 않았습니다."]
+					mainTitle: "해당 경로를 찾을 수 없습니다.",
+					subTitle: ["해당 건물이 길이랑 연결되지 않았습니다."],
 				},
 				422: {
-					mainTitle: "해당 경로를 찾을 수 없습니다.", subTitle: ["위험 요소 버튼을 클릭하여,", "통행할 수 없는 원인을 파악하실 수 있습니다."]
-				}
-			}
-		}
-	)
+					mainTitle: "해당 경로를 찾을 수 없습니다.",
+					subTitle: ["위험 요소 버튼을 클릭하여,", "통행할 수 없는 원인을 파악하실 수 있습니다."],
+				},
+			},
+		},
+	);
 
 	const results = useSuspenseQueries({
 		queries: [
@@ -468,7 +479,6 @@ export default function MapPage() {
 
 		if (prevZoom.current >= 17 && zoom <= 16) {
 			if (isCautionAcitve) {
-				setIsCautionActive(false);
 				toggleMarkers(
 					false,
 					cautionMarkers.map((marker) => marker.element),
@@ -476,7 +486,6 @@ export default function MapPage() {
 				);
 			}
 			if (isDangerAcitve) {
-				setIsDangerActive(false);
 				toggleMarkers(
 					false,
 					dangerMarkers.map((marker) => marker.element),
@@ -487,6 +496,21 @@ export default function MapPage() {
 			toggleMarkers(true, universityMarker ? [universityMarker] : [], map);
 			toggleMarkers(false, _buildingMarkers, map);
 		} else if (prevZoom.current <= 16 && zoom >= 17) {
+			if (isCautionAcitve) {
+				toggleMarkers(
+					true,
+					cautionMarkers.map((marker) => marker.element),
+					map,
+				);
+			}
+			if (isDangerAcitve) {
+				toggleMarkers(
+					true,
+					dangerMarkers.map((marker) => marker.element),
+					map,
+				);
+			}
+
 			toggleMarkers(false, universityMarker ? [universityMarker] : [], map);
 			toggleMarkers(true, _buildingMarkers, map);
 		}

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -38,9 +38,6 @@ const ReportForm = () => {
 	const { reportRouteId: routeId } = useReportRisk();
 
 	useRedirectUndefined<University | RouteId | undefined>([university, routeId]);
-
-	console.log(routeId);
-
 	if (!routeId) return;
 
 	const { data } = useSuspenseQuery({
@@ -113,33 +110,36 @@ const ReportForm = () => {
 		}
 	};
 
-	const [ErrorModal, { mutate }] = useMutationError({
-		mutationFn: () =>
-			postReport(university?.id ?? 1001, routeId, {
-				dangerFactors: formData.dangerIssues,
-				cautionFactors: formData.cautionIssues,
-			}),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["report", university?.id ?? 1001, routeId] });
-			openSuccess();
-		},
-		onError: () => {
-			setErrorTitle("제보에 실패하였습니다");
-		},
-	}, undefined, {
-		fallback: {
-			400: {
-				mainTitle: '불편한 길 제보 실패',
-				subTitle: ['잘못된 요청입니다.', '잠시 후 다시 시도 부탁드립니다.'],
+	const [ErrorModal, { mutate }] = useMutationError(
+		{
+			mutationFn: () =>
+				postReport(university?.id ?? 1001, routeId, {
+					dangerFactors: formData.dangerIssues,
+					cautionFactors: formData.cautionIssues,
+				}),
+			onSuccess: () => {
+				queryClient.removeQueries({ queryKey: [university?.id ?? 1001, "risks"] });
+				openSuccess();
 			},
-			404: {
-				mainTitle: '불편한 길 제보 실패',
-				subTitle: ['해당 경로는 다른 사용자에 의해 삭제되어,', '지도 화면에서 바로 확인할 수 있어요.']
-			}
+			onError: () => {
+				setErrorTitle("제보에 실패하였습니다");
+			},
 		},
-		onClose: redirectToMap
-
-	});
+		undefined,
+		{
+			fallback: {
+				400: {
+					mainTitle: "불편한 길 제보 실패",
+					subTitle: ["잘못된 요청입니다.", "잠시 후 다시 시도 부탁드립니다."],
+				},
+				404: {
+					mainTitle: "불편한 길 제보 실패",
+					subTitle: ["해당 경로는 다른 사용자에 의해 삭제되어,", "지도 화면에서 바로 확인할 수 있어요."],
+				},
+			},
+			onClose: redirectToMap,
+		},
+	);
 
 	return (
 		<div className="flex flex-col h-dvh w-full max-w-[450px] mx-auto relative">

--- a/uniro_frontend/src/utils/fetch/fetch.ts
+++ b/uniro_frontend/src/utils/fetch/fetch.ts
@@ -4,6 +4,8 @@ export default function Fetch() {
 	const baseURL = import.meta.env.VITE_REACT_SERVER_BASE_URL;
 
 	const get = async <T>(url: string, params?: Record<string, string | number | boolean>): Promise<T> => {
+		console.log("GET : ", url);
+
 		const paramsURL = new URLSearchParams(
 			Object.entries(params || {}).map(([key, value]) => [key, String(value)]),
 		).toString();
@@ -28,6 +30,8 @@ export default function Fetch() {
 	};
 
 	const post = async <T, K>(url: string, body?: Record<string, K | K[]>): Promise<boolean> => {
+		console.log("POST : ", url);
+
 		const response = await fetch(`${baseURL}${url}`, {
 			method: "POST",
 			body: JSON.stringify(body),


### PR DESCRIPTION
## #️⃣  작업 내용
1. 지도 메인페이지 줌 아웃시 위험 주의 비활성화 로직 제거
2. 불편한 길 반영 시, 잔여 캐시로 인한 제보 확인 불가 해결
3. 지도 제스쳐 핸들링 방식 변경

## 버그 수정 및 요청 사항 반영

### 지도 메인페이지 줌 아웃시 위험 주의 비활성화 로직 제거

```typescript
	useEffect(() => {
		if (!map) return;

		const _buildingMarkers = buildingMarkers.map((buildingMarker) => buildingMarker.element);

		if (prevZoom.current >= 17 && zoom <= 16) {
			if (isCautionAcitve) {
				toggleMarkers(
					false,
					cautionMarkers.map((marker) => marker.element),
					map,
				);
			}
			if (isDangerAcitve) {
				toggleMarkers(
					false,
					dangerMarkers.map((marker) => marker.element),
					map,
				);
			}

			toggleMarkers(true, universityMarker ? [universityMarker] : [], map);
			toggleMarkers(false, _buildingMarkers, map);
		} else if (prevZoom.current <= 16 && zoom >= 17) {
			if (isCautionAcitve) {
				toggleMarkers(
					true,
					cautionMarkers.map((marker) => marker.element),
					map,
				);
			}
			if (isDangerAcitve) {
				toggleMarkers(
					true,
					dangerMarkers.map((marker) => marker.element),
					map,
				);
			}

			toggleMarkers(false, universityMarker ? [universityMarker] : [], map);
			toggleMarkers(true, _buildingMarkers, map);
		}
	}, [map, zoom]);
```
- setActive를 모두 삭제하고, active 상태를 유지하였습니다.

| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/44b6400a-9ec1-48c8-a20f-8ebf6b3e3837">  | <video src="https://github.com/user-attachments/assets/b63e4e57-1720-4f6a-a1fa-a3f23d92b5b4">|


### 불편한 길 반영 시, 잔여 캐시로 인한 제보 확인 불가 해결
```typescript

onSuccess: () => {
				queryClient.removeQueries({ queryKey: [university?.id ?? 1001, "risks"] });
				openSuccess();
			},

```
- mutate 성공 시, 기존에 존재하던 cache를 remove하여 재요청을 할 수 있도록 하였습니다.
- 준혁님과 함께 고민했던 내용인데 invalidateQueries와 removeQuries에 대해서 많은 고민이 있었습니다.
1. invalidateQuries는 해당 key를 가진 쿼리를 무효화하여 useQuery시, 값을 재요청하는 기능이 존재한다.
2. useSuspenseQuery는 반응성을 위해 새로운 값을 요청하기 전에, 기존에 무효화된 값을 먼저 return하고 재요청 이후 새로운 값을 return한다.
3. 지도의 경우, 지도에 마커를 생성하는 것이 state로 관리되는 것이 아니기에, 이전 무효화 값을 마커로 생성하여 삭제되지 않아서 invalidateQuries가 아니라 removeQuries로 쿼리를 아예 삭제하여 문제를 해결할 수 있었습니다.


| before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/130fc0a2-ef7d-4617-b17f-b65903832808">  | <video src="https://github.com/user-attachments/assets/9f01cb93-572d-44c8-9de6-6e3c372c87ca">|


## 연관된 이슈
UNI-202, UNI-203, UNI-204