### PR TITLE
[UNI-221] feat : 지도 메인 페이지, UX/UI 변경

### DIFF
--- a/uniro_frontend/src/assets/icon/search.svg
+++ b/uniro_frontend/src/assets/icon/search.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 19.5C15.4183 19.5 19 15.9183 19 11.5C19 7.08172 15.4183 3.5 11 3.5C6.58172 3.5 3 7.08172 3 11.5C3 15.9183 6.58172 19.5 11 19.5Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.9999 21.5L16.6499 17.15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/uniro_frontend/src/components/map/TopSheet.tsx
+++ b/uniro_frontend/src/components/map/TopSheet.tsx
@@ -1,10 +1,7 @@
 import RouteInput from "../map/routeSearchInput";
-import OriginIcon from "../../assets/map/origin.svg?react";
-import Destination from "../../assets/map/destination.svg?react";
-import LocationIcon from "../../../public/icons/location-thick.svg?react";
-import SwitchIcon from "../../assets/switch.svg?react";
+import SearchIcon from "../../assets/icon/search.svg?react";
+import LocationIcon from "../../assets/location-thin.svg?react";
 import { Link } from "react-router";
-import { motion } from "framer-motion";
 import useRoutePoint from "../../hooks/useRoutePoint";
 import useSearchBuilding from "../../hooks/useSearchBuilding";
 import { RoutePoint } from "../../constant/enum/routeEnum";
@@ -21,7 +18,7 @@ export default function MapTopSheet({ isVisible }: MapTopSheetProps) {
 	return (
 		<AnimatedContainer
 			isVisible={isVisible}
-			className="absolute top-0 w-full left-0  py-[18px] px-5  bg-white rounded-b-2xl shadow-xl overflow-auto z-20"
+			className="absolute top-0 w-full left-0  py-[18px] px-5  rounded-b-2xl overflow-auto z-20"
 			positionDelta={300}
 			transition={{
 				type: "spring",
@@ -30,32 +27,21 @@ export default function MapTopSheet({ isVisible }: MapTopSheetProps) {
 			}}
 			isTop={true}
 		>
-			<p className="flex flex-row items-center mb-[10px] text-kor-body2 font-medium text-gray-800 underline underline-offset-4">
-				<LocationIcon stroke="#4D4D4D" className="mr-1" />
-				<Link to="/university">한양대학교</Link>
-			</p>
 			<div className="flex flex-row space-x-1">
-				<div className="flex-1 flex flex-col space-y-[10px]">
+				<div className="flex-1 flex flex-row space-x-5">
 					<RouteInput
 						onClick={() => setMode(RoutePoint.ORIGIN)}
-						placeholder="출발지를 입력하세요"
+						placeholder={`한양대학교 건물을 검색해보세요`}
 						value={origin ? origin.buildingName : ""}
 						onCancel={() => setOrigin(undefined)}
 					>
-						<OriginIcon />
+						<SearchIcon />
 					</RouteInput>
-					<RouteInput
-						onClick={() => setMode(RoutePoint.DESTINATION)}
-						placeholder="도착지를 입력하세요"
-						value={destination ? destination.buildingName : ""}
-						onCancel={() => setDestination(undefined)}
-					>
-						<Destination />
-					</RouteInput>
-				</div>
-				<div className="flex items-center">
-					<button onClick={switchBuilding} className="cursor-pointer p-1 rounded-[8px] active:bg-gray-200">
-						<SwitchIcon />
+					<button className="flex flex-col items-center justify-around h-[50px] w-[75px] shadow-lg bg-primary-500 active:bg-primary-600 text-gray-100 rounded-200  mb-[10px] text-kor-body2 font-medium ">
+						<LocationIcon stroke="#FFFFFF" className="mb-[-10px]" />
+						<Link to="/building" className="text-kor-caption">
+							길 찾기
+						</Link>
 					</button>
 				</div>
 			</div>

--- a/uniro_frontend/src/components/map/floatingButtons.tsx
+++ b/uniro_frontend/src/components/map/floatingButtons.tsx
@@ -11,7 +11,7 @@ export function DangerToggleButton({ isActive, onClick }: ToggleButtonProps) {
 	return (
 		<button
 			onClick={onClick}
-			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full border-[1.5px] active:bg-gray-200 active:border-gray-400 active:text-gray-700 ${isActive ? "bg-system-red border-gray-100 text-gray-100" : "bg-gray-100 border-gray-400 text-gray-700"}`}
+			className={`w-fit h-fit p-[14px] flex shadow-lg items-center justify-center rounded-full active:bg-gray-200  active:text-gray-700 ${isActive ? "bg-system-red border-gray-100 text-gray-100" : "bg-gray-100 border-gray-400 text-gray-700"}`}
 		>
 			<DangerIcon />
 		</button>
@@ -22,7 +22,7 @@ export function CautionToggleButton({ isActive, onClick }: ToggleButtonProps) {
 	return (
 		<button
 			onClick={onClick}
-			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full border-[1.5px] active:bg-gray-200 active:border-gray-400 active:text-gray-700 ${isActive ? "bg-system-orange border-gray-100 text-gray-100" : "bg-gray-100 border-gray-400 text-gray-700"}`}
+			className={`w-fit h-fit p-[14px] flex shadow-lg items-center justify-center rounded-full active:bg-gray-200  active:text-gray-700 ${isActive ? "bg-system-orange border-gray-100 text-gray-100" : "bg-gray-100 border-gray-400 text-gray-700"}`}
 		>
 			<CautionIcon />
 		</button>
@@ -39,7 +39,7 @@ export function UndoButton({ onClick, disabled }: UndoButtonProps) {
 		<button
 			disabled={disabled}
 			onClick={onClick}
-			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full border-[1.5px]  bg-gray-100 border-gray-400 text-gray-700 ${disabled ? "bg-gray-300" : "active:bg-gray-200 active:border-gray-400 active:text-gray-700"}`}
+			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full  bg-gray-100 border-gray-400 text-gray-700 ${disabled ? "bg-gray-300" : "active:bg-gray-200  active:text-gray-700"}`}
 		>
 			<UndoIcon />
 		</button>

--- a/uniro_frontend/src/components/map/reportButton.tsx
+++ b/uniro_frontend/src/components/map/reportButton.tsx
@@ -5,7 +5,7 @@ export default function ReportButton({ ...rest }: ButtonHTMLAttributes<HTMLButto
 	return (
 		<button
 			{...rest}
-			className="rounded-full w-fit h-[50px] px-6 py-3 flex flex-row items-center bg-gray-900 text-gray-100"
+			className="rounded-full w-fit h-[50px] px-6 py-3 flex flex-row items-center shadow-lg bg-gray-900 text-gray-100"
 		>
 			제보하기
 			<ReportIcon className="ml-3" stroke="#FFFFFF" />

--- a/uniro_frontend/src/components/map/routeSearchInput.tsx
+++ b/uniro_frontend/src/components/map/routeSearchInput.tsx
@@ -13,7 +13,7 @@ interface RouteInputProps extends InputHTMLAttributes<HTMLInputElement> {
 export default function RouteInput({ placeholder, children, value, onCancel, onClick }: RouteInputProps) {
 	return (
 		<div
-			className={`h-[50px] w-full max-w-[450px] flex flex-row justify-between items-center space-x-2 p-3 rounded-200 bg-gray-200 border border-gray-200`}
+			className={`h-[50px] shadow-lg w-full max-w-[450px] flex flex-row justify-between items-center space-x-2 p-3 rounded-200 bg-gray-200 border border-gray-200`}
 		>
 			{children}
 			<Link


### PR DESCRIPTION
## #️⃣ 작업 내용

1.  지도 메인페이지 UX / UI를 개선하였습니다.
 - 피드백 과정에서 현재 UX / UI가 기존 대중적인 서비스 (네이버, 카카오, 구글)과 많이 달라 어렵다는 피드백을 받아서, 해당 서비스들과 유사하게 변경하였습니다.
- 추후, 길 찾기 위한 건물 선택 로직까지 변경될 예정입니다.

## 동작확인

<img width="451" alt="image" src="https://github.com/user-attachments/assets/172de165-c9d1-4339-b04d-6f573d31cf8d" />
