### PR TITLE
[UNI-221] feat : 지도 메인페이지 UX 개선 및 길찾기 사용자 로직 변경

### DIFF
--- a/uniro_frontend/src/components/map/TopSheet.tsx
+++ b/uniro_frontend/src/components/map/TopSheet.tsx
@@ -1,24 +1,65 @@
-import RouteInput from "../map/routeSearchInput";
 import SearchIcon from "../../assets/icon/search.svg?react";
+import OriginIcon from "../../assets/map/origin.svg?react";
+import SwitchIcon from "../../assets/switch.svg?react";
+import DestinationIcon from "../../assets/map/destination.svg?react";
 import LocationIcon from "../../assets/location-thin.svg?react";
-import { Link } from "react-router";
+import ChevronLeft from "../../../public/icons/chevron-left.svg?react";
 import useRoutePoint from "../../hooks/useRoutePoint";
 import useSearchBuilding from "../../hooks/useSearchBuilding";
 import { RoutePoint } from "../../constant/enum/routeEnum";
 import AnimatedContainer from "../../container/animatedContainer";
+import { BuildingInput, RouteInput } from "./mapSearchInput";
 
 interface MapTopSheetProps {
 	isVisible: boolean;
 }
 
-export default function MapTopSheet({ isVisible }: MapTopSheetProps) {
+export function MapTopBuildingSheet({ isVisible }: MapTopSheetProps) {
 	const { origin, setOrigin, destination, setDestination, switchBuilding } = useRoutePoint();
-	const { setMode } = useSearchBuilding();
+	const { searchMode, setSearchMode } = useSearchBuilding();
 
 	return (
 		<AnimatedContainer
 			isVisible={isVisible}
-			className="absolute top-0 w-full left-0  py-[18px] px-5  rounded-b-2xl overflow-auto z-20"
+			className="absolute top-0 w-full left-0  py-[18px] px-2  rounded-b-2xl overflow-auto z-20"
+			positionDelta={300}
+			transition={{
+				type: "spring",
+				damping: 20,
+				duration: 0.3,
+			}}
+			isTop={true}
+		>
+
+			<div className="flex-1 flex flex-row space-x-2">
+				<BuildingInput
+					onClick={() => { }}
+					placeholder={`한양대학교 건물을 검색해보세요`}
+					value={origin ? origin.buildingName : ""}
+					onCancel={() => setOrigin(undefined)}
+				>
+					<SearchIcon />
+				</BuildingInput>
+				<button onClick={() => setSearchMode("ORIGIN")} className="flex flex-col items-center justify-around h-[50px] w-[75px] shadow-lg bg-primary-500 active:bg-primary-600 rounded-200">
+					<LocationIcon stroke="#FFFFFF" className="mb-[-10px]" />
+					<p className="text-kor-caption text-gray-100 font-medium">
+						길 찾기
+					</p>
+				</button>
+			</div>
+		</AnimatedContainer >
+	);
+}
+
+
+export function MapTopRouteSheet({ isVisible }: MapTopSheetProps) {
+	const { origin, setOrigin, destination, setDestination, switchBuilding } = useRoutePoint();
+	const { searchMode, setSearchMode } = useSearchBuilding();
+
+	return (
+		<AnimatedContainer
+			isVisible={isVisible}
+			className="absolute top-0 w-full left-0  py-[18px] px-2  rounded-b-2xl overflow-auto z-20 bg-gray-100"
 			positionDelta={300}
 			transition={{
 				type: "spring",
@@ -28,23 +69,35 @@ export default function MapTopSheet({ isVisible }: MapTopSheetProps) {
 			isTop={true}
 		>
 			<div className="flex flex-row space-x-1">
-				<div className="flex-1 flex flex-row space-x-5">
+				<div className="flex items-center">
+					<button onClick={() => { setSearchMode("BUILDING") }} className="cursor-pointer p-1 rounded-[8px] active:bg-gray-200">
+						<ChevronLeft />
+					</button>
+				</div>
+				<div className="flex-1 flex flex-col space-y-[10px]">
 					<RouteInput
-						onClick={() => setMode(RoutePoint.ORIGIN)}
-						placeholder={`한양대학교 건물을 검색해보세요`}
+						onClick={() => { }}
+						placeholder="출발지를 입력하세요"
 						value={origin ? origin.buildingName : ""}
 						onCancel={() => setOrigin(undefined)}
 					>
-						<SearchIcon />
+						<OriginIcon />
 					</RouteInput>
-					<button className="flex flex-col items-center justify-around h-[50px] w-[75px] shadow-lg bg-primary-500 active:bg-primary-600 text-gray-100 rounded-200  mb-[10px] text-kor-body2 font-medium ">
-						<LocationIcon stroke="#FFFFFF" className="mb-[-10px]" />
-						<Link to="/building" className="text-kor-caption">
-							길 찾기
-						</Link>
+					<RouteInput
+						onClick={() => { }}
+						placeholder="도착지를 입력하세요"
+						value={destination ? destination.buildingName : ""}
+						onCancel={() => setDestination(undefined)}
+					>
+						<DestinationIcon />
+					</RouteInput>
+				</div>
+				<div className="flex items-center">
+					<button onClick={switchBuilding} className="cursor-pointer p-1 rounded-[8px] active:bg-gray-200">
+						<SwitchIcon />
 					</button>
 				</div>
 			</div>
-		</AnimatedContainer>
+		</AnimatedContainer >
 	);
 }

--- a/uniro_frontend/src/components/map/TopSheet.tsx
+++ b/uniro_frontend/src/components/map/TopSheet.tsx
@@ -6,7 +6,6 @@ import LocationIcon from "../../assets/location-thin.svg?react";
 import ChevronLeft from "../../../public/icons/chevron-left.svg?react";
 import useRoutePoint from "../../hooks/useRoutePoint";
 import useSearchBuilding from "../../hooks/useSearchBuilding";
-import { RoutePoint } from "../../constant/enum/routeEnum";
 import AnimatedContainer from "../../container/animatedContainer";
 import { BuildingInput, RouteInput } from "./mapSearchInput";
 
@@ -76,7 +75,7 @@ export function MapTopRouteSheet({ isVisible }: MapTopSheetProps) {
 				</div>
 				<div className="flex-1 flex flex-col space-y-[10px]">
 					<RouteInput
-						onClick={() => { }}
+						onClick={() => { setSearchMode("ORIGIN") }}
 						placeholder="출발지를 입력하세요"
 						value={origin ? origin.buildingName : ""}
 						onCancel={() => setOrigin(undefined)}
@@ -84,7 +83,7 @@ export function MapTopRouteSheet({ isVisible }: MapTopSheetProps) {
 						<OriginIcon />
 					</RouteInput>
 					<RouteInput
-						onClick={() => { }}
+						onClick={() => { setSearchMode("DESTINATION") }}
 						placeholder="도착지를 입력하세요"
 						value={destination ? destination.buildingName : ""}
 						onCancel={() => setDestination(undefined)}

--- a/uniro_frontend/src/components/map/TopSheet.tsx
+++ b/uniro_frontend/src/components/map/TopSheet.tsx
@@ -14,7 +14,6 @@ interface MapTopSheetProps {
 }
 
 export function MapTopBuildingSheet({ isVisible }: MapTopSheetProps) {
-	const { origin, setOrigin, destination, setDestination, switchBuilding } = useRoutePoint();
 	const { searchMode, setSearchMode } = useSearchBuilding();
 
 	return (
@@ -34,8 +33,6 @@ export function MapTopBuildingSheet({ isVisible }: MapTopSheetProps) {
 				<BuildingInput
 					onClick={() => { }}
 					placeholder={`한양대학교 건물을 검색해보세요`}
-					value={origin ? origin.buildingName : ""}
-					onCancel={() => setOrigin(undefined)}
 				>
 					<SearchIcon />
 				</BuildingInput>
@@ -55,6 +52,12 @@ export function MapTopRouteSheet({ isVisible }: MapTopSheetProps) {
 	const { origin, setOrigin, destination, setDestination, switchBuilding } = useRoutePoint();
 	const { searchMode, setSearchMode } = useSearchBuilding();
 
+	const resetRoutePoint = () => {
+		setOrigin(undefined);
+		setDestination(undefined);
+		setSearchMode("BUILDING");
+	}
+
 	return (
 		<AnimatedContainer
 			isVisible={isVisible}
@@ -69,7 +72,7 @@ export function MapTopRouteSheet({ isVisible }: MapTopSheetProps) {
 		>
 			<div className="flex flex-row space-x-1">
 				<div className="flex items-center">
-					<button onClick={() => { setSearchMode("BUILDING") }} className="cursor-pointer p-1 rounded-[8px] active:bg-gray-200">
+					<button onClick={resetRoutePoint} className="cursor-pointer p-1 rounded-[8px] active:bg-gray-200">
 						<ChevronLeft />
 					</button>
 				</div>

--- a/uniro_frontend/src/components/map/mapBottomSheet.tsx
+++ b/uniro_frontend/src/components/map/mapBottomSheet.tsx
@@ -17,7 +17,6 @@ interface MapBottomSheetProps {
 
 export default function MapBottomSheet({ isVisible, selectedMarker, selectRoutePoint }: MapBottomSheetProps) {
 	const { dragControls, scrollRef, preventScroll } = useNavigationBottomSheet();
-	const { mode } = useSearchBuilding();
 
 	return (
 		<AnimatedContainer
@@ -32,69 +31,38 @@ export default function MapBottomSheet({ isVisible, selectedMarker, selectRouteP
 		>
 			<BottomSheetHandle dragControls={dragControls} />
 			<div ref={scrollRef} className="w-full overflow-y-auto h-fit" onScroll={preventScroll}>
-				{selectedMarker &&
-					(selectedMarker.from === "Marker" ? (
-						<MapBottomSheetFromMarker
-							building={selectedMarker}
-							onClickLeft={() => selectRoutePoint(RoutePoint.ORIGIN)}
-							onClickRight={() => selectRoutePoint(RoutePoint.DESTINATION)}
-						/>
-					) : (
-						<MapBottomSheetFromList
-							building={selectedMarker}
-							onClick={selectRoutePoint}
-							buttonText={mode === RoutePoint.ORIGIN ? "출발지 설정" : "도착지 설정"}
-						/>
-					))}
+				<MapBottomSheetFromMarker
+					building={selectedMarker}
+					onClickLeft={() => selectRoutePoint(RoutePoint.ORIGIN)}
+					onClickRight={() => selectRoutePoint(RoutePoint.DESTINATION)}
+				/>
 			</div>
 		</AnimatedContainer>
 	);
 }
 
-interface MapBottomSheetFromListProps {
-	building: SelectedMarkerTypes;
-	buttonText: string;
-	onClick: () => void;
-}
-
-function MapBottomSheetFromList({ building, buttonText, onClick }: MapBottomSheetFromListProps) {
-	if (building.property === undefined) return;
-
-	const { buildingName, buildingImageUrl, phoneNumber, address } = building.property;
-
-	return (
-		<div className="h-full px-5 pt-3 pb-6 flex flex-col items-between">
-			<div className="mb-[14px]">
-				<img src={buildingImageUrl} className="w-full h-[150px] mb-[14px] rounded-300 object-cover" />
-				<div className="flex flex-col space-y-1">
-					<p className="text-kor-heading2 font-semibold text-gray-900 text-left">{buildingName}</p>
-					<p className="text-kor-body3 font-medium text-gray-700 flex flex-row">
-						<Location stroke="#808080" className="mr-[10px]" />
-						{address}
-					</p>
-					<p className="text-kor-body3 font-medium text-gray-700 flex flex-row">
-						<Call stroke="#808080" className="mr-[10px]" />
-						{phoneNumber}
-					</p>
-				</div>
-			</div>
-			<Button onClick={onClick} variant="secondary">
-				{buttonText}
-			</Button>
-		</div>
-	);
-}
-
 interface MapBottomSheetFromMarkerProps {
-	building: SelectedMarkerTypes;
+	building: SelectedMarkerTypes | undefined;
 	onClickLeft: () => void;
 	onClickRight: () => void;
 }
 
 function MapBottomSheetFromMarker({ building, onClickLeft, onClickRight }: MapBottomSheetFromMarkerProps) {
-	if (building.property === undefined) return;
+	if (!building || building.property === undefined) return;
 
 	const { buildingName, buildingImageUrl, phoneNumber, address } = building.property;
+
+	const { setSearchMode } = useSearchBuilding();
+
+	const handlLeftClick = () => {
+		setSearchMode('ORIGIN');
+		onClickLeft();
+	}
+
+	const handleRightClick = () => {
+		setSearchMode('DESTINATION');
+		onClickRight();
+	}
 
 	return (
 		<div className="h-full px-5 pt-3 pb-6 flex flex-col items-between">
@@ -113,10 +81,10 @@ function MapBottomSheetFromMarker({ building, onClickLeft, onClickRight }: MapBo
 				</div>
 			</div>
 			<div className="flex flex-row space-x-3">
-				<Button onClick={onClickLeft} variant="secondary">
+				<Button onClick={handlLeftClick} variant="secondary">
 					출발지 설정
 				</Button>
-				<Button onClick={onClickRight} variant="secondary">
+				<Button onClick={handleRightClick} variant="secondary">
 					도착지 설정
 				</Button>
 			</div>

--- a/uniro_frontend/src/components/map/mapSearchInput.tsx
+++ b/uniro_frontend/src/components/map/mapSearchInput.tsx
@@ -10,7 +10,7 @@ interface RouteInputProps extends InputHTMLAttributes<HTMLInputElement> {
 	onClick: () => void;
 }
 
-export function BuildingInput({ placeholder, children, value, onCancel, onClick }: RouteInputProps) {
+export function BuildingInput({ placeholder, children, onClick }: RouteInputProps) {
 	return (
 		<div
 			className={`h-[50px] shadow-lg w-full max-w-[450px] flex flex-row justify-between items-center space-x-2 p-3 rounded-200 bg-gray-200 border border-gray-200`}
@@ -19,15 +19,10 @@ export function BuildingInput({ placeholder, children, value, onCancel, onClick 
 			<Link
 				onClick={onClick}
 				to="/building"
-				className={`text-start flex-1 text-kor-body2  ${value ? "text-gray-900 font-semibold" : "text-gray-700 font-medium"}`}
+				className={`text-start flex-1 text-kor-body2  text-gray-700 font-medium`}
 			>
-				{value ? value : placeholder}
+				{placeholder}
 			</Link>
-			{value && (
-				<button onClick={onCancel} className="cursor-pointer">
-					<Close />
-				</button>
-			)}
 		</div>
 	);
 }

--- a/uniro_frontend/src/components/map/mapSearchInput.tsx
+++ b/uniro_frontend/src/components/map/mapSearchInput.tsx
@@ -10,10 +10,32 @@ interface RouteInputProps extends InputHTMLAttributes<HTMLInputElement> {
 	onClick: () => void;
 }
 
-export default function RouteInput({ placeholder, children, value, onCancel, onClick }: RouteInputProps) {
+export function BuildingInput({ placeholder, children, value, onCancel, onClick }: RouteInputProps) {
 	return (
 		<div
 			className={`h-[50px] shadow-lg w-full max-w-[450px] flex flex-row justify-between items-center space-x-2 p-3 rounded-200 bg-gray-200 border border-gray-200`}
+		>
+			{children}
+			<Link
+				onClick={onClick}
+				to="/building"
+				className={`text-start flex-1 text-kor-body2  ${value ? "text-gray-900 font-semibold" : "text-gray-700 font-medium"}`}
+			>
+				{value ? value : placeholder}
+			</Link>
+			{value && (
+				<button onClick={onCancel} className="cursor-pointer">
+					<Close />
+				</button>
+			)}
+		</div>
+	);
+}
+
+export function RouteInput({ placeholder, children, value, onCancel, onClick }: RouteInputProps) {
+	return (
+		<div
+			className={`h-[50px] w-full max-w-[450px] flex flex-row justify-between items-center space-x-2 p-3 rounded-200 bg-gray-200 border border-gray-200`}
 		>
 			{children}
 			<Link

--- a/uniro_frontend/src/hooks/useSearchBuilding.ts
+++ b/uniro_frontend/src/hooks/useSearchBuilding.ts
@@ -3,19 +3,21 @@ import { Building } from "../data/types/node";
 import { RoutePointType } from "../data/types/route";
 import { RoutePoint } from "../constant/enum/routeEnum";
 
+export type SearchMode = "BUILDING" | "ORIGIN" | "DESTINATION";
+
 interface SearchModeStore {
-	mode: RoutePointType;
-	setMode: (mode: RoutePointType) => void;
+	searchMode: SearchMode;
+	setSearchMode: (mode: SearchMode) => void;
 	building: Building | undefined;
-	setBuilding: (newBuilding: Building) => void;
+	setBuilding: (newBuilding: Building | undefined) => void;
 }
 
 /** 건물 리스트에서 건물을 출발지, 도착지로 결정하는 경우 */
 const useSearchBuilding = create<SearchModeStore>((set) => ({
-	mode: RoutePoint.ORIGIN,
-	setMode: (newMode: RoutePointType) => set(() => ({ mode: newMode })),
+	searchMode: "BUILDING",
+	setSearchMode: (newMode: SearchMode) => set(() => ({ searchMode: newMode })),
 	building: undefined,
-	setBuilding: (newBuilding: Building) => set(() => ({ building: newBuilding })),
+	setBuilding: (newBuilding: Building | undefined) => set(() => ({ building: newBuilding })),
 }));
 
 export default useSearchBuilding;

--- a/uniro_frontend/src/pages/buildingSearch.tsx
+++ b/uniro_frontend/src/pages/buildingSearch.tsx
@@ -1,5 +1,4 @@
 import Input from "../components/customInput";
-import { hanyangBuildings } from "../data/mock/hanyangBuildings";
 import BuildingCard from "../components/building/buildingCard";
 import useSearchBuilding from "../hooks/useSearchBuilding";
 import useUniversityInfo from "../hooks/useUniversityInfo";
@@ -7,10 +6,13 @@ import useRedirectUndefined from "../hooks/useRedirectUndefined";
 import { useQuery } from "@tanstack/react-query";
 import { getAllBuildings } from "../api/nodes";
 import { University } from "../data/types/university";
+import CloseIcon from "../assets/icon/close.svg?react";
+import { useNavigate } from "react-router";
 
 export default function BuildingSearchPage() {
 	const { university } = useUniversityInfo();
 	const { setBuilding } = useSearchBuilding();
+	const navigate = useNavigate();
 
 	if (!university) return;
 
@@ -25,12 +27,19 @@ export default function BuildingSearchPage() {
 			}),
 	},)
 
+	const handleBack = () => {
+		navigate(-1);
+	}
+
 	useRedirectUndefined<University | undefined>([university]);
 
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center">
-			<div className="px-[14px] py-4 border-b-[1px] border-gray-400">
+			<div className="flex flex-row px-[14px] py-4 space-x-2 border-b-[1px] border-gray-400">
 				<Input onLengthChange={() => { }} handleVoiceInput={() => { }} placeholder="" />
+				<button onClick={handleBack} className="cursor-pointer p-1 rounded-[8px] active:bg-gray-200">
+					<CloseIcon />
+				</button>
 			</div>
 			<div className="flex-1 overflow-y-scroll">
 				<ul className="px-4 pt-1 space-y-1">
@@ -43,6 +52,7 @@ export default function BuildingSearchPage() {
 					))}
 				</ul>
 			</div>
+
 		</div>
 	);
-}
+}	

--- a/uniro_frontend/src/pages/demo.tsx
+++ b/uniro_frontend/src/pages/demo.tsx
@@ -3,7 +3,7 @@ import Button from "../components/customButton";
 import LandingButton from "../components/landingButton";
 import Input from "../components/customInput";
 import Map from "../component/Map";
-import RouteInput from "../components/map/routeSearchInput";
+import { RouteInput } from "../components/map/mapSearchInput";
 import OriginIcon from "../assets/map/origin.svg?react";
 import DestinationIcon from "../assets/map/destination.svg?react";
 import { useEffect, useState } from "react";
@@ -70,30 +70,30 @@ export default function Demo() {
 				<div className="w-1/3 flex flex-col justify-start space-y-5 p-5 mb-5 rounded-sm border border-dashed border-[#9747FF] ">
 					<ReportButton />
 					<div className="flex space-x-3 rounded-sm border border-dashed border-[#9747FF] p-3">
-						<DangerToggleButton onClick={() => {}} isActive={false} />
-						<DangerToggleButton onClick={() => {}} isActive={true} />
+						<DangerToggleButton onClick={() => { }} isActive={false} />
+						<DangerToggleButton onClick={() => { }} isActive={true} />
 					</div>
 
 					<div className="flex space-x-3 rounded-sm border border-dashed border-[#9747FF] p-3">
-						<CautionToggleButton onClick={() => {}} isActive={false} />
-						<CautionToggleButton onClick={() => {}} isActive={true} />
+						<CautionToggleButton onClick={() => { }} isActive={false} />
+						<CautionToggleButton onClick={() => { }} isActive={true} />
 					</div>
 				</div>
 
 				<div className="w-1/3 rounded-sm border border-dashed border-[#9747FF] flex flex-col justify-start space-y-5 p-5">
 					<Input
 						placeholder="우리 학교를 검색해보세요"
-						handleVoiceInput={() => {}}
+						handleVoiceInput={() => { }}
 						onLengthChange={(e: string) => {
 							console.log(e);
 						}}
 					/>
-					<RouteInput onClick={() => {}} placeholder="출발지를 입력하세요">
+					<RouteInput onClick={() => { }} placeholder="출발지를 입력하세요">
 						<OriginIcon />
 					</RouteInput>
 
 					<RouteInput
-						onClick={() => {}}
+						onClick={() => { }}
 						placeholder="도착지를 입력하세요"
 						value={destination}
 						onCancel={() => setDestination("")}

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -32,6 +32,7 @@ import { getAllBuildings } from "../api/nodes";
 import { getNavigationResult } from "../api/route";
 import useQueryError from "../hooks/useQueryError";
 import { Coord } from "../data/types/coord";
+import AnimatedContainer from "../container/animatedContainer";
 
 
 export type SelectedMarkerTypes = {
@@ -575,23 +576,42 @@ export default function MapPage() {
 				selectedMarker={selectedMarker}
 				isVisible={selectedMarker?.type === Markers.BUILDING ? true : false}
 			/>
-			{origin && destination && origin.nodeId !== destination.nodeId ? (
-				/** 출발지랑 도착지가 존재하는 경우 길찾기 버튼 보이기 */
+			{/* 출발지랑 도착지가 존재하는 경우 길찾기 버튼 보이기 */}
+			<AnimatedContainer
+				isVisible={origin !== undefined && destination !== undefined && origin.nodeId !== destination.nodeId}
+				positionDelta={200}
+				transition={{
+					duration: 0.3,
+					type: 'spring',
+					damping: 20,
+				}}
+				className=""
+			>
 				<div onClick={() => findFastRoute()} className="absolute bottom-6 space-y-2 w-full px-4">
 					<Button variant="primary">길찾기</Button>
 				</div>
-			) : (
-				/** 출발지랑 도착지가 존재하지 않거나, 같은 경우 기존 Button UI 보이기 */
-				<>
-					<div className="absolute right-4 bottom-6 space-y-2">
-						<ReportButton onClick={open} />
-					</div>
-					<div className="absolute right-4 bottom-[90px] space-y-2">
-						<CautionToggleButton isActive={isCautionAcitve} onClick={toggleCautionButton} />
-						<DangerToggleButton isActive={isDangerAcitve} onClick={toggleDangerButton} />
-					</div>
-				</>
-			)}
+			</AnimatedContainer>
+
+			{/* 출발지랑 도착지가 존재하지 않거나, 같은 경우 기존 Button UI 보이기 */}
+			<AnimatedContainer
+				isVisible={!(origin !== undefined && destination !== undefined && origin.nodeId !== destination.nodeId)}
+				positionDelta={200}
+				transition={{
+					duration: 0.3,
+					type: 'spring',
+					damping: 20,
+				}}
+				className=""
+			>
+				<div className="absolute right-4 bottom-6 space-y-2">
+					<ReportButton onClick={open} />
+				</div>
+				<div className="absolute right-4 bottom-[90px] space-y-2">
+					<CautionToggleButton isActive={isCautionAcitve} onClick={toggleCautionButton} />
+					<DangerToggleButton isActive={isDangerAcitve} onClick={toggleDangerButton} />
+				</div>
+			</AnimatedContainer>
+
 			{isOpen && <ReportModal close={close} />}
 			<FailModal />
 		</div>

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -3,7 +3,7 @@ import useMap from "../hooks/useMap";
 import createMarkerElement from "../components/map/mapMarkers";
 import { Building, NodeId } from "../data/types/node";
 import MapBottomSheet from "../components/map/mapBottomSheet";
-import MapTopSheet from "../components/map/TopSheet";
+import { MapTopBuildingSheet, MapTopRouteSheet } from "../components/map/TopSheet";
 import { CautionToggleButton, DangerToggleButton } from "../components/map/floatingButtons";
 import ReportButton from "../components/map/reportButton";
 import useRoutePoint from "../hooks/useRoutePoint";
@@ -31,6 +31,7 @@ import { getAllRisks } from "../api/routes";
 import { getAllBuildings } from "../api/nodes";
 import { getNavigationResult } from "../api/route";
 import useQueryError from "../hooks/useQueryError";
+
 
 export type SelectedMarkerTypes = {
 	type: MarkerTypes;
@@ -61,7 +62,7 @@ export default function MapPage() {
 	const [universityMarker, setUniversityMarker] = useState<AdvancedMarker>();
 
 	const { origin, setOrigin, destination, setDestination } = useRoutePoint();
-	const { building: selectedBuilding } = useSearchBuilding();
+	const { building: selectedBuilding, setBuilding, searchMode } = useSearchBuilding();
 
 	const [_, isOpen, open, close] = useModal();
 
@@ -477,6 +478,11 @@ export default function MapPage() {
 	useEffect(() => {
 		if (selectedMarker && selectedMarker.type === Markers.BUILDING) {
 			moveToBound();
+			setBuilding(selectedMarker.property as Building);
+		}
+
+		return () => {
+			setBuilding(undefined)
 		}
 	}, [selectedMarker]);
 
@@ -526,12 +532,13 @@ export default function MapPage() {
 
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center">
-			<MapTopSheet isVisible={selectedMarker ? false : true} />
+			<MapTopBuildingSheet isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode === "BUILDING"} />
+			<MapTopRouteSheet isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode != "BUILDING"} />
 			<div ref={mapRef} className="w-full h-full" />
 			<MapBottomSheet
 				selectRoutePoint={selectRoutePoint}
 				selectedMarker={selectedMarker}
-				isVisible={selectedMarker ? true : false}
+				isVisible={selectedMarker?.type === Markers.BUILDING ? true : false}
 			/>
 			{origin && destination && origin.nodeId !== destination.nodeId ? (
 				/** 출발지랑 도착지가 존재하는 경우 길찾기 버튼 보이기 */

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -337,6 +337,25 @@ export default function MapPage() {
 		if (!map || !marker) return;
 
 		if (marker.type === Markers.BUILDING && marker.property) {
+			if (marker.id === origin?.nodeId) {
+				marker.element.content = createMarkerElement({
+					type: Markers.ORIGIN,
+					title: marker.property.buildingName,
+					className: "translate-routemarker",
+				});
+				return;
+			}
+
+			if (marker.id === destination?.nodeId) {
+				marker.element.content = createMarkerElement({
+					type: Markers.DESTINATION,
+					title: destination.buildingName,
+					className: "translate-routemarker",
+				});
+				return;
+			}
+
+
 			if (isSelect) {
 				marker.element.content = createMarkerElement({
 					type: Markers.SELECTED_BUILDING,
@@ -345,20 +364,6 @@ export default function MapPage() {
 				});
 
 				return;
-			}
-
-			if (marker.id === origin?.nodeId) {
-				marker.element.content = createMarkerElement({
-					type: Markers.ORIGIN,
-					title: marker.property.buildingName,
-					className: "translate-routemarker",
-				});
-			} else if (marker.id === destination?.nodeId) {
-				marker.element.content = createMarkerElement({
-					type: Markers.DESTINATION,
-					title: destination.buildingName,
-					className: "translate-routemarker",
-				});
 			}
 
 			marker.element.content = createMarkerElement({

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -178,7 +178,7 @@ export default function MapPage() {
 
 			const buildingMarker = createAdvancedMarker(
 				AdvancedMarker,
-				null,
+				(nodeId === origin?.nodeId || nodeId === destination?.nodeId) ? map : null,
 				new google.maps.LatLng(lat, lng),
 				createMarkerElement({ type: Markers.BUILDING, title: buildingName, className: "translate-marker" }),
 				() => {
@@ -450,6 +450,8 @@ export default function MapPage() {
 		const originMarker = findBuildingMarker(origin.nodeId);
 		if (!originMarker) return;
 
+		originMarker.map = map;
+
 		originMarker.content = createMarkerElement({
 			type: Markers.ORIGIN,
 			title: origin.buildingName,
@@ -473,6 +475,8 @@ export default function MapPage() {
 
 		const destinationMarker = findBuildingMarker(destination.nodeId);
 		if (!destinationMarker) return;
+
+		destinationMarker.map = map;
 
 		destinationMarker.content = createMarkerElement({
 			type: Markers.DESTINATION,


### PR DESCRIPTION
## #️⃣ 작업 내용

1.  지도 메인페이지 UX / UI 개선
2. TopSheet, BottomSheet 재설정
3. 시작 도착 선택시 해당 마커를 보일 수 있도록 지도 이동
4. 지도 검색 페이지, 뒤로가기 버튼 추가

## 주요 기능

### 상단 Input Top Sheet 2가지 생성
```typescript
	<MapTopBuildingSheet isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode === "BUILDING"} />
	<MapTopRouteSheet isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode != "BUILDING"} />
	<div ref={mapRef} className="w-full h-full" />
	<MapBottomSheet
		selectRoutePoint={selectRoutePoint}
		selectedMarker={selectedMarker}
		isVisible={selectedMarker?.type === Markers.BUILDING ? true : false}
	/>
```

- 시트를 보여주는 시나리오는 총 3가지가 존재합니다.
- 1. 건물을 선택하여 BottomSheet 보여주기
- 2. 건물을 검색하기 위한 건물 검색 TopSheet 보여주기
- 3. 경로를 검색하기 위한 경로 검색 TopSheet 보여주기

- 2번과 3번을 구분하기 위해, 기존에 있던 useSearchBuilding에서 2가지 모드를 3가지 `BUILDING, ORIGIN, DESTINATION`으로 재정의하고 검색 모드가 `BUILDING`인지 아닌지로 구분하였습니다.

- 그리고 모드가 바뀜에 따라 TopSheet간의 전환이 자연스럽게 진행하도록 애니메이션을 적용하였습니다.

### 사용자 건물 선택 로직 (시나리오 변경)
- 직접 UX를 설계하는 과정이 필요하여 제 나름대로 설계를 하고 Flow 차트를 그려봤습니다.


- 1. 건물 검색 버튼
- 2. 경로 검색 버튼
- 3. 바텀 시트

- 3가지의 주요 컴포넌트 간의 관계도 입니다.

![KakaoTalk_Photo_2025-02-13-17-38-10](https://github.com/user-attachments/assets/aefb1da5-5e10-4130-a22e-18efa36e991f)

### 동적 지도 이동
- 출발, 도착을 선택한 경우에 해당 위치에 맞게 지도를 조정하고자 @jpark0506 준혁님께서 작성해주신 moveToBound 함수를 약간 변형하여 사용하였습니다.
```typescript
const moveToBound = (coord: Coord) => {
		buildingBoundary.current = new google.maps.LatLngBounds();
		buildingBoundary.current.extend(
			coord
		);
		// 라이브러리를 다양한 화면을 관찰해보았을 때, h-가 377인것을 확인했습니다.
		map?.fitBounds(buildingBoundary.current, {
			top: 0,
			right: 0,
			bottom: BOTTOM_SHEET_HEIGHT,
			left: 0,
		});
	};
```
- 이동시킬 좌표를 입력받아서 이동되도록 변경하였고
```typescript

	/** 출발 도착 설정시, 출발 도착지가 한 눈에 보이도록 지도 조정 */
	useEffect(() => {
		if (origin && destination) {
			const newBound = new google.maps.LatLngBounds();
			newBound.extend(origin);
			newBound.extend(destination)
			map?.fitBounds(newBound)
		}

	}, [origin, destination]);

```
- 출발 도착지가 결정된 경우에, 자연스럽게 이동할 수 있도록 두 점을 포함하였습니다.
- 이 과정에서 매우 먼 거리를 출발 도착으로 선정한경우, 줌이 바뀌어 마커가 안보이는 경우가 발생하였습니다.
```typescript
useEffect(() => {
		if (!map) return;

		if (prevZoom.current >= 17 && zoom <= 16) {
			if (isCautionAcitve) {
				toggleMarkers(
					false,
					cautionMarkers.map((marker) => marker.element),
					map,
				);
			}
			if (isDangerAcitve) {
				toggleMarkers(
					false,
					dangerMarkers.map((marker) => marker.element),
					map,
				);
			}

			toggleMarkers(true, universityMarker ? [universityMarker] : [], map);
			toggleMarkers(false, buildingMarkers.filter(el => el.nodeId !== origin?.nodeId && el.nodeId !== destination?.nodeId).map(el => el.element), map);
	}, [map, zoom]);
```

- 그리하여, 줌이 변경되더라도, 출발, 도착 건물 마커는 toggle되지 않도록하였습니다.
- 또한, 출발 도착을 변경하는 경우에도 마커가 해제되는 문제를 발견하여 
```typescript
	/** 도착지 결정 시, Marker Content 변경 */
	useEffect(() => {
		if (!destination || !destination.nodeId) return;

		const destinationMarker = findBuildingMarker(destination.nodeId);
		if (!destinationMarker) return;

		destinationMarker.map = map;

		destinationMarker.content = createMarkerElement({
			type: Markers.DESTINATION,
			title: destination.buildingName,
			className: "translate-routemarker",
		});

		return () => {
			const curZoom = map?.getZoom() as number;

			destinationMarker.content = createMarkerElement({
				type: Markers.BUILDING,
				title: destination.buildingName,
				className: "translate-marker",
			});
			if (curZoom <= 16) destinationMarker.map = null;
		};
	}, [destination, buildingMarkers]);
```
- 다음과 같이, 항상 map을 map으로 설정하고 cleanUp에서 zoom을 가져오도록하여 출발 도착이 해제되는 경우에만 지도에서 지우도록 하였습니다.
- 이때, zoom State를 사용할경우, cleanUp이 되는 즉, 전체적으로 state가 변경되기 전의 zoom을 가져와 map.getZoom()으로 라이브 줌을 가져올 수 있도록 하였습니다.


### 애니메이션 적용
- 하단 CTA 버튼과 플로팅 버튼에 애니메이션을 부여하여 자연스러운 노출, 소멸을 유도하였습니다.

### 버그 수정,
- 기존에 #48 에서 수정했던 출발, 도착 마커가 선택하더라도 스타일이 변경되지 않는 수정사항이 로직 변경으로 인해 다시 발생하여 수정하였습니다.

## 동작 화면

### 상단 검색 전환

https://github.com/user-attachments/assets/e3d6a1ef-c159-4360-8eb6-2ab656d20f2c


### 길 찾기 유저 로직 변화

https://github.com/user-attachments/assets/f1eae1b0-9855-4b96-b861-b3c475e34b48

### 출발 도착 선택 시, 지도 동적 이동

https://github.com/user-attachments/assets/efdaa987-8bad-4d3b-a5d2-789b36c5b711

### CTA, 플로팅 버튼 애니메이션

https://github.com/user-attachments/assets/1ebeafe8-7c10-4991-a4fd-f87be19341f8


