### PR TITLE
[UNI-237] fix: 대학교 및 건물 이름 순으로 조회하도록 수정 맟 페이지네이션 삭제

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/controller/BuildingApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/controller/BuildingApi.java
@@ -41,7 +41,6 @@ public interface BuildingApi {
 	ResponseEntity<SearchBuildingResDTO> searchBuildings(
 		@PathVariable("univId") Long univId,
 		@RequestParam(value = "name", required = false) String name,
-		@RequestParam(value = "cursor-id", required = false) Long cursorId,
 		@RequestParam(value = "page-size", required = false) Integer pageSize
 	);
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/controller/BuildingController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/controller/BuildingController.java
@@ -39,10 +39,9 @@ public class BuildingController implements BuildingApi {
 	public ResponseEntity<SearchBuildingResDTO> searchBuildings(
 		@PathVariable("univId") Long univId,
 		@RequestParam(value = "name", required = false) String name,
-		@RequestParam(value = "cursor-id", required = false) Long cursorId,
-		@RequestParam(value = "page-size", required = false, defaultValue = "6") Integer pageSize
+		@RequestParam(value = "page-size", required = false, defaultValue = "10") Integer pageSize
 	) {
-		SearchBuildingResDTO searchBuildingResDTO = buildingService.searchBuildings(univId, name, cursorId, pageSize);
+		SearchBuildingResDTO searchBuildingResDTO = buildingService.searchBuildings(univId, name, pageSize);
 		return ResponseEntity.ok().body(searchBuildingResDTO);
 	}
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/dto/response/SearchBuildingResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/dto/response/SearchBuildingResDTO.java
@@ -15,13 +15,7 @@ public class SearchBuildingResDTO {
 	@Schema(description = "실제 data", example = "")
 	private final List<GetBuildingResDTO> data;
 
-	@Schema(description = "다음 페이지 요청을 위한 커서 ID (마지막 데이터의 ID)", example = "103")
-	private final Long nextCursor;
-
-	@Schema(description = "다음 페이지가 존재하는지 여부", example = "true")
-	private final boolean hasNext;
-
-	public static SearchBuildingResDTO of(List<GetBuildingResDTO> resDTOS, Long nextCursor, boolean hasNext) {
-		return new SearchBuildingResDTO(resDTOS, nextCursor, hasNext);
+	public static SearchBuildingResDTO of(List<GetBuildingResDTO> resDTOS) {
+		return new SearchBuildingResDTO(resDTOS);
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingCustomRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingCustomRepository.java
@@ -6,5 +6,5 @@ import com.softeer5.uniro_backend.common.CursorPage;
 import com.softeer5.uniro_backend.building.service.vo.BuildingNode;
 
 public interface BuildingCustomRepository {
-	CursorPage<List<BuildingNode>> searchBuildings(Long univId, String name, Long cursorId, Integer pageSize);
+	List<BuildingNode> searchBuildings(Long univId, String name, Integer pageSize);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingCustomRepositoryImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingCustomRepositoryImpl.java
@@ -34,7 +34,7 @@ public class BuildingCustomRepositoryImpl implements BuildingCustomRepository {
 				cursorIdCondition(cursorId),
 				nameCondition(name)
 			)
-			.orderBy(building.nodeId.asc()) // Cursor 기반에서는 정렬이 중요
+			.orderBy(building.name.asc()) // Cursor 기반에서는 정렬이 중요
 			.limit(pageSize + 1) // 다음 페이지 여부를 판단하기 위해 +1로 조회
 			.fetch();
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingCustomRepositoryImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/repository/BuildingCustomRepositoryImpl.java
@@ -23,37 +23,20 @@ public class BuildingCustomRepositoryImpl implements BuildingCustomRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public CursorPage<List<BuildingNode>> searchBuildings(Long univId, String name, Long cursorId, Integer pageSize) {
+	public List<BuildingNode> searchBuildings(Long univId, String name, Integer pageSize) {
 
-		List<BuildingNode> buildingNodes = queryFactory
+		return queryFactory
 			.select(new QBuildingNode(building, node))
 			.from(building)
 			.innerJoin(node).on(node.id.eq(building.nodeId))
 			.where(
 				building.univId.eq(univId),
-				cursorIdCondition(cursorId),
 				nameCondition(name)
 			)
-			.orderBy(building.name.asc()) // Cursor 기반에서는 정렬이 중요
-			.limit(pageSize + 1) // 다음 페이지 여부를 판단하기 위해 +1로 조회
+			.orderBy(building.name.asc())
+			.limit(pageSize)
 			.fetch();
-
-		// nextCursor 및 hasNext 판단
-		boolean hasNext = buildingNodes.size() > pageSize;
-		Long nextCursor = hasNext ? buildingNodes.get(pageSize).getBuilding().getNodeId() : null;
-
-		// 마지막 요소 제거 (다음 페이지 여부 판단용으로 추가된 데이터 제거)
-		if (hasNext) {
-			buildingNodes.remove(buildingNodes.size() - 1);
-		}
-
-		return new CursorPage<>(buildingNodes, nextCursor, hasNext);
 	}
-
-	private BooleanExpression cursorIdCondition(Long cursorId) {
-		return cursorId == null ? null : building.nodeId.gt(cursorId);
-	}
-
 	private BooleanExpression nameCondition(String name) {
 		return name == null || name.isEmpty() ? null : building.name.containsIgnoreCase(name);
 	}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/service/BuildingService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/service/BuildingService.java
@@ -46,15 +46,15 @@ public class BuildingService {
 			.toList();
 	}
 
-	public SearchBuildingResDTO searchBuildings(Long univId, String name, Long cursorId, Integer pageSize){
+	public SearchBuildingResDTO searchBuildings(Long univId, String name, Integer pageSize){
 
-		CursorPage<List<BuildingNode>> buildingNodes = buildingRepository.searchBuildings(univId, name, cursorId, pageSize);
+		List<BuildingNode> buildingNodes = buildingRepository.searchBuildings(univId, name, pageSize);
 
-		List<GetBuildingResDTO> data = buildingNodes.getData().stream()
+		List<GetBuildingResDTO> data = buildingNodes.stream()
 			.map(buildingNode -> GetBuildingResDTO.of(buildingNode.getBuilding(), buildingNode.getNode()))
 			.toList();
 
-		return SearchBuildingResDTO.of(data, buildingNodes.getNextCursor(), buildingNodes.isHasNext());
+		return SearchBuildingResDTO.of(data);
 	}
 
 	public GetBuildingResDTO getBuilding(Long nodeId){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/controller/UnivApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/controller/UnivApi.java
@@ -19,7 +19,6 @@ public interface UnivApi {
     })
     ResponseEntity<SearchUnivResDTO> searchUniv(
             @RequestParam(value = "name", required = false) String name,
-            @RequestParam(value = "cursor-id", required = false) Long cursorId,
             @RequestParam(value = "page-size", required = false) Integer pageSize
     );
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/controller/UnivController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/controller/UnivController.java
@@ -16,10 +16,9 @@ public class UnivController implements UnivApi {
     @Override
     @GetMapping("/univ/search")
     public ResponseEntity<SearchUnivResDTO> searchUniv(
-            @RequestParam(value = "name", required = false) String name,
-            @RequestParam(value = "cursor-id", required = false) Long cursorId,
-            @RequestParam(value = "page-size", required = false, defaultValue = "6") Integer pageSize){
-        SearchUnivResDTO searchResult = univService.searchUniv(name, cursorId, pageSize);
+        @RequestParam(value = "name", required = false) String name,
+        @RequestParam(value = "page-size", required = false, defaultValue = "10") Integer pageSize){
+        SearchUnivResDTO searchResult = univService.searchUniv(name, pageSize);
         return ResponseEntity.ok().body(searchResult);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/dto/SearchUnivResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/dto/SearchUnivResDTO.java
@@ -15,13 +15,7 @@ public class SearchUnivResDTO {
     @Schema(description = "실제 data", example = "")
     private final List<UnivInfo> data;
 
-    @Schema(description = "다음 페이지 요청을 위한 커서 ID (마지막 데이터의 ID)", example = "103")
-    private final Long nextCursor;
-
-    @Schema(description = "다음 페이지가 존재하는지 여부", example = "true")
-    private final boolean hasNext;
-
-    public static SearchUnivResDTO of(List<UnivInfo> univInfos, Long nextCursor, boolean hasNext) {
-        return new SearchUnivResDTO(univInfos,nextCursor,hasNext);
+    public static SearchUnivResDTO of(List<UnivInfo> univInfos) {
+        return new SearchUnivResDTO(univInfos);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepository.java
@@ -1,10 +1,9 @@
 package com.softeer5.uniro_backend.univ.repository;
 
-import com.softeer5.uniro_backend.common.CursorPage;
 import com.softeer5.uniro_backend.univ.dto.UnivInfo;
 
 import java.util.List;
 
 public interface UnivCustomRepository {
-    CursorPage<List<UnivInfo>> searchUniv(String name, Long cursorId, Integer pageSize);
+    List<UnivInfo> searchUniv(String name, Integer pageSize);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepositoryImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepositoryImpl.java
@@ -18,31 +18,17 @@ public class UnivCustomRepositoryImpl implements UnivCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public CursorPage<List<UnivInfo>> searchUniv(String name, Long cursorId, Integer pageSize) {
+    public List<UnivInfo> searchUniv(String name, Integer pageSize) {
 
-        List<UnivInfo> universities = queryFactory
+        return queryFactory
                 .select(new QUnivInfo(univ.id, univ.name, univ.imageUrl))
                 .from(univ)
                 .where(
-                        nameCondition(name),
-                        cursorIdCondition(cursorId)
+                    nameCondition(name)
                 )
                 .orderBy(univ.name.asc())
                 .limit(pageSize + 1)
                 .fetch();
-
-        boolean hasNext = universities.size() > pageSize;
-        Long nextCursor = hasNext ? universities.get(pageSize).getId() : null;
-
-        if (hasNext) {
-            universities.remove(universities.size() - 1);
-        }
-
-        return new CursorPage<>(universities, nextCursor, hasNext);
-    }
-
-    private BooleanExpression cursorIdCondition(Long cursorId) {
-        return cursorId == null ? null : univ.id.gt(cursorId);
     }
     private BooleanExpression nameCondition(String name) {
         return name == null || name.isEmpty() ? null : univ.name.containsIgnoreCase(name);

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepositoryImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepositoryImpl.java
@@ -27,7 +27,7 @@ public class UnivCustomRepositoryImpl implements UnivCustomRepository {
                     nameCondition(name)
                 )
                 .orderBy(univ.name.asc())
-                .limit(pageSize + 1)
+                .limit(pageSize)
                 .fetch();
     }
     private BooleanExpression nameCondition(String name) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepositoryImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/repository/UnivCustomRepositoryImpl.java
@@ -27,7 +27,7 @@ public class UnivCustomRepositoryImpl implements UnivCustomRepository {
                         nameCondition(name),
                         cursorIdCondition(cursorId)
                 )
-                .orderBy(univ.id.asc())
+                .orderBy(univ.name.asc())
                 .limit(pageSize + 1)
                 .fetch();
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/service/UnivService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/service/UnivService.java
@@ -16,8 +16,8 @@ import java.util.List;
 public class UnivService {
     private final UnivRepository univRepository;
 
-    public SearchUnivResDTO searchUniv(String name, Long cursorId, Integer pageSize) {
-        CursorPage<List<UnivInfo>> universities = univRepository.searchUniv(name,cursorId,pageSize);
-        return SearchUnivResDTO.of(universities.getData(),universities.getNextCursor(), universities.isHasNext());
+    public SearchUnivResDTO searchUniv(String name, Integer pageSize) {
+        List<UnivInfo> universities = univRepository.searchUniv(name, pageSize);
+        return SearchUnivResDTO.of(universities);
     }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 대학교 및 건물 이름 순으로 조회하도록 수정했습니다.
- 페이지네이션 삭제에 대해서는 논의 후에 적용하겠습니다.

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->

### 대학교 이름
<img width="713" alt="스크린샷 2025-02-15 오후 2 30 17" src="https://github.com/user-attachments/assets/d7e6fe67-aaae-4b72-8a3e-b435e63e9d9b" />

### 건물 이름
<img width="709" alt="스크린샷 2025-02-15 오후 2 30 02" src="https://github.com/user-attachments/assets/275482e2-8700-4ed1-bd1f-b97b902d6639" />


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/