### PR TITLE
[UNI-217] fix: 길 추가시 동일한 노드 판단 로직 구현

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     //길 생성
     ELEVATION_API_ERROR(500, "구글 해발고도 API에서 오류가 발생했습니다."),
+    DUPLICATE_NEAREST_NODE(400, "중복된 인접 노드가 존재합니다."),
 
     // 건물 노드
     BUILDING_NOT_FOUND(404, "유효한 건물을 찾을 수 없습니다."),

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -500,6 +500,15 @@ public class RouteCalculator {
         for (int i = 1; i < requests.size(); i++) {
             CreateRouteReqDTO cur = requests.get(i);
 
+            for(int j = i+1; j < Math.min(i+3, requests.size()) ; j++){
+                CreateRouteReqDTO next = requests.get(j);
+				Coordinate curCoordinate = new Coordinate(cur.getLng(), cur.getLat());
+				Coordinate nextCoordinate = new Coordinate(next.getLng(), next.getLat());
+				if(getNodeKey(curCoordinate).equals(getNodeKey(nextCoordinate))){
+                    throw new RouteCalculationException("has duplicate nearest node", DUPLICATE_NEAREST_NODE);
+                }
+            }
+
             // 정확히 그 점과 일치하는 노드가 있는지 확인
             Node curNode = nodeMap.get(getNodeKey(new Coordinate(cur.getLng(), cur.getLat())));
             if(curNode != null){

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
@@ -321,7 +321,7 @@ class MapServiceTest {
 		}
 
 		@Test
-		@DisplayName("인접한 노드는 중복될 수 없다.")
+		@DisplayName("인접한 노드는 중복될 수 없다. a->b->b 경우 ")
 		void nearest_test1(){
 			// given
 			List<CreateRouteReqDTO> requests = List.of(
@@ -367,8 +367,56 @@ class MapServiceTest {
 		}
 
 		@Test
-		@DisplayName("동일한 노드가 2노드 이후에 있을 경우 정상 입력이다.")
+		@DisplayName("인접한 노드는 중복될 수 없다. a->b->a 경우 ")
 		void nearest_test2(){
+			// given
+			List<CreateRouteReqDTO> requests = List.of(
+				new CreateRouteReqDTO(37.554533318727884, 127.040754103711),
+				new CreateRouteReqDTO(37.554506962309226, 127.0407538544841),
+				new CreateRouteReqDTO(37.554480605890554, 127.04075360525738),
+				new CreateRouteReqDTO(37.5544542494719, 127.04075335603085),
+				new CreateRouteReqDTO(37.554427893053244, 127.04075310680449),
+
+				new CreateRouteReqDTO(37.55437473334863, 127.04076651784956),
+
+				new CreateRouteReqDTO(37.554367645389384, 127.0407906577353),
+
+				new CreateRouteReqDTO(37.55437473334863, 127.04076651784956),
+
+				new CreateRouteReqDTO(37.55436055742524, 127.04081479761643),
+				new CreateRouteReqDTO(37.554353469456174, 127.04083893749296),
+				new CreateRouteReqDTO(37.55436126622311, 127.04086665364699),
+				new CreateRouteReqDTO(37.55436906298358, 127.04089436980678),
+				new CreateRouteReqDTO(37.55437685973755, 127.04092208597243),
+				new CreateRouteReqDTO(37.55440095878911, 127.04091538046072),
+				new CreateRouteReqDTO(37.554425057840305, 127.04090867494469),
+				new CreateRouteReqDTO(37.554449156891096, 127.04090196942433),
+				new CreateRouteReqDTO(37.55447325594152, 127.04089526389961),
+				new CreateRouteReqDTO(37.55449735499156, 127.04088855837058),
+				new CreateRouteReqDTO(37.55452145404122, 127.0408818528372),
+				new CreateRouteReqDTO(37.55453208597017, 127.04085637186247),
+				new CreateRouteReqDTO(37.554542717893675, 127.04083089088046),
+				new CreateRouteReqDTO(37.554553349811684, 127.0408054098912),
+				new CreateRouteReqDTO(37.554563981724215, 127.04077992889464)
+			);
+
+			Node node1 = NodeFixture.createNode(37.554533318727884, 127.040754103711);
+			Node node2 = NodeFixture.createNode(0, 0);
+			List<Node> savedNode = nodeRepository.saveAll(List.of(node1, node2));
+
+			routeRepository.save(RouteFixture.createRoute(savedNode.get(0), savedNode.get(1)));
+
+			doNothing().when(mapClient).fetchHeights(anyList());
+
+			// when, then
+			Assertions.assertThatThrownBy(() -> mapService.createRoute(1001L, new CreateRoutesReqDTO(savedNode.get(0).getId(), null, requests)))
+				.isInstanceOf(RouteCalculationException.class)
+				.hasMessageContaining("has duplicate nearest node");
+		}
+
+		@Test
+		@DisplayName("동일한 노드가 2노드 이후에 있을 경우 정상 입력이다. a -> b -> c -> a 경우")
+		void nearest_test3(){
 			// given
 			List<CreateRouteReqDTO> requests = List.of(
 				new CreateRouteReqDTO(37.554533318727884, 127.040754103711),

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
@@ -1,20 +1,25 @@
 package com.softeer5.uniro_backend.map.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.softeer5.uniro_backend.common.exception.custom.RouteCalculationException;
+import com.softeer5.uniro_backend.external.MapClient;
 import com.softeer5.uniro_backend.fixture.NodeFixture;
 import com.softeer5.uniro_backend.fixture.RouteFixture;
 import com.softeer5.uniro_backend.map.dto.request.CreateRoutesReqDTO;
@@ -39,6 +44,9 @@ class MapServiceTest {
 	private RouteRepository routeRepository;
 	@Autowired
 	private NodeRepository nodeRepository;
+
+	@MockBean
+	private MapClient mapClient;
 
 	@Nested
 	class 경로추가{
@@ -311,6 +319,114 @@ class MapServiceTest {
 			assertThat(results).hasSize(6);
 			assertThat(results.get(1).isCore()).isTrue();
 		}
+
+		@Test
+		@DisplayName("인접한 노드는 중복될 수 없다.")
+		void nearest_test1(){
+			// given
+			List<CreateRouteReqDTO> requests = List.of(
+				new CreateRouteReqDTO(37.554533318727884, 127.040754103711),
+				new CreateRouteReqDTO(37.554506962309226, 127.0407538544841),
+				new CreateRouteReqDTO(37.554480605890554, 127.04075360525738),
+				new CreateRouteReqDTO(37.5544542494719, 127.04075335603085),
+				new CreateRouteReqDTO(37.554427893053244, 127.04075310680449),
+				new CreateRouteReqDTO(37.55437473334863, 127.04076651784956),
+
+				new CreateRouteReqDTO(37.55437473334863, 127.04076651784956),
+
+				new CreateRouteReqDTO(37.554367645389384, 127.0407906577353),
+				new CreateRouteReqDTO(37.55436055742524, 127.04081479761643),
+				new CreateRouteReqDTO(37.554353469456174, 127.04083893749296),
+				new CreateRouteReqDTO(37.55436126622311, 127.04086665364699),
+				new CreateRouteReqDTO(37.55436906298358, 127.04089436980678),
+				new CreateRouteReqDTO(37.55437685973755, 127.04092208597243),
+				new CreateRouteReqDTO(37.55440095878911, 127.04091538046072),
+				new CreateRouteReqDTO(37.554425057840305, 127.04090867494469),
+				new CreateRouteReqDTO(37.554449156891096, 127.04090196942433),
+				new CreateRouteReqDTO(37.55447325594152, 127.04089526389961),
+				new CreateRouteReqDTO(37.55449735499156, 127.04088855837058),
+				new CreateRouteReqDTO(37.55452145404122, 127.0408818528372),
+				new CreateRouteReqDTO(37.55453208597017, 127.04085637186247),
+				new CreateRouteReqDTO(37.554542717893675, 127.04083089088046),
+				new CreateRouteReqDTO(37.554553349811684, 127.0408054098912),
+				new CreateRouteReqDTO(37.554563981724215, 127.04077992889464)
+			);
+
+			Node node1 = NodeFixture.createNode(37.554533318727884, 127.040754103711);
+			Node node2 = NodeFixture.createNode(0, 0);
+			List<Node> savedNode = nodeRepository.saveAll(List.of(node1, node2));
+
+			routeRepository.save(RouteFixture.createRoute(savedNode.get(0), savedNode.get(1)));
+
+			doNothing().when(mapClient).fetchHeights(anyList());
+
+			// when, then
+			Assertions.assertThatThrownBy(() -> mapService.createRoute(1001L, new CreateRoutesReqDTO(savedNode.get(0).getId(), null, requests)))
+				.isInstanceOf(RouteCalculationException.class)
+				.hasMessageContaining("has duplicate nearest node");
+		}
+
+		@Test
+		@DisplayName("동일한 노드가 2노드 이후에 있을 경우 정상 입력이다.")
+		void nearest_test2(){
+			// given
+			List<CreateRouteReqDTO> requests = List.of(
+				new CreateRouteReqDTO(37.554533318727884, 127.040754103711),
+				new CreateRouteReqDTO(37.554506962309226, 127.0407538544841),
+				new CreateRouteReqDTO(37.554480605890554, 127.04075360525738),
+				new CreateRouteReqDTO(37.5544542494719, 127.04075335603085),
+				new CreateRouteReqDTO(37.554427893053244, 127.04075310680449),
+
+				new CreateRouteReqDTO(37.55437473334863, 127.04076651784956),
+
+				new CreateRouteReqDTO(37.554367645389384, 127.0407906577353),
+				new CreateRouteReqDTO(37.55436055742524, 127.04081479761643),
+
+				new CreateRouteReqDTO(37.55437473334863, 127.04076651784956),
+
+				new CreateRouteReqDTO(37.554353469456174, 127.04083893749296),
+				new CreateRouteReqDTO(37.55436126622311, 127.04086665364699),
+				new CreateRouteReqDTO(37.55436906298358, 127.04089436980678),
+				new CreateRouteReqDTO(37.55437685973755, 127.04092208597243),
+				new CreateRouteReqDTO(37.55440095878911, 127.04091538046072),
+				new CreateRouteReqDTO(37.554425057840305, 127.04090867494469),
+				new CreateRouteReqDTO(37.554449156891096, 127.04090196942433),
+				new CreateRouteReqDTO(37.55447325594152, 127.04089526389961),
+				new CreateRouteReqDTO(37.55449735499156, 127.04088855837058),
+				new CreateRouteReqDTO(37.55452145404122, 127.0408818528372),
+				new CreateRouteReqDTO(37.55453208597017, 127.04085637186247),
+				new CreateRouteReqDTO(37.554542717893675, 127.04083089088046),
+				new CreateRouteReqDTO(37.554553349811684, 127.0408054098912),
+				new CreateRouteReqDTO(37.554563981724215, 127.04077992889464)
+			);
+
+			Node node1 = NodeFixture.createNode(37.554533318727884, 127.040754103711);
+			Node node2 = NodeFixture.createNode(0, 0);
+			List<Node> savedNode = nodeRepository.saveAll(List.of(node1, node2));
+
+			routeRepository.save(RouteFixture.createRoute(savedNode.get(0), savedNode.get(1)));
+
+			doNothing().when(mapClient).fetchHeights(anyList());
+
+			// when
+			mapService.createRoute(1001L, new CreateRoutesReqDTO(savedNode.get(0).getId(), null, requests));
+
+			// then
+			List<Node> savedNodes = nodeRepository.findAll();
+
+			assertThat(savedNodes).hasSize(23);
+
+			int coreCount = 0;
+
+			for(Node n : savedNodes){
+				if(n.isCore()){
+					coreCount++;
+				}
+			}
+
+			assertThat(coreCount).isEqualTo(1);
+		}
+
 
 	}
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [X] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 근접(2 노드 미만)한 노드에서 동일한 좌표값의 노드가 들어올 경우 예외가 발생하도록 구현했습니다.

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 첫번째 요소도 검사를 해야했기에 for문을 2개 만들어야 하는 아쉬움이 있었습니다.
- 이를 개선하기 위해 코드의 가독성을 위해 원래 N번 순회하던 것을 2N 순회로 변경하였습니다.
- 성능적으로는 아쉬울 수 있지만 가독성이 높아졌고, N^2이 아닌 2N이라 괜찮다고 생각했는데 의견 궁금합니다!

## 🧪 테스트 결과
<img width="689" alt="스크린샷 2025-02-13 오후 11 44 30" src="https://github.com/user-attachments/assets/a3dd9c87-f515-4ed7-8bd0-015e5dd26fc9" />

<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/