### PR TITLE
[UNI-213] feat: 롤백 기능시 건물노드 삭제 기능 포함

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -8,6 +8,7 @@ import com.softeer5.uniro_backend.admin.entity.RevInfo;
 import com.softeer5.uniro_backend.admin.repository.NodeAuditRepository;
 import com.softeer5.uniro_backend.admin.repository.RevInfoRepository;
 import com.softeer5.uniro_backend.admin.repository.RouteAuditRepository;
+import com.softeer5.uniro_backend.building.repository.BuildingRepository;
 import com.softeer5.uniro_backend.common.exception.custom.AdminException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteException;
 import com.softeer5.uniro_backend.map.dto.response.GetAllRoutesResDTO;
@@ -35,6 +36,7 @@ public class AdminService {
     private final RevInfoRepository revInfoRepository;
     private final RouteRepository routeRepository;
     private final NodeRepository nodeRepository;
+    private final BuildingRepository buildingRepository;
 
     private final RouteAuditRepository routeAuditRepository;
     private final NodeAuditRepository nodeAuditRepository;
@@ -57,12 +59,10 @@ public class AdminService {
         List<Route> revRoutes = routeAuditRepository.getAllRoutesAtRevision(univId, versionId);
         List<Node> revNodes = nodeAuditRepository.getAllNodesAtRevision(univId, versionId);
 
-        // TODO: 시점 확인 필요
         routeRepository.deleteAllByCreatedAt(univId, revInfo.getRevTimeStamp());
         nodeRepository.deleteAllByCreatedAt(univId, revInfo.getRevTimeStamp());
+        buildingRepository.deleteAllByCreatedAt(univId, revInfo.getRevTimeStamp());
 
-        // TODO: 삭제 시점 및 삭제 순서 확인
-        // TODO: 빌딩 노드에 대한 고민
         routeAuditRepository.deleteAllAfterVersionId(univId, versionId);
         nodeAuditRepository.deleteAllAfterVersionId(univId, versionId);
         revInfoRepository.deleteAllAfterVersionId(univId, versionId);

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/entity/Building.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/entity/Building.java
@@ -1,7 +1,13 @@
 package com.softeer5.uniro_backend.building.entity;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +19,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Building {
 
 	@Id
@@ -41,5 +48,6 @@ public class Building {
 	@NotNull
 	private Long univId;
 
-
+	@CreatedDate
+	private LocalDateTime createdAt;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingRepository.java
@@ -1,10 +1,13 @@
 package com.softeer5.uniro_backend.building.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.softeer5.uniro_backend.building.service.vo.BuildingNode;
 import com.softeer5.uniro_backend.building.entity.Building;
@@ -33,4 +36,9 @@ public interface BuildingRepository extends JpaRepository<Building, Long>, Build
 	List<Building> findAllByNodeIdIn(List<Long> nodeIds);
 
 	boolean existsByNodeIdAndUnivId(Long nodeId, Long univId);
+
+	@Modifying(clearAutomatically = true)
+	@Transactional
+	@Query("DELETE FROM Building b WHERE b.univId = :univId AND b.createdAt > :versionTimeStamp")
+	void deleteAllByCreatedAt(Long univId, LocalDateTime versionTimeStamp);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 건물노드를 _aud 테이블에서 특별히 관리하진 않기로 했습니다.
- 하지만 롤백 기능 사용시, building 테이블에는 존재하지만, node 테이블에는 존재하지 않은 데이터가 발생할 여지가 있다고 생각했습니다.
- 이에 해당 문제를 해결하기 위해 특정 시점으로부터 만들어진 노드뿐만 아니라 building 도 삭제하도록 구현했습니다.

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/