### PR TITLE
[UNI-194] feat : 길 찾기 로직을 도보, 휠체어, 전동휠체어로 제공하도록 구현

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/RouteDifferInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/RouteDifferInfo.java
@@ -22,6 +22,6 @@ public class RouteDifferInfo {
     private final double cost;
 
     public static RouteDifferInfo of(Route route) {
-        return new RouteDifferInfo(route.getCautionFactorsByList(), route.getDangerFactorsByList(), route.getCost());
+        return new RouteDifferInfo(route.getCautionFactorsByList(), route.getDangerFactorsByList(), route.getDistance());
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -8,6 +8,6 @@ public final class UniroConst {
 	public static final double MANUAL_WHEELCHAIR_SECONDS_PER_MITER = 2.5;
 	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 1.0;
 	public static final double EARTH_RADIUS = 6378137;
-	public static final double BUILDING_ROUTE_COST = 1e8;
+	public static final double BUILDING_ROUTE_DISTANCE = 1e8;
 	public static final int IS_SINGLE_ROUTE = 2;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -7,7 +7,7 @@ public final class UniroConst {
 	public static final double PEDESTRIAN_SECONDS_PER_MITER = 1.2;
 	public static final double MANUAL_WHEELCHAIR_SECONDS_PER_MITER = 2.5;
 	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 1.0;
-	public static final double METERS_PER_DEGREE = 113000.0;
+	public static final double EARTH_RADIUS = 6378137;
 	public static final double BUILDING_ROUTE_COST = 1e8;
 	public static final int IS_SINGLE_ROUTE = 2;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -4,7 +4,9 @@ public final class UniroConst {
 	public static final String NODE_KEY_DELIMITER = " ";
 	public static final int CORE_NODE_CONDITION = 3;
 	public static final int BEFORE_DEFAULT_ORDER = -1;
-	public static final double SECONDS_PER_MITER = 1.666;
+	public static final double PEDESTRIAN_SECONDS_PER_MITER = 1.2;
+	public static final double MANUAL_WHEELCHAIR_SECONDS_PER_MITER = 2.5;
+	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 1.0;
 	public static final double METERS_PER_DEGREE = 113000.0;
 	public static final double BUILDING_ROUTE_COST = 1e8;
 	public static final int IS_SINGLE_ROUTE = 2;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/RouteUtils.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/RouteUtils.java
@@ -11,6 +11,6 @@ public final class RouteUtils {
     }
 
     public static boolean isBuildingRoute(Route route){
-        return route.getCost() > BUILDING_ROUTE_COST - 1;
+        return route.getDistance() > BUILDING_ROUTE_COST - 1;
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/RouteUtils.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/utils/RouteUtils.java
@@ -2,7 +2,7 @@ package com.softeer5.uniro_backend.common.utils;
 
 import com.softeer5.uniro_backend.map.entity.Route;
 
-import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_COST;
+import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_DISTANCE;
 
 public final class RouteUtils {
 
@@ -11,6 +11,6 @@ public final class RouteUtils {
     }
 
     public static boolean isBuildingRoute(Route route){
-        return route.getDistance() > BUILDING_ROUTE_COST - 1;
+        return route.getDistance() > BUILDING_ROUTE_DISTANCE - 1;
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
@@ -20,6 +20,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @Tag(name = "간선 및 위험&주의 요소 관련 Api")
 public interface MapApi {
 
@@ -68,9 +70,9 @@ public interface MapApi {
 			@ApiResponse(responseCode = "200", description = "빠른 길 계산 성공"),
 			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
-	ResponseEntity<FastestRouteResDTO> findFastestRoute(@PathVariable("univId") Long univId,
-																	@RequestParam Long startNodeId,
-																	@RequestParam Long endNodeId);
+	ResponseEntity<List<FastestRouteResDTO>> findFastestRoute(@PathVariable("univId") Long univId,
+															  @RequestParam Long startNodeId,
+															  @RequestParam Long endNodeId);
 
 
 	@Operation(summary = "빌딩 노드와 연결된 길 생성")

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
@@ -18,6 +18,8 @@ import com.softeer5.uniro_backend.map.service.MapService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RestController
 public class MapController implements MapApi {
@@ -66,10 +68,10 @@ public class MapController implements MapApi {
 
 	@Override
 	@GetMapping("/{univId}/routes/fastest")
-	public ResponseEntity<FastestRouteResDTO> findFastestRoute(@PathVariable("univId") Long univId,
-																	@RequestParam(value = "start-node-id") Long startNodeId,
-																	@RequestParam(value = "end-node-id") Long endNodeId) {
-		FastestRouteResDTO fastestRouteResDTO = mapService.findFastestRoute(univId, startNodeId, endNodeId);
+	public ResponseEntity<List<FastestRouteResDTO>> findFastestRoute(@PathVariable("univId") Long univId,
+																	 @RequestParam(value = "start-node-id") Long startNodeId,
+																	 @RequestParam(value = "end-node-id") Long endNodeId) {
+		List<FastestRouteResDTO> fastestRouteResDTO = mapService.findFastestRoute(univId, startNodeId, endNodeId);
 		return ResponseEntity.ok(fastestRouteResDTO);
 	}
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/FastestRouteResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/FastestRouteResDTO.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Schema(name = "FastestRouteResDTO", description = "빠른 경로 조회 DTO")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class FastestRouteResDTO {
-    @Schema(description = "길찾기 타입 (PEDES-도보, WHEEL_FAST-휠체어빠른, WHEEL_SAFE-휠체어안전)", example = "true")
+    @Schema(description = "길찾기 타입 (PEDES-도보, WHEEL_FAST-휠체어빠른, WHEEL_SAFE-휠체어안전)", example = "PEDES")
     private final RoadExclusionPolicy routeType;
     @Schema(description = "길 찾기 결과에 위험요소가 포함되어있는지 여부", example = "true")
     private final boolean hasCaution;
@@ -20,9 +20,9 @@ public class FastestRouteResDTO {
     private final double totalDistance;
     @Schema(description = "총 걸리는 시간(초) - 도보", example = "1050.32198432")
     private final Double pedestrianTotalCost;
-    @Schema(description = "총 걸리는 시간(초) - 수동휠체어", example = "1050.32198432")
+    @Schema(description = "총 걸리는 시간(초) - 수동휠체어", example = "2253.51234432")
     private final Double manualTotalCost;
-    @Schema(description = "총 걸리는 시간(초) - 전동휠체어", example = "1050.32198432")
+    @Schema(description = "총 걸리는 시간(초) - 전동휠체어", example = "935.3125632")
     private final Double electricTotalCost;
     @Schema(description = "길 찾기 결과에 포함된 모든 길", example = "")
     private final List<RouteInfoResDTO> routes;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/FastestRouteResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/FastestRouteResDTO.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.map.dto.response;
 
+import com.softeer5.uniro_backend.map.entity.RoadExclusionPolicy;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,22 +12,38 @@ import java.util.List;
 @Schema(name = "FastestRouteResDTO", description = "빠른 경로 조회 DTO")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class FastestRouteResDTO {
+    @Schema(description = "길찾기 타입 (PEDES-도보, WHEEL_FAST-휠체어빠른, WHEEL_SAFE-휠체어안전)", example = "true")
+    private final RoadExclusionPolicy routeType;
     @Schema(description = "길 찾기 결과에 위험요소가 포함되어있는지 여부", example = "true")
     private final boolean hasCaution;
     @Schema(description = "총 이동거리", example = "150.3421234")
     private final double totalDistance;
-    @Schema(description = "총 걸리는 시간(초)", example = "1050.32198432")
-    private final double totalCost;
+    @Schema(description = "총 걸리는 시간(초) - 도보", example = "1050.32198432")
+    private final Double pedestrianTotalCost;
+    @Schema(description = "총 걸리는 시간(초) - 수동휠체어", example = "1050.32198432")
+    private final Double manualTotalCost;
+    @Schema(description = "총 걸리는 시간(초) - 전동휠체어", example = "1050.32198432")
+    private final Double electricTotalCost;
     @Schema(description = "길 찾기 결과에 포함된 모든 길", example = "")
     private final List<RouteInfoResDTO> routes;
     @Schema(description = "상세안내 관련 정보", example = "")
     private final List<RouteDetailResDTO> routeDetails;
 
-    public static FastestRouteResDTO of(boolean hasCaution,
+    public static FastestRouteResDTO of(RoadExclusionPolicy routeType,
+                                        boolean hasCaution,
                                         double totalDistance,
-                                        double totalCost,
+                                        Double pedestrianTotalCost,
+                                        Double manualTotalCost,
+                                        Double electricTotalCost,
                                         List<RouteInfoResDTO> routes,
                                         List<RouteDetailResDTO> routeDetails) {
-        return new FastestRouteResDTO(hasCaution,totalDistance,totalCost,routes,routeDetails);
+        return new FastestRouteResDTO(routeType,
+                hasCaution,
+                totalDistance,
+                pedestrianTotalCost,
+                manualTotalCost,
+                electricTotalCost,
+                routes,
+                routeDetails);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/RoadExclusionPolicy.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/RoadExclusionPolicy.java
@@ -12,16 +12,16 @@ public enum RoadExclusionPolicy {
         boolean isCaution = !route.getCautionFactors().isEmpty();
         boolean isDanger = !route.getDangerFactors().isEmpty();
         return switch(policy){
-            case PEDES -> !isCaution && !isDanger;
+            case PEDES -> true;
             case WHEEL_FAST -> !isDanger;
-            case WHEEL_SAFE -> true;
+            case WHEEL_SAFE -> !isCaution && !isDanger;
             default -> false;
         };
     }
 
-    public static Double calculateCost(RoadExclusionPolicy policy, double type, double cost){
-        boolean isWheel = (type==PEDESTRIAN_SECONDS_PER_MITER);
-        double totalCost = type * cost;
+    public static Double calculateCost(RoadExclusionPolicy policy, double type, double distance){
+        boolean isWheel = (type!=PEDESTRIAN_SECONDS_PER_MITER);
+        double totalCost = type * distance;
         if(isWheel && policy == PEDES) return null;
         if(!isWheel && policy != PEDES) return null;
         return totalCost;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/RoadExclusionPolicy.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/RoadExclusionPolicy.java
@@ -1,0 +1,29 @@
+package com.softeer5.uniro_backend.map.entity;
+
+import static com.softeer5.uniro_backend.common.constant.UniroConst.PEDESTRIAN_SECONDS_PER_MITER;
+
+public enum RoadExclusionPolicy {
+
+    PEDES,
+    WHEEL_FAST,
+    WHEEL_SAFE;
+
+    public static boolean isAvailableRoute(RoadExclusionPolicy policy, Route route) {
+        boolean isCaution = !route.getCautionFactors().isEmpty();
+        boolean isDanger = !route.getDangerFactors().isEmpty();
+        return switch(policy){
+            case PEDES -> !isCaution && !isDanger;
+            case WHEEL_FAST -> !isDanger;
+            case WHEEL_SAFE -> true;
+            default -> false;
+        };
+    }
+
+    public static Double calculateCost(RoadExclusionPolicy policy, double type, double cost){
+        boolean isWheel = (type==PEDESTRIAN_SECONDS_PER_MITER);
+        double totalCost = type * cost;
+        if(isWheel && policy == PEDES) return null;
+        if(!isWheel && policy != PEDES) return null;
+        return totalCost;
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Route.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Route.java
@@ -41,7 +41,7 @@ public class Route {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private double cost;
+	private double distance;
 
 	private LineString path;
 
@@ -95,12 +95,12 @@ public class Route {
 	public void updateFromRevision(Route revRoute){
 		this.cautionFactors = revRoute.getCautionFactors();
 		this.dangerFactors = revRoute.getDangerFactors();
-		this.cost = revRoute.cost;
+		this.distance = revRoute.distance;
 	}
 
 	public boolean isEqualRoute(Route route) {
 		if(!route.getId().equals(this.getId())) return false;
-		if(route.getCost() != this.getCost())return false;
+		if(route.getDistance() != this.getDistance())return false;
 		if(!route.getCautionFactors().equals(this.getCautionFactors())) return false;
 		if(!route.getDangerFactors().equals(this.getDangerFactors())) return false;
 
@@ -108,9 +108,9 @@ public class Route {
 	}
 
 	@Builder
-	private Route(double cost, LineString path, Node node1, Node node2, Long univId,
-		Set<CautionFactor> cautionFactors, Set<DangerFactor> dangerFactors) {
-		this.cost = cost;
+	private Route(double distance, LineString path, Node node1, Node node2, Long univId,
+				  Set<CautionFactor> cautionFactors, Set<DangerFactor> dangerFactors) {
+		this.distance = distance;
 		this.path = path;
 		this.node1 = node1;
 		this.node2 = node2;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -1,6 +1,6 @@
 package com.softeer5.uniro_backend.map.service;
 
-import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_COST;
+import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_DISTANCE;
 import static com.softeer5.uniro_backend.common.constant.UniroConst.CORE_NODE_CONDITION;
 import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
 import static com.softeer5.uniro_backend.common.utils.GeoUtils.getInstance;
@@ -133,7 +133,7 @@ public class MapService {
 		}
 
 		Route route = Route.builder()
-				.distance(BUILDING_ROUTE_COST)
+				.distance(BUILDING_ROUTE_DISTANCE)
 				.path(geometryFactory.createLineString(
 						new Coordinate[] {buildingNode.getCoordinates().getCoordinate(),
 								connectedNode.getCoordinates().getCoordinate()}))

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -57,7 +57,7 @@ public class MapService {
 		return routeCalculator.assembleRoutes(routes);
 	}
 
-	public FastestRouteResDTO findFastestRoute(Long univId, Long startNodeId, Long endNodeId){
+	public List<FastestRouteResDTO> findFastestRoute(Long univId, Long startNodeId, Long endNodeId){
 
 		if(startNodeId.equals(endNodeId)){
 			throw new RouteCalculationException("Start and end nodes cannot be the same", SAME_START_AND_END_POINT);
@@ -69,7 +69,7 @@ public class MapService {
 			|| buildings.get(0).getNodeId().equals(buildings.get(1).getNodeId())
 			|| buildings.stream().anyMatch(building -> !Objects.equals(building.getUnivId(), univId))){
 
-			throw new RouteCalculationException("Unable to find a valid route", ErrorCode.FASTEST_ROUTE_NOT_FOUND);
+			throw new BuildingException("Building not found", BUILDING_NOT_FOUND);
 		}
 
 		List<Route> routesWithNode = routeRepository.findAllRouteByUnivIdWithNodes(univId);
@@ -133,7 +133,7 @@ public class MapService {
 		}
 
 		Route route = Route.builder()
-				.cost(BUILDING_ROUTE_COST)
+				.distance(BUILDING_ROUTE_COST)
 				.path(geometryFactory.createLineString(
 						new Coordinate[] {buildingNode.getCoordinates().getCoordinate(),
 								connectedNode.getCoordinates().getCoordinate()}))

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -297,14 +297,22 @@ public class RouteCalculator {
                 route.getNode2().getCoordinates().getY());
     }
 
-    // 길의 길이를 리턴하는 메서드
+    // 하버사인 공식으로 길의 길이를 리턴하는 메서드
     private double calculateDistance(double lng1, double lat1, double lng2, double lat2) {
-        double dLat = (lat2 - lat1) * METERS_PER_DEGREE;
+        double radLat1 = Math.toRadians(lat1);
+        double radLat2 = Math.toRadians(lat2);
+        double radLng1 = Math.toRadians(lng1);
+        double radLng2 = Math.toRadians(lng2);
 
-        double avgLat = (lat1 + lat2) / 2.0;
-        double dLng = (lng2 - lng1) * METERS_PER_DEGREE * Math.cos(Math.toRadians(avgLat));
+        double deltaLat = radLat2 - radLat1;
+        double deltaLng = radLng2 - radLng1;
 
-        return Math.sqrt(dLat * dLat + dLng * dLng);
+        double a = Math.pow(Math.sin(deltaLat / 2), 2)
+                + Math.cos(radLat1) * Math.cos(radLat2)
+                * Math.pow(Math.sin(deltaLng / 2), 2);
+        double c = 2 * Math.asin(Math.sqrt(a));
+
+        return EARTH_RADIUS * c;
     }
 
     // 길 상세정보를 추출하는 메서드

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -158,7 +158,7 @@ public class RouteCalculator {
             }
 
             //처음과 마지막을 제외한 구간에서 빌딩노드를 거쳐왔다면, 이는 유효한 길이 없는 것이므로 예외처리
-            if (totalDistance > BUILDING_ROUTE_COST - 1) continue;
+            if (totalDistance > BUILDING_ROUTE_DISTANCE - 1) continue;
 
             List<RouteDetailResDTO> details = getRouteDetail(startNode, endNode, shortestRoutes);
 
@@ -252,7 +252,7 @@ public class RouteCalculator {
     }
 
     private boolean isBuildingRoute(Route route){
-        return route.getDistance() > BUILDING_ROUTE_COST - 1;
+        return route.getDistance() > BUILDING_ROUTE_DISTANCE - 1;
     }
 
     // 두 route 간의 각도를 통한 계산으로 방향성을 정하는 메서드

--- a/uniro_backend/src/main/resources/data.sql
+++ b/uniro_backend/src/main/resources/data.sql
@@ -11,7 +11,7 @@ VALUES
 
 -- 목 데이터 삽입
 INSERT INTO
-    route (id, cost, path, node1_id, node2_id, univ_id, core_route_id, caution_factors, danger_factors)
+    route (id, distance, path, node1_id, node2_id, univ_id, core_route_id, caution_factors, danger_factors)
 VALUES
     (1, 10.5, ST_GeomFromText('LINESTRING(30.001 37.001, 30.002 37.002)', 4326), 1, 2, 1001, NULL, '["SLOPE", "CURB"]', '["STAIRS"]'),
     (2, 20.0, ST_GeomFromText('LINESTRING(30.002 37.002, 30.003 37.003)', 4326), 2, 3, 1001, NULL, '["CRACK"]', '["SLOPE", "STAIRS"]'),

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/RouteFixture.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/RouteFixture.java
@@ -34,4 +34,16 @@ public class RouteFixture {
 				.path(convertDoubleToLineString(List.of(new double[]{1.0, 2.0}, new double[]{3.0, 4.0})))
 				.build();
 	}
+
+	public static Route createRouteWithDistance(Node node1, Node node2, double distance){
+		return Route.builder()
+				.distance(distance)
+				.node1(node1)
+				.node2(node2)
+				.univId(1001L)
+				.cautionFactors(new HashSet<>())
+				.dangerFactors(new HashSet<>())
+				.build();
+	}
+
 }

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
@@ -1,0 +1,124 @@
+package com.softeer5.uniro_backend.map.service;
+
+import com.softeer5.uniro_backend.building.entity.Building;
+import com.softeer5.uniro_backend.building.repository.BuildingRepository;
+import com.softeer5.uniro_backend.fixture.NodeFixture;
+import com.softeer5.uniro_backend.fixture.RouteFixture;
+import com.softeer5.uniro_backend.map.dto.response.FastestRouteResDTO;
+import com.softeer5.uniro_backend.map.entity.CautionFactor;
+import com.softeer5.uniro_backend.map.entity.DangerFactor;
+import com.softeer5.uniro_backend.map.entity.Node;
+import com.softeer5.uniro_backend.map.entity.Route;
+import com.softeer5.uniro_backend.map.repository.NodeRepository;
+import com.softeer5.uniro_backend.map.repository.RouteRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_COST;
+
+@SpringBootTest
+@Testcontainers
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional
+class RouteCalculatorTest {
+    @Autowired
+    MapService mapService;
+    @Autowired
+    NodeRepository nodeRepository;
+    @Autowired
+    BuildingRepository buildingRepository;
+    @Autowired
+    RouteRepository routeRepository;
+
+
+    @Nested
+    class 경로추가 {
+        @Test
+        void 기본_길찾기() {
+            Node n1 = NodeFixture.createNode(0, 0);
+            Node n2 = NodeFixture.createNode(0, 0);
+            Node n3 = NodeFixture.createNode(0, 0);
+            Node n4 = NodeFixture.createNode(0, 0);
+            Node n5 = NodeFixture.createNode(0, 0);
+            Node n6 = NodeFixture.createNode(0, 0);
+            Node n7 = NodeFixture.createNode(0, 0);
+            Node n8 = NodeFixture.createNode(0, 0);
+
+            Route r1 = RouteFixture.createRouteWithDistance(n1, n2, BUILDING_ROUTE_COST);
+            Route r2 = RouteFixture.createRouteWithDistance(n2, n3, 15);
+            Route r3 = RouteFixture.createRouteWithDistance(n3, n7, 1);
+            Route r4 = RouteFixture.createRouteWithDistance(n3, n4, 6);
+            Route r5 = RouteFixture.createRouteWithDistance(n4, n5, BUILDING_ROUTE_COST);
+            Route r6 = RouteFixture.createRouteWithDistance(n5, n6, BUILDING_ROUTE_COST);
+            Route r7 = RouteFixture.createRouteWithDistance(n6, n7, 18);
+            Route r8 = RouteFixture.createRouteWithDistance(n7, n8, 3);
+            Route r9 = RouteFixture.createRouteWithDistance(n8, n1, BUILDING_ROUTE_COST);
+
+            Building b1 = Building.builder().nodeId(1L).univId(1001L).build();
+            Building b5 = Building.builder().nodeId(5L).univId(1001L).build();
+
+            nodeRepository.saveAll(List.of(n1, n2, n3, n4, n5, n6, n7, n8));
+            routeRepository.saveAll(List.of(r1, r2, r3, r4, r5, r6, r7, r8, r9));
+            buildingRepository.saveAll(List.of(b1, b5));
+
+            System.out.println("########## 기본 #############");
+            List<FastestRouteResDTO> fastestRoute = mapService.findFastestRoute(1001L, 1L, 5L);
+
+            for (FastestRouteResDTO f : fastestRoute) {
+                printFastestRouteResDTO(f);
+            }
+
+            System.out.println("########## 주의요소 추가 #############");
+            List<CautionFactor> cautionFactorsList = new ArrayList<>();
+            cautionFactorsList.add(CautionFactor.CRACK);
+            r3.setCautionFactorsByList(cautionFactorsList);
+
+            routeRepository.save(r3);
+
+            fastestRoute = mapService.findFastestRoute(1001L, 1L, 5L);
+
+            for (FastestRouteResDTO f : fastestRoute) {
+                printFastestRouteResDTO(f);
+            }
+
+            System.out.println("########## 위험요소 추가 #############");
+
+            List<DangerFactor> dangerFactorsList = new ArrayList<>();
+            dangerFactorsList.add(DangerFactor.ETC);
+            r6.setDangerFactorsByList(dangerFactorsList);
+            r2.setDangerFactorsByList(dangerFactorsList);
+
+            routeRepository.save(r6);
+
+            fastestRoute = mapService.findFastestRoute(1001L, 1L, 5L);
+
+            for (FastestRouteResDTO f : fastestRoute) {
+                printFastestRouteResDTO(f);
+            }
+
+        }
+    }
+
+    public static void printFastestRouteResDTO(FastestRouteResDTO dto) {
+        System.out.println("--------------------------------------------------");
+        System.out.println("Route Type           : " + dto.getRouteType());
+        System.out.println("Has Caution          : " + dto.isHasCaution());
+        System.out.println("Total Distance       : " + dto.getTotalDistance());
+        System.out.println("Pedestrian Total Cost: " + dto.getPedestrianTotalCost());
+        System.out.println("Manual Total Cost    : " + dto.getManualTotalCost());
+        System.out.println("Electric Total Cost  : " + dto.getElectricTotalCost());
+
+        System.out.println("--------------------------------------------------");
+    }
+
+}

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
@@ -23,7 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_COST;
+import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_DISTANCE;
 
 @SpringBootTest
 @Testcontainers
@@ -54,15 +54,15 @@ class RouteCalculatorTest {
             Node n7 = NodeFixture.createNode(0, 0);
             Node n8 = NodeFixture.createNode(0, 0);
 
-            Route r1 = RouteFixture.createRouteWithDistance(n1, n2, BUILDING_ROUTE_COST);
+            Route r1 = RouteFixture.createRouteWithDistance(n1, n2, BUILDING_ROUTE_DISTANCE);
             Route r2 = RouteFixture.createRouteWithDistance(n2, n3, 15);
             Route r3 = RouteFixture.createRouteWithDistance(n3, n7, 1);
             Route r4 = RouteFixture.createRouteWithDistance(n3, n4, 6);
-            Route r5 = RouteFixture.createRouteWithDistance(n4, n5, BUILDING_ROUTE_COST);
-            Route r6 = RouteFixture.createRouteWithDistance(n5, n6, BUILDING_ROUTE_COST);
+            Route r5 = RouteFixture.createRouteWithDistance(n4, n5, BUILDING_ROUTE_DISTANCE);
+            Route r6 = RouteFixture.createRouteWithDistance(n5, n6, BUILDING_ROUTE_DISTANCE);
             Route r7 = RouteFixture.createRouteWithDistance(n6, n7, 18);
             Route r8 = RouteFixture.createRouteWithDistance(n7, n8, 3);
-            Route r9 = RouteFixture.createRouteWithDistance(n8, n1, BUILDING_ROUTE_COST);
+            Route r9 = RouteFixture.createRouteWithDistance(n8, n1, BUILDING_ROUTE_DISTANCE);
 
             Building b1 = Building.builder().nodeId(1L).univId(1001L).build();
             Building b5 = Building.builder().nodeId(5L).univId(1001L).build();


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### 1. 길 찾기 로직의 결과를 도보, 휠체어, 전동휠체어로 제공
- 배리어프리 내비게이션의 특성을 따르기 위해 길 찾기 결과를 휠체어, 전동휠체어, 도보로 구분하고, 이를 각각 안전한길&빠른길로 제공하였습니다.
   - 이를 위해 길 찾기 로직을 도보 빠른길(주의/위험요소 무시), 휠체어 빠른길(위험요소 무시), 휠체어 안전한길(주의/위험요소 모두 고려)을 포함하여 총 3회 진행하였습니다.
   - 길 찾기 결과에 휠체어, 전동휠체어, 도보의 속도를 고려하여 소요시간을 책정하였습니다.

### 2. 길의 실제 거리를 측정하는 공식을 하버사인 공식으로 변경
- 길 찾기 공식을 Google Map에서 제공하는 방식과 동일하게 하버사인 공식으로 변경하였습니다.

### 3. route의 cost를 distance로 변경
- 길 찾기 결과에 휠체어,전동휠체어, 도보의 속도를 고려하는 방식으로 변경하였기 떄문에 기존 route의 cost를 distance로 변경하였습니다.
- 길 추가 로직에 calculateDistance()로 적절한 값 할당하도록 변경하였습니다.

### 4. 테스트코드
- 간단하게 정상출력 여부를 확인할 수 있는 테스트코드만 작성해 보았습니다. 추후 견고한 테스트 코드를 추가할 예정입니다.

## To reviewer
   - 기존 로직에선 길 찾기 도중 예외상황이 발생하면 예외를 던졌지만, 현재는 총 3회 진행하기 때문에 continue; 로 패스하는 방식을 사용하였습니다. 즉, continue는 exception이라고 생각하시면 될 것 같습니다.
   - 가독성을 위해 약간의 리팩토링을 진행하였습니다. (terminateBoundaryRoutes 메서드 분리)

## 🚨 merge하기 전 route의 cost 컬럼을 distance로 rename 해야함!!

## 🧪 테스트 결과
<img width="647" alt="image" src="https://github.com/user-attachments/assets/a5566683-26e6-437e-88d3-c3e52ed50693" />
