### PR TITLE
[UNI-139] refactor: 로깅 메세지 가독성 좋게 변경

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ArgType.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ArgType.java
@@ -1,0 +1,34 @@
+package com.softeer5.uniro_backend.common.logging;
+
+import java.util.List;
+
+public enum ArgType {
+	NULL,
+	LIST,
+	CUSTOM_DTO,
+	ENTITY,
+	OTHER;
+
+	public static ArgType getArgType(Object arg) {
+		if (arg == null) {
+			return NULL;
+		} else if (arg instanceof List<?>) {
+			return LIST;
+		} else if (isCustomDto(arg)) {
+			return CUSTOM_DTO;
+		} else if (isEntity(arg)) {
+			return ENTITY;
+		} else {
+			return OTHER;
+		}
+	}
+
+	private static boolean isCustomDto(Object arg) {
+		return arg.getClass().getName().contains("dto");
+	}
+
+	private static boolean isEntity(Object arg) {
+		return arg.getClass().getName().contains("entity");
+	}
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -11,7 +11,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -90,12 +89,12 @@ public class ExecutionLoggingAop {
 		StringBuilder parametersLogMessage = new StringBuilder();
 
 		Arrays.stream(args)
-			.forEach(arg -> logCommonTest(arg, "[Parameter]", parametersLogMessage, 0));
+			.forEach(arg -> logDetail(arg, "[Parameter]", parametersLogMessage, 0));
 
 		log.info("\n{}", parametersLogMessage.toString());
 	}
 
-	private void logCommonTest(Object arg, String requestType, StringBuilder logMessage, int depth) {
+	private void logDetail(Object arg, String requestType, StringBuilder logMessage, int depth) {
 		String indent = "  ".repeat(depth); // depth 수준에 따른 들여쓰기
 
 		if (arg == null) {
@@ -107,7 +106,7 @@ public class ExecutionLoggingAop {
 			logMessage.append(indent).append(requestType).append(" ").append(arg.getClass().getSimpleName()).append("\n");
 			List<?> list = (List<?>) arg;
 			for (int i = 0; i < list.size(); i++) {
-				logCommonTest(list.get(i), "[List Element " + i + "] ", logMessage, depth + 1);
+				logDetail(list.get(i), "[List Element " + i + "] ", logMessage, depth + 1);
 			}
 		} else if (isCustomDto(arg)) {
 			logMessage.append(indent).append(requestType).append("DTO: ").append(arg.getClass().getSimpleName()).append("\n");
@@ -127,7 +126,7 @@ public class ExecutionLoggingAop {
 			try {
 				field.setAccessible(true);
 				Object value = field.get(object);
-				logCommonTest(value, "[Field] " + field.getName(), logMessage, depth + 1);
+				logDetail(value, "[Field] " + field.getName(), logMessage, depth + 1);
 			} catch (IllegalAccessException e) {
 				logMessage.append(indent).append("[Field Access Error] Cannot access field: ").append(field.getName()).append("\n");
 			}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -28,7 +28,7 @@ public class ExecutionLoggingAop {
 
 	@Around("execution(* com.softeer5.uniro_backend..*(..)) "
 		+ "&& !within(com.softeer5.uniro_backend.common..*) "
-		+ "&& !within(com.softeer5.uniro_backend.resolver..*)")
+	)
 	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
 		String userId = userIdThreadLocal.get();
 		if (userId == null) {


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 로그 메세지의 가독성 및 정보량에 아쉬움이 있어 개선해봤습니다.
- DTO 또는 엔티티의 경우에도 재귀적으로 모든 데이터를 출력하도록 수정했습니다.
- depth 를 두어, 보다 더 쉽게 로그 값을 확인할 수 있도록 개선했습니다.
- 이로 인해 로그메세지가 오히려 길어져서 가독성을 헤칠 수도 있을 것 같은데요! 만약 그렇게 된다면 다시 롤백해보도록 하겠습니다!

<img width="1295" alt="스크린샷 2025-02-13 오후 3 30 58" src="https://github.com/user-attachments/assets/b7981ef5-e4ac-44c7-b56a-45c226a6e07d" />


## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/