### PR TITLE
[UNI-215] fix : 구글 구면좌표계 제거 및 interpolate 함수 및 distance 함수 구현

### DIFF
--- a/uniro_frontend/src/hooks/useMap.tsx
+++ b/uniro_frontend/src/hooks/useMap.tsx
@@ -7,7 +7,6 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 	const [overlay, setOverlay] = useState<google.maps.OverlayView | null>(null);
 	const [AdvancedMarker, setAdvancedMarker] = useState<typeof google.maps.marker.AdvancedMarkerElement | null>(null);
 	const [Polyline, setPolyline] = useState<typeof google.maps.Polyline | null>(null);
-	const [spherical, setSpherical] = useState<typeof google.maps.geometry.spherical | null>(null);
 	const [mapLoaded, setMapLoaded] = useState<boolean>(false);
 
 	useEffect(() => {
@@ -15,13 +14,12 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 
 		const initMap = async () => {
 			try {
-				const { map, overlay, AdvancedMarkerElement, Polyline, spherical } = await initializeMap(
+				const { map, overlay, AdvancedMarkerElement, Polyline } = await initializeMap(
 					mapRef.current,
 					mapOptions,
 				);
 				setMap(map);
 				setOverlay(overlay);
-				setSpherical(() => spherical);
 				setAdvancedMarker(() => AdvancedMarkerElement);
 				setPolyline(() => Polyline);
 				setMapLoaded(true);
@@ -39,7 +37,7 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 		};
 	}, []);
 
-	return { mapRef, map, overlay, AdvancedMarker, Polyline, spherical, mapLoaded };
+	return { mapRef, map, overlay, AdvancedMarker, Polyline, mapLoaded };
 };
 
 export default useMap;

--- a/uniro_frontend/src/map/initializer/googleMapInitializer.ts
+++ b/uniro_frontend/src/map/initializer/googleMapInitializer.ts
@@ -7,14 +7,13 @@ interface MapWithOverlay {
 	overlay: google.maps.OverlayView | null;
 	AdvancedMarkerElement: typeof google.maps.marker.AdvancedMarkerElement;
 	Polyline: typeof google.maps.Polyline;
-	spherical: typeof google.maps.geometry.spherical;
 }
 
 export const initializeMap = async (
 	mapElement: HTMLElement | null,
 	mapOptions?: google.maps.MapOptions,
 ): Promise<MapWithOverlay> => {
-	const { Map, OverlayView, AdvancedMarkerElement, Polyline, spherical } = await loadGoogleMapsLibraries();
+	const { Map, OverlayView, AdvancedMarkerElement, Polyline } = await loadGoogleMapsLibraries();
 
 	if (!mapElement) {
 		throw new Error("Map Element is not provided");
@@ -45,5 +44,5 @@ export const initializeMap = async (
 	overlay.onRemove = function () {};
 	overlay.setMap(map);
 
-	return { map, overlay, AdvancedMarkerElement, Polyline, spherical };
+	return { map, overlay, AdvancedMarkerElement, Polyline };
 };

--- a/uniro_frontend/src/map/loader/googleMapLoader.ts
+++ b/uniro_frontend/src/map/loader/googleMapLoader.ts
@@ -9,9 +9,8 @@ const GoogleMapsLoader = new Loader({
 const loadGoogleMapsLibraries = async () => {
 	const { Map, OverlayView, Polyline } = await GoogleMapsLoader.importLibrary("maps");
 	const { AdvancedMarkerElement } = await GoogleMapsLoader.importLibrary("marker");
-	const { spherical } = await GoogleMapsLoader.importLibrary("geometry");
 
-	return { Map, OverlayView, AdvancedMarkerElement, Polyline, spherical };
+	return { Map, OverlayView, AdvancedMarkerElement, Polyline };
 };
 
 export default loadGoogleMapsLibraries;

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -33,7 +33,7 @@ interface reportMarkerTypes extends MarkerTypesWithElement {
 }
 
 export default function ReportRiskPage() {
-	const { map, mapRef, AdvancedMarker, Polyline, spherical } = useMap({ zoom: 18, minZoom: 17 });
+	const { map, mapRef, AdvancedMarker, Polyline } = useMap({ zoom: 18, minZoom: 17 });
 
 	const [reportMarker, setReportMarker] = useState<reportMarkerTypes>();
 
@@ -166,12 +166,12 @@ export default function ReportRiskPage() {
 				});
 
 				const point = LatLngToLiteral(e.latLng);
-				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(spherical, edges, point);
+				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(edges, point);
 
 				const newReportMarker = createAdvancedMarker(
 					AdvancedMarker,
 					map,
-					centerCoordinate(spherical, nearestEdge.node1, nearestEdge.node2),
+					centerCoordinate(nearestEdge.node1, nearestEdge.node2),
 					createMarkerElement({
 						type: Markers.REPORT,
 						className: "translate-routemarker",

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -38,7 +38,7 @@ type SelectedMarkerTypes = {
 export default function ReportRoutePage() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
-	const { map, mapRef, AdvancedMarker, Polyline, spherical } = useMap({ zoom: 18, minZoom: 17 });
+	const { map, mapRef, AdvancedMarker, Polyline } = useMap({ zoom: 18, minZoom: 17 });
 	const originPoint = useRef<{ point: Node; element: AdvancedMarker } | undefined>();
 	const [newPoints, setNewPoints] = useState<{ element: AdvancedMarker | null; coords: (Coord | Node)[] }>({
 		element: null,
@@ -241,7 +241,7 @@ export default function ReportRoutePage() {
 		const lastPoint = newPoints.coords[newPoints.coords.length - 1] as Node | Coord;
 
 		for (const edge of edges) {
-			const subNode = createSubNodes(spherical, new Polyline({ path: edge })).slice(0, -1);
+			const subNode = createSubNodes(new Polyline({ path: edge })).slice(0, -1);
 			subNodes.push(...subNode);
 		}
 
@@ -288,7 +288,7 @@ export default function ReportRoutePage() {
 				});
 
 				const point = LatLngToLiteral(e.latLng);
-				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(spherical, edges, point);
+				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(edges, point);
 
 				const tempWaypointMarker = createAdvancedMarker(
 					AdvancedMarker,

--- a/uniro_frontend/src/utils/coordinates/centerCoordinate.ts
+++ b/uniro_frontend/src/utils/coordinates/centerCoordinate.ts
@@ -1,17 +1,6 @@
 import { Coord } from "../../data/types/coord";
-import { LatLngToLiteral } from "./coordinateTransform";
+import { interpolate } from "../interpolate";
 
-export default function centerCoordinate(
-	spherical: typeof google.maps.geometry.spherical | null,
-	point1: Coord,
-	point2: Coord,
-): Coord {
-	if (spherical === null) {
-		return {
-			lat: (point1.lat + point2.lat) / 2,
-			lng: (point1.lng + point2.lng) / 2,
-		};
-	} else {
-		return LatLngToLiteral(spherical.interpolate(point1, point2, 0.5));
-	}
+export default function centerCoordinate(point1: Coord, point2: Coord): Coord {
+	return interpolate(point1, point2, 0.5);
 }

--- a/uniro_frontend/src/utils/coordinates/distance.ts
+++ b/uniro_frontend/src/utils/coordinates/distance.ts
@@ -1,23 +1,26 @@
+import { Coord } from "../../data/types/coord";
+
 /** 하버사인 공식 */
-export default function distance(
-	spherical: typeof google.maps.geometry.spherical | null,
-	point1: google.maps.LatLngLiteral,
-	point2: google.maps.LatLngLiteral,
-): number {
-	const { lat: lat1, lng: lng1 } = point1;
-	const { lat: lat2, lng: lng2 } = point2;
+export default function distance(point1: Coord, point2: Coord): number {
+	const R = 6378137;
+	const { lat: lat_a, lng: lng_a } = point1;
+	const { lat: lat_b, lng: lng_b } = point2;
 
-	if (spherical === null) {
-		const R = 6371000;
-		const toRad = (angle: number) => (angle * Math.PI) / 180;
+	const rad_lat_a = toRad(lat_a);
+	const rad_lng_a = toRad(lng_a);
+	const rad_lat_b = toRad(lat_b);
+	const rad_lng_b = toRad(lng_b);
 
-		const dLat = toRad(lat2 - lat1);
-		const dLon = toRad(lng2 - lng1);
-
-		const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
-		const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-
-		return R * c;
-	}
-	return spherical.computeLength([point1, point2]);
+	return (
+		R *
+		2 *
+		Math.asin(
+			Math.sqrt(
+				Math.pow(Math.sin((rad_lat_a - rad_lat_b) / 2), 2) +
+					Math.cos(rad_lat_a) * Math.cos(rad_lat_b) * Math.pow(Math.sin((rad_lng_a - rad_lng_b) / 2), 2),
+			),
+		)
+	);
 }
+
+const toRad = (angle: number) => (angle * Math.PI) / 180;

--- a/uniro_frontend/src/utils/interpolate.ts
+++ b/uniro_frontend/src/utils/interpolate.ts
@@ -1,0 +1,35 @@
+import { Coord } from "../data/types/coord";
+
+function toRad(deg: number) {
+	return (deg * Math.PI) / 180;
+}
+function toDeg(rad: number) {
+	return (rad * 180) / Math.PI;
+}
+
+export function interpolate(point1: Coord, point2: Coord, fraction: number): Coord {
+	const lat1 = toRad(point1.lat);
+	const lng1 = toRad(point1.lng);
+
+	const lat2 = toRad(point2.lat);
+	const lng2 = toRad(point2.lng);
+
+	const angle = Math.acos(Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(lng2 - lng1));
+
+	const sinAngle = Math.sin(angle);
+
+	const A = Math.sin((1 - fraction) * angle) / sinAngle;
+	const B = Math.sin(fraction * angle) / sinAngle;
+
+	const x = A * Math.cos(lat1) * Math.cos(lng1) + B * Math.cos(lat2) * Math.cos(lng2);
+	const y = A * Math.cos(lat1) * Math.sin(lng1) + B * Math.cos(lat2) * Math.sin(lng2);
+	const z = A * Math.sin(lat1) + B * Math.sin(lat2);
+
+	const interpolatedLat = Math.atan2(z, Math.sqrt(x * x + y * y));
+	const interpolatedLng = Math.atan2(y, x);
+
+	return {
+		lat: toDeg(interpolatedLat),
+		lng: toDeg(interpolatedLng),
+	};
+}

--- a/uniro_frontend/src/utils/polylines/createSubnodes.ts
+++ b/uniro_frontend/src/utils/polylines/createSubnodes.ts
@@ -2,43 +2,22 @@ import { EDGE_LENGTH } from "../../constant/edge";
 import { Coord } from "../../data/types/coord";
 import { LatLngToLiteral } from "../coordinates/coordinateTransform";
 import distance from "../coordinates/distance";
+import { interpolate } from "../interpolate";
 
 /** 구면 보간 없이 계산한 결과 */
-export default function createSubNodes(
-	spherical: typeof google.maps.geometry.spherical | null,
-	polyLine: google.maps.Polyline,
-): Coord[] {
+export default function createSubNodes(polyLine: google.maps.Polyline): Coord[] {
 	const paths = polyLine.getPath();
 	const [startNode, endNode] = paths.getArray().map((el) => LatLngToLiteral(el));
 
-	const length = distance(spherical, startNode, endNode);
-	console.log("구면 보간", length);
+	const length = distance(startNode, endNode);
 
 	const subEdgesCount = Math.ceil(length / EDGE_LENGTH);
 
 	const subNodes: Coord[] = [startNode];
 
-	if (spherical === null || !spherical) {
-		const interval = {
-			lat: (endNode.lat - startNode.lat) / subEdgesCount,
-			lng: (endNode.lng - startNode.lng) / subEdgesCount,
-		};
-
-		for (let i = 1; i < subEdgesCount; i++) {
-			const subNode: Coord = {
-				lat: startNode.lat + interval.lat * i,
-				lng: startNode.lng + interval.lng * i,
-			};
-			subNodes.push(subNode);
-		}
-
-		subNodes.push(endNode);
-		return subNodes;
-	}
-
 	for (let i = 1; i < subEdgesCount; i++) {
 		const fraction = i / subEdgesCount;
-		subNodes.push(LatLngToLiteral(spherical.interpolate(startNode, endNode, fraction)));
+		subNodes.push(interpolate(startNode, endNode, fraction));
 	}
 
 	subNodes.push(endNode);

--- a/uniro_frontend/src/utils/polylines/findNearestEdge.ts
+++ b/uniro_frontend/src/utils/polylines/findNearestEdge.ts
@@ -5,7 +5,6 @@ import centerCoordinate from "../coordinates/centerCoordinate";
 import distance from "../coordinates/distance";
 
 export default function findNearestSubEdge(
-	spherical: typeof google.maps.geometry.spherical | null,
 	edges: CoreRoute[],
 	point: Coord,
 ): {
@@ -16,7 +15,7 @@ export default function findNearestSubEdge(
 		.map((edge) => {
 			return {
 				edge,
-				distance: distance(spherical, point, centerCoordinate(spherical, edge.node1, edge.node2)),
+				distance: distance(point, centerCoordinate(edge.node1, edge.node2)),
 			};
 		})
 		.sort((a, b) => {
@@ -26,8 +25,8 @@ export default function findNearestSubEdge(
 	const nearestEdge = edgesWithDistance[0].edge;
 
 	const { node1, node2 } = nearestEdge;
-	const distance0 = distance(spherical, node1, point);
-	const distance1 = distance(spherical, node2, point);
+	const distance0 = distance(node1, point);
+	const distance1 = distance(node2, point);
 	const nearestPoint = distance0 > distance1 ? node2 : node1;
 
 	return {


### PR DESCRIPTION
## #️⃣  작업 내용
1. interpolate 함수 구현
2. distance 함수 로직 변경
3. 구글 구면 좌표계 제거

## 버그 수정 및 요청 사항 반영

### interpolate 함수 구현

- 백엔드로부터 새로운 길 제보시 중복 포인트 삽입이 발생한다는 것을 인지하여 문제를 해결하였습니다.
- 2~3m의 작은 길을 생성하여 샘플링 시, 중복포인트가 발생한다는 것을 확인하여 원인을 분석한 결과, #98 에서 도입한 구글 geometry 라이브러리에서 interpolate 시 발생하는 문제였습니다.

- @jpark0506 준혁님께서 비슷한 사례 [Google Issue Tracker](https://issuetracker.google.com/issues/260343763?pli=1) [StackOverflow](https://stackoverflow.com/questions/7636546/google-maps-v3-geometry-library-interpolate-does-not-return-expected-lat-lng)를 찾아주신 덕분에 짧은 거리에 대해 interpolate 시킬 경우, Google SDK에서 계산하는 로직으로는 좌표가 소수점 5번째 이하부터는 동작하지 않는 것을 확인하여 쉽게 해결할 수 있었습니다.
 
```javascript
 Zt.interpolate = function(a, b, c) {
        a = _.Se(a);
        b = _.Se(b);
        var d = _.Pe(a)
          , e = _.Qe(a)
          , f = _.Pe(b)
          , g = _.Qe(b)
          , h = Math.cos(d)
          , k = Math.cos(f);
        b = Zt.Js(a, b);
        var l = Math.sin(b);
        if (1E-6 > l)
            return new _.Oe(a.lat(),a.lng());
        a = Math.sin((1 - c) * b) / l;
        c = Math.sin(c * b) / l;
        b = a * h * Math.cos(e) + c * k * Math.cos(g);
        e = a * h * Math.sin(e) + c * k * Math.sin(g);
        return new _.Oe(_.Wd(Math.atan2(a * Math.sin(d) + c * Math.sin(f), Math.sqrt(b * b + e * e))),_.Wd(Math.atan2(e, b)))
    }
``` 
- if 문에 의해 매우 짧은 거리일 경우, 첫 번째 좌표를 그대로 반환하는 문제가 존재하였습니다.
- 이로 인해, 짧은 길을 생성할 경우, 중복 포인트가 생성되는 것을 확인하여, 해당 interpolate함수를 분석하여 if문 없이 직접 구현하였습니다.

```typescript

export function interpolate(point1: Coord, point2: Coord, fraction: number): Coord {
	const lat1 = toRad(point1.lat);
	const lng1 = toRad(point1.lng);

	const lat2 = toRad(point2.lat);
	const lng2 = toRad(point2.lng);

	const angle = Math.acos(Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(lng2 - lng1));

	const sinAngle = Math.sin(angle);

	const A = Math.sin((1 - fraction) * angle) / sinAngle;
	const B = Math.sin(fraction * angle) / sinAngle;

	const x = A * Math.cos(lat1) * Math.cos(lng1) + B * Math.cos(lat2) * Math.cos(lng2);
	const y = A * Math.cos(lat1) * Math.sin(lng1) + B * Math.cos(lat2) * Math.sin(lng2);
	const z = A * Math.sin(lat1) + B * Math.sin(lat2);

	const interpolatedLat = Math.atan2(z, Math.sqrt(x * x + y * y));
	const interpolatedLng = Math.atan2(y, x);

	return {
		lat: toDeg(interpolatedLat),
		lng: toDeg(interpolatedLng),
	};
}
```
- 위 SDK에서 제공하는 함수들을 개발자 도구를 통해 추적하여 서비스에서 사용할 수 있는 자바스크립트 코드로 변경하였습니다.
- interpolate를 직접 만들어서, geometry 라이브러리를 import하는 주요 목적이 사라져 해당 라이브러리를 import하지 않기 위해 사용되던 computeLength 함수또한, SDK를 분석하였습니다.

### distance 함수 구현

```javascript
    Yda = function(a, b) {
        const c = _.dk(a);
        a = _.ek(a);
        const d = _.dk(b);
        b = _.ek(b);
        return 2 * Math.asin(Math.sqrt(Math.pow(Math.sin((c - d) / 2), 2) + Math.cos(c) * Math.cos(d) * Math.pow(Math.sin((a - b) / 2), 2)))
    }
```

- 위 함수를 분석한 결과, 제가 기존에 생성했던 #32 하버사인 공식과 유사한 것을 확인하고 기존의 로직을 수정하여 사용하기로 하였습니다.
```typescript
import { Coord } from "../../data/types/coord";

/** 하버사인 공식 */
export default function distance(point1: Coord, point2: Coord): number {
	const R = 6378137;
	const { lat: lat_a, lng: lng_a } = point1;
	const { lat: lat_b, lng: lng_b } = point2;

	const rad_lat_a = toRad(lat_a);
	const rad_lng_a = toRad(lng_a);
	const rad_lat_b = toRad(lat_b);
	const rad_lng_b = toRad(lng_b);

	return (
		R *
		2 *
		Math.asin(
			Math.sqrt(
				Math.pow(Math.sin((rad_lat_a - rad_lat_b) / 2), 2) +
					Math.cos(rad_lat_a) * Math.cos(rad_lat_b) * Math.pow(Math.sin((rad_lng_a - rad_lng_b) / 2), 2),
			),
		)
	);
}

const toRad = (angle: number) => (angle * Math.PI) / 180;
```
- 지구의 반지름 수치가 변경되었고, 각도의 차이를 (좌표 - 좌표) 후 radian으로 변환이 아닌 radian으로 변환 후, 차이를 계산할 수 있도록 로직을 수정하였습니다.

- 이후 모든 로직을 google.maps.geometry 라이브러리를 사용하던 것에서 직접 구현한 함수들로 대체할 수 있었습니다.



## 동작화면
<img width="1728" alt="스크린샷 2025-02-12 오후 3 11 50" src="https://github.com/user-attachments/assets/9cf2f96f-fa1c-4071-b253-586b4ee3eb52" />

- 구글 보정 시, 동일 값이 여러 번 생성된 것을 확인할 수 있고 직접 interpolate 함수를 사용한 결과 같은 경로에 대해서 모두 다른 점들을 생성한 결과를 확인할 수 있습니다.

- 또한, 백엔드에서 거리를 계산하는 방식과 프론트에서 계산하는 방식이 차이가 있어, 일관된 로직을 적용시키기 위해서 거리 계산 방식을 하버사인으로 통일할 수 있도록 제안하였습니다.

