### PR TITLE
[UNI-219] feat: 로그인 기능 구현 및 JWT 인터셉터 구현

### DIFF
--- a/uniro_backend/build.gradle
+++ b/uniro_backend/build.gradle
@@ -78,6 +78,12 @@ dependencies {
 	testImplementation 'org.testcontainers:jdbc:1.19.5'
 	testImplementation 'org.testcontainers:mysql:1.19.5'
 
+	// jwt
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+	implementation 'com.auth0:java-jwt:4.4.0'
+
 }
 
 tasks.named('test') {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthApi.java
@@ -1,0 +1,23 @@
+package com.softeer5.uniro_backend.admin.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.softeer5.uniro_backend.admin.dto.request.LoginReqDTO;
+import com.softeer5.uniro_backend.admin.dto.response.LoginResDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "admin 로그인 페이지 API")
+public interface AuthApi {
+	@Operation(summary = "로그인")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "로그인 성공"),
+		@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
+	})
+	ResponseEntity<LoginResDTO> login(@RequestBody LoginReqDTO loginReqDTO);
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthApi.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "admin 로그인 페이지 API")
 public interface AuthApi {
@@ -19,5 +20,5 @@ public interface AuthApi {
 		@ApiResponse(responseCode = "200", description = "로그인 성공"),
 		@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
-	ResponseEntity<LoginResDTO> login(@RequestBody LoginReqDTO loginReqDTO);
+	ResponseEntity<LoginResDTO> login(@RequestBody @Valid LoginReqDTO loginReqDTO);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.softeer5.uniro_backend.admin.dto.request.LoginReqDTO;
 import com.softeer5.uniro_backend.admin.dto.response.LoginResDTO;
 import com.softeer5.uniro_backend.admin.service.AuthService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -17,7 +18,7 @@ public class AuthController implements AuthApi {
 	private final AuthService authService;
 	@Override
 	@PostMapping("/admin/auth/login")
-	public ResponseEntity<LoginResDTO> login(@RequestBody LoginReqDTO loginReqDTO) {
+	public ResponseEntity<LoginResDTO> login(@RequestBody @Valid LoginReqDTO loginReqDTO) {
 		LoginResDTO loginResDTO = authService.login(loginReqDTO);
 		return ResponseEntity.ok(loginResDTO);
 	}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.softeer5.uniro_backend.admin.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.softeer5.uniro_backend.admin.dto.request.LoginReqDTO;
+import com.softeer5.uniro_backend.admin.dto.response.LoginResDTO;
+import com.softeer5.uniro_backend.admin.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController implements AuthApi {
+	private final AuthService authService;
+	@Override
+	@PostMapping("/admin/auth/login")
+	public ResponseEntity<LoginResDTO> login(@RequestBody LoginReqDTO loginReqDTO) {
+		LoginResDTO loginResDTO = authService.login(loginReqDTO);
+		return ResponseEntity.ok(loginResDTO);
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/request/LoginReqDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/request/LoginReqDTO.java
@@ -1,0 +1,20 @@
+package com.softeer5.uniro_backend.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema(name = "LoginReqDTO", description = "로그인 요청 DTO")
+public class LoginReqDTO {
+	@Schema(description = "대학교 id", example = "1001")
+	@NotNull
+	private final Long univId;
+
+	@Schema(description = "인증 코드", example = "abcd123")
+	@NotNull
+	private final String code;
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/LoginResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/LoginResDTO.java
@@ -1,0 +1,17 @@
+package com.softeer5.uniro_backend.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(name = "LoginResDTO", description = "로그인 응답 DTO")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoginResDTO {
+	private final String accessToken;
+
+	public static LoginResDTO of(String accessToken) {
+		return new LoginResDTO(accessToken);
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/entity/Admin.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/entity/Admin.java
@@ -1,0 +1,33 @@
+package com.softeer5.uniro_backend.admin.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Admin {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotNull
+	private String code;
+
+	@NotNull
+	private Long univId;
+
+	@Builder
+	private Admin(Long id, String code, Long univId) {
+		this.id = id;
+		this.code = code;
+		this.univId = univId;
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/AdminInterceptor.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/AdminInterceptor.java
@@ -1,5 +1,7 @@
 package com.softeer5.uniro_backend.admin.interceptor;
 
+import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -7,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.softeer5.uniro_backend.admin.jwt.SecurityContext;
+import com.softeer5.uniro_backend.common.exception.custom.AdminException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,8 +29,7 @@ public class AdminInterceptor implements HandlerInterceptor {
 			Long adminUnivId = SecurityContext.getUnivId(); // JWT에서 가져온 univId
 
 			if (!univId.equals(adminUnivId)) {
-				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized university access");
-				return false;
+				throw new AdminException("Unauthorized university access", UNAUTHORIZED_UNIV);
 			}
 		}
 		return true;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/AdminInterceptor.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/AdminInterceptor.java
@@ -1,0 +1,36 @@
+package com.softeer5.uniro_backend.admin.interceptor;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.softeer5.uniro_backend.admin.jwt.SecurityContext;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class AdminInterceptor implements HandlerInterceptor {
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		String requestURI = request.getRequestURI();
+
+		// "/admin/{univId}/" 패턴만 검증
+		Pattern pattern = Pattern.compile("^/admin/(\\d+)/.*$");
+		Matcher matcher = pattern.matcher(requestURI);
+
+		if (matcher.matches()) {
+			Long univId = Long.valueOf(matcher.group(1)); // URL에서 univId 추출
+			Long adminUnivId = SecurityContext.getUnivId(); // JWT에서 가져온 univId
+
+			if (!univId.equals(adminUnivId)) {
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized university access");
+				return false;
+			}
+		}
+		return true;
+	}
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/JwtInterceptor.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/JwtInterceptor.java
@@ -1,0 +1,59 @@
+package com.softeer5.uniro_backend.admin.interceptor;
+
+import com.softeer5.uniro_backend.admin.jwt.JwtTokenProvider;
+import com.softeer5.uniro_backend.admin.jwt.SecurityContext;
+import com.softeer5.uniro_backend.common.exception.custom.AdminException;
+import com.softeer5.uniro_backend.common.error.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtInterceptor implements HandlerInterceptor {
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public JwtInterceptor(JwtTokenProvider jwtTokenProvider) {
+		this.jwtTokenProvider = jwtTokenProvider;
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		String uri = request.getRequestURI();
+
+		// ✅ 로그인 API는 인터셉터 우회
+		if (uri.startsWith("/admin/auth/")) {
+			return true;
+		}
+
+		// ✅ "/admin/{univId}/*" 패턴만 인증 적용
+		if (!uri.matches("^/admin/\\d+/.*$")) {
+			return true;
+		}
+
+		String authHeader = request.getHeader("Authorization");
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+			throw new AdminException("Invalid token", ErrorCode.INVALID_TOKEN);
+		}
+
+		String token = authHeader.substring(7); // "Bearer " 제거
+
+		if (!jwtTokenProvider.validateToken(token)) {
+			throw new AdminException("Invalid token", ErrorCode.INVALID_TOKEN);
+		}
+
+		Long univId = jwtTokenProvider.getUnivId(token);
+
+		// ✅ SecurityContext에 저장 (ThreadLocal 방식)
+		SecurityContext.setUnivId(univId);
+
+		return true; // 컨트롤러 실행 허용
+	}
+
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+		// 요청 처리 후 SecurityContext 비우기
+		SecurityContext.clear();
+	}
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/JwtInterceptor.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/interceptor/JwtInterceptor.java
@@ -19,17 +19,7 @@ public class JwtInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-		String uri = request.getRequestURI();
-
-		// ✅ 로그인 API는 인터셉터 우회
-		if (uri.startsWith("/admin/auth/")) {
-			return true;
-		}
-
-		// ✅ "/admin/{univId}/*" 패턴만 인증 적용
-		if (!uri.matches("^/admin/\\d+/.*$")) {
-			return true;
-		}
+		// Authorization 헤더에서 JWT 토큰 추출
 
 		String authHeader = request.getHeader("Authorization");
 		if (authHeader == null || !authHeader.startsWith("Bearer ")) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/jwt/JwtTokenProvider.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/jwt/JwtTokenProvider.java
@@ -1,0 +1,50 @@
+package com.softeer5.uniro_backend.admin.jwt;
+
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+@Component
+public class JwtTokenProvider {
+
+	@Value("${jwt.secret}")
+	private String secretKey; // 실제로는 안전한 방법으로 관리해야 함
+	private final long validityInMilliseconds = 36000000000L; // 10000 hour
+
+	public String createToken(Long univId) {
+		final Claims claims = Jwts.claims().setSubject(String.valueOf(univId));
+		Date now = new Date();
+		Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(validity)
+			.signWith(SignatureAlgorithm.HS256, secretKey)
+			.compact();
+	}
+
+	public Long getUnivId(String token) {
+		return Long.parseLong(Jwts.parser()
+			.setSigningKey(secretKey)
+			.parseClaimsJws(token)
+			.getBody()
+			.getSubject());
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
+	}
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/jwt/SecurityContext.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/jwt/SecurityContext.java
@@ -1,0 +1,18 @@
+package com.softeer5.uniro_backend.admin.jwt;
+
+public class SecurityContext {
+	private static final ThreadLocal<Long> univIdHolder = new ThreadLocal<>();
+
+	public static void setUnivId(Long univId) {
+		univIdHolder.set(univId);
+	}
+
+	public static Long getUnivId() {
+		return univIdHolder.get();
+	}
+
+	public static void clear() {
+		univIdHolder.remove();
+	}
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/AdminRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.softeer5.uniro_backend.admin.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.softeer5.uniro_backend.admin.entity.Admin;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+	Optional<Admin> findByUnivId(Long univId);
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AuthService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AuthService.java
@@ -1,0 +1,36 @@
+package com.softeer5.uniro_backend.admin.service;
+
+import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.softeer5.uniro_backend.admin.dto.request.LoginReqDTO;
+import com.softeer5.uniro_backend.admin.dto.response.LoginResDTO;
+import com.softeer5.uniro_backend.admin.entity.Admin;
+import com.softeer5.uniro_backend.admin.jwt.JwtTokenProvider;
+import com.softeer5.uniro_backend.admin.repository.AdminRepository;
+import com.softeer5.uniro_backend.common.exception.custom.AdminException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final AdminRepository adminRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public LoginResDTO login(LoginReqDTO loginReqDTO) {
+
+		Admin admin = adminRepository.findByUnivId(loginReqDTO.getUnivId())
+			.orElseThrow(() -> new AdminException("invalid univ id", INVALID_UNIV_ID));
+
+		if (!admin.getCode().equals(loginReqDTO.getCode())) {
+			throw new AdminException("invalid code", INVALID_ADMIN_CODE);
+		}
+
+		return LoginResDTO.of(jwtTokenProvider.createToken(admin.getUnivId()));
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
@@ -22,6 +22,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		// JWT 인터셉터는 더 먼저 실행되도록 우선순위 낮춤
 		registry.addInterceptor(jwtInterceptor)
 			.addPathPatterns("/admin/{univId}/**") // "/admin/{univId}/" 패턴만 적용
+			.excludePathPatterns("/admin/auth/login")
 			.order(0); // 가장 먼저 실행되도록 설정
 
 		// AdminInterceptor는 그 다음에 실행

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
@@ -1,0 +1,35 @@
+package com.softeer5.uniro_backend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.softeer5.uniro_backend.admin.interceptor.AdminInterceptor;
+import com.softeer5.uniro_backend.admin.interceptor.JwtInterceptor;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+	private final AdminInterceptor adminInterceptor;
+	private final JwtInterceptor jwtInterceptor; // JWT 인터셉터 추가
+
+	public WebMvcConfig(AdminInterceptor adminInterceptor, JwtInterceptor jwtInterceptor) {
+		this.adminInterceptor = adminInterceptor;
+		this.jwtInterceptor = jwtInterceptor;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		// JWT 인터셉터는 더 먼저 실행되도록 우선순위 낮춤
+		registry.addInterceptor(jwtInterceptor)
+			.addPathPatterns("/admin/{univId}/**") // "/admin/{univId}/" 패턴만 적용
+			.order(0); // 가장 먼저 실행되도록 설정
+
+		// AdminInterceptor는 그 다음에 실행
+		registry.addInterceptor(adminInterceptor)
+			.addPathPatterns("/admin/{univId}/**") // "/admin/{univId}/" 패턴만 적용
+			.excludePathPatterns("/admin/auth/login")
+			.order(1); // JWT 이후에 실행되도록 설정
+	}
+}
+
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -37,7 +37,7 @@ public enum ErrorCode {
     INVALID_ADMIN_CODE(403, "유효하지 않은 어드민 코드 입니다."),
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     UNAUTHORIZED_UNIV(401, "해당 대학교의 권한이 없습니다."),
-    INVALID_UNIV_ID(500, "유효하지 않은 대학교 id 입니다."),
+    INVALID_UNIV_ID(400, "유효하지 않은 대학교 id 입니다."),
     ;
 
     private final int httpStatus;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -1,7 +1,5 @@
 package com.softeer5.uniro_backend.common.error;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -35,7 +33,11 @@ public enum ErrorCode {
     INTERSECTION_ONLY_ALLOWED_POINT(400, "기존 경로와 겹칠 수 없습니다."),
 
     // 어드민
-    INVALID_VERSION_ID(400, "유효하지 않은 버전 id 입니다.")
+    INVALID_VERSION_ID(400, "유효하지 않은 버전 id 입니다."),
+    INVALID_ADMIN_CODE(403, "유효하지 않은 어드민 코드 입니다."),
+    INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
+    UNAUTHORIZED_UNIV(401, "해당 대학교의 권한이 없습니다."),
+    INVALID_UNIV_ID(500, "유효하지 않은 대학교 id 입니다."),
     ;
 
     private final int httpStatus;

--- a/uniro_backend/src/main/resources/application-dev.yml
+++ b/uniro_backend/src/main/resources/application-dev.yml
@@ -39,3 +39,6 @@ management:
 
 cors:
   allowed-origins: ${allowed-origins}
+
+jwt:
+  secret: ${JWT_SECRET}

--- a/uniro_backend/src/main/resources/application-local.yml
+++ b/uniro_backend/src/main/resources/application-local.yml
@@ -40,3 +40,6 @@ management:
 
 cors:
   allowed-origins: ${allowed-origins}
+
+jwt:
+  secret: ${JWT_SECRET}

--- a/uniro_backend/src/main/resources/application-test.yml
+++ b/uniro_backend/src/main/resources/application-test.yml
@@ -24,3 +24,6 @@ map:
 
 cors:
   allowed-origins: ${allowed-origins}
+
+jwt:
+  secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
### 1. 로그인 기능 구현 및 Admin 엔티티 정의
- 로그인 기능을 구현했습니다. code와 univId 를 입력하면 액세스 토큰을 발행하는 로직입니다.
- admin 엔티티 정의도 같이 봐주시면 감사하겠습니다 !

### 2. JWT 인터셉터 구현
- 기존에는 필터를 통해 구현하려고 했으나 스프링 시큐리티를 사용하지 않고 빠르게 구현하기 조금 어렵다고 판단했습니다.
- 따라서 인터셉터로 구현하여 컨트롤러 단 전에서 필터링 하도록 구현했습니다.

### 3. Admin 인터셉터 구현
- 어드민 인증은 되었지만, 특정 대학교가 아닌 다른 대학교의 접근은 금지하는 것이 필요했습니다.
- 처음에는 서비스 로직에 if 문으로 뺄려고 했습니다.
- 하지만 중복된 코드가 많고, 실제 서비스 로직과 관심사가 다르다고 생각하여 인터셉터로 분리하였습니다.
- 이에 대해 의견 있으시면 편하게 말씀주세요 !!

<img width="798" alt="스크린샷 2025-02-13 오후 6 23 27" src="https://github.com/user-attachments/assets/54043d67-3421-48e3-a08c-b145c5441886" />
<br>

- **해당 세팅은 WebMvcConfig 를 통해서도 확인 가능합니다.**

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="703" alt="스크린샷 2025-02-13 오후 6 19 17" src="https://github.com/user-attachments/assets/e864a918-a2b1-4047-80f6-c120eae4d1a3" />
<img width="685" alt="스크린샷 2025-02-13 오후 6 19 47" src="https://github.com/user-attachments/assets/41f65b27-cc0e-406c-8f36-0606facec6f4" />


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/