### PR TITLE
[UNI-238] feat : 현재 버전과 특정 버전의 차이점 조회 API 구현

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/ChangedRouteDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/ChangedRouteDTO.java
@@ -16,7 +16,7 @@ public class ChangedRouteDTO {
     @Schema(description = "해당 버전 (과거)", example = "")
     private final RouteDifferInfo difference;
 
-    public static ChangedRouteDTO of(Long id, RouteDifferInfo current, RouteDifferInfo revision) {
-        return new ChangedRouteDTO(id, current, revision);
+    public static ChangedRouteDTO of(Long id, RouteDifferInfo current, RouteDifferInfo difference) {
+        return new ChangedRouteDTO(id, current, difference);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/ChangedRouteDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/ChangedRouteDTO.java
@@ -14,7 +14,7 @@ public class ChangedRouteDTO {
     @Schema(description = "현재", example = "")
     private final RouteDifferInfo current;
     @Schema(description = "해당 버전 (과거)", example = "")
-    private final RouteDifferInfo revision;
+    private final RouteDifferInfo difference;
 
     public static ChangedRouteDTO of(Long id, RouteDifferInfo current, RouteDifferInfo revision) {
         return new ChangedRouteDTO(id, current, revision);

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
@@ -1,6 +1,9 @@
 package com.softeer5.uniro_backend.admin.repository;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
@@ -35,4 +38,18 @@ public class RouteAuditRepository {
 			.executeUpdate();
 	}
 
+	public List<Route> findUpdatedRouteByUnivIdWithNodes(Long univId, Long versionId) {
+		AuditReader auditReader = AuditReaderFactory.get(entityManager);
+		List<Route> allRevisions = auditReader.createQuery()
+				.forRevisionsOfEntity(Route.class, true, true)
+				.add(AuditEntity.revisionNumber().gt(versionId))
+				.getResultList();
+
+		Map<Long, Route> uniqueRoutesMap = new HashMap<>();
+		for (Route route : allRevisions) {
+			// 이미 해당 엔티티 ID가 존재하면, 여기서 최신 리비전을 선택하는 로직을 추가할 수 있음
+			uniqueRoutesMap.put(route.getId(), route);
+		}
+		return new ArrayList<>(uniqueRoutesMap.values());
+	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
@@ -43,11 +43,11 @@ public class RouteAuditRepository {
 		List<Route> allRevisions = auditReader.createQuery()
 				.forRevisionsOfEntity(Route.class, true, true)
 				.add(AuditEntity.revisionNumber().gt(versionId))
+				.addOrder(AuditEntity.revisionNumber().asc())
 				.getResultList();
 
 		Map<Long, Route> uniqueRoutesMap = new HashMap<>();
 		for (Route route : allRevisions) {
-			// 이미 해당 엔티티 ID가 존재하면, 여기서 최신 리비전을 선택하는 로직을 추가할 수 있음
 			uniqueRoutesMap.put(route.getId(), route);
 		}
 		return new ArrayList<>(uniqueRoutesMap.values());

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
@@ -43,6 +43,7 @@ public class RouteAuditRepository {
 		List<Route> allRevisions = auditReader.createQuery()
 				.forRevisionsOfEntity(Route.class, true, true)
 				.add(AuditEntity.revisionNumber().gt(versionId))
+				.add(AuditEntity.property("univId").eq(univId))
 				.addOrder(AuditEntity.revisionNumber().asc())
 				.getResultList();
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -141,7 +141,7 @@ public class AdminService {
             revRouteMap.put(revRoute.getId(), revRoute);
         }
 
-        List<Route> routes = routeRepository.findAllRouteByUnivIdWithNodes(univId);
+        List<Route> routes = routeAuditRepository.findUpdatedRouteByUnivIdWithNodes(univId,versionId);
 
         Map<Long, List<Route>> lostAdjMap = new HashMap<>();
         Map<Long, Node> lostNodeMap = new HashMap<>();

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -12,6 +12,7 @@ import com.softeer5.uniro_backend.building.repository.BuildingRepository;
 import com.softeer5.uniro_backend.common.exception.custom.AdminException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteException;
 import com.softeer5.uniro_backend.map.dto.response.GetAllRoutesResDTO;
+import com.softeer5.uniro_backend.map.dto.response.GetChangedRoutesByRevisionResDTO;
 import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;
 import com.softeer5.uniro_backend.map.dto.response.NodeInfoResDTO;
 import com.softeer5.uniro_backend.map.entity.Node;
@@ -146,6 +147,54 @@ public class AdminService {
 
         return GetAllRoutesByRevisionResDTO.of(routesInfo, getRiskRoutesResDTO, lostRouteDTO, changedRoutes);
     }
+
+    public GetChangedRoutesByRevisionResDTO getChangedRoutesByRevision(Long univId, Long versionId) {
+        revInfoRepository.findById(versionId)
+                .orElseThrow(() -> new AdminException("invalid version id", INVALID_VERSION_ID));
+
+        List<Route> revRoutes = routeAuditRepository.getAllRoutesAtRevision(univId, versionId);
+
+        if(revRoutes.isEmpty()) {
+            throw new RouteException("Route Not Found", ROUTE_NOT_FOUND);
+        }
+
+        Map<Long, Route> revRouteMap = new HashMap<>();
+        for(Route revRoute : revRoutes){
+            revRouteMap.put(revRoute.getId(), revRoute);
+        }
+
+        List<Route> routes = routeRepository.findAllRouteByUnivIdWithNodes(univId);
+
+        Map<Long, List<Route>> lostAdjMap = new HashMap<>();
+        Map<Long, Node> lostNodeMap = new HashMap<>();
+        List<ChangedRouteDTO> changedRoutes = new ArrayList<>();
+        List<Route> riskRoutes = new ArrayList<>();
+
+        for(Route route : routes){
+            if(revRouteMap.containsKey(route.getId())){
+                Route revRoute = revRouteMap.get(route.getId());
+                handleRevisionRoute(revRoute, route, changedRoutes, riskRoutes);
+                continue;
+            }
+            //해당 시점 이후에 생성된 루트들 (과거 시점엔 보이지 않는 루트)
+            handleLostRoute(route, lostAdjMap, lostNodeMap);
+        }
+
+        //시작점이 1개인 nodeList 생성
+        List<Node> endNodes = determineEndNodes(lostAdjMap, lostNodeMap);
+
+        List<NodeInfoResDTO> lostNodeInfos = lostNodeMap.entrySet().stream()
+                .map(entry -> {
+                    Node node = entry.getValue();
+                    return NodeInfoResDTO.of(entry.getKey(), node.getX(), node.getY());
+                })
+                .toList();
+
+        LostRoutesDTO lostRouteDTO = LostRoutesDTO.of(lostNodeInfos, routeCalculator.getCoreRoutes(lostAdjMap, endNodes));
+
+        return GetChangedRoutesByRevisionResDTO.of(lostRouteDTO,changedRoutes);
+    }
+
 
     private void handleRevisionRoute(Route revRoute, Route route, List<ChangedRouteDTO> changedRoutes, List<Route> riskRoutes) {
         //변경사항이 있는 경우

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/setting/RevisionContext.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/setting/RevisionContext.java
@@ -31,5 +31,7 @@ public class RevisionContext {
 
     public static void clear() {
         univIdHolder.remove();
+        actionHolder.remove();
+        REVISION_TYPE_THREAD_LOCAL.remove();
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
@@ -2,10 +2,7 @@ package com.softeer5.uniro_backend.map.controller;
 
 import com.softeer5.uniro_backend.map.dto.request.CreateBuildingRouteReqDTO;
 import com.softeer5.uniro_backend.map.dto.request.CreateRoutesReqDTO;
-import com.softeer5.uniro_backend.map.dto.response.FastestRouteResDTO;
-import com.softeer5.uniro_backend.map.dto.response.GetAllRoutesResDTO;
-import com.softeer5.uniro_backend.map.dto.response.GetRiskResDTO;
-import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;
+import com.softeer5.uniro_backend.map.dto.response.*;
 import com.softeer5.uniro_backend.map.dto.request.PostRiskReqDTO;
 
 import jakarta.validation.Valid;
@@ -82,4 +79,12 @@ public interface MapApi {
 	})
 	ResponseEntity<Void> createBuildingRoute(@PathVariable("univId") Long univId,
 													@RequestBody @Valid CreateBuildingRouteReqDTO createBuildingRouteReqDTO);
+
+	@Operation(summary = "현재 버전과 특정 버전의 차이점 조회")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "현재 버전과 특정 버전의 차이점 조회 성공"),
+			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
+	})
+	ResponseEntity<GetChangedRoutesByRevisionResDTO> getChangedRoutesByRevision(@PathVariable("univId") Long univId,
+																				@PathVariable("versionId") Long versionId);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
@@ -1,11 +1,9 @@
 package com.softeer5.uniro_backend.map.controller;
 
+import com.softeer5.uniro_backend.admin.service.AdminService;
 import com.softeer5.uniro_backend.map.dto.request.CreateBuildingRouteReqDTO;
 import com.softeer5.uniro_backend.map.dto.request.CreateRoutesReqDTO;
-import com.softeer5.uniro_backend.map.dto.response.FastestRouteResDTO;
-import com.softeer5.uniro_backend.map.dto.response.GetAllRoutesResDTO;
-import com.softeer5.uniro_backend.map.dto.response.GetRiskResDTO;
-import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;
+import com.softeer5.uniro_backend.map.dto.response.*;
 import com.softeer5.uniro_backend.map.dto.request.PostRiskReqDTO;
 import com.softeer5.uniro_backend.map.service.RouteCalculator;
 
@@ -25,7 +23,7 @@ import java.util.List;
 public class MapController implements MapApi {
 
 	private final MapService mapService;
-	private final RouteCalculator routeCalculator;
+	private final AdminService adminService;
 
 	@Override
 	@GetMapping("/{univId}/routes")
@@ -81,6 +79,14 @@ public class MapController implements MapApi {
 													@RequestBody @Valid CreateBuildingRouteReqDTO createBuildingRouteReqDTO){
 		mapService.createBuildingRoute(univId,createBuildingRouteReqDTO);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@Override
+	@GetMapping("/{univId}/routes/{versionId}")
+	public ResponseEntity<GetChangedRoutesByRevisionResDTO> getChangedRoutesByRevision(@PathVariable("univId") Long univId,
+																					   @PathVariable("versionId") Long versionId){
+		GetChangedRoutesByRevisionResDTO getChangedRoutesByRevisionResDTO = adminService.getChangedRoutesByRevision(univId,versionId);
+		return ResponseEntity.ok(getChangedRoutesByRevisionResDTO);
 	}
 
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetChangedRoutesByRevisionResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetChangedRoutesByRevisionResDTO.java
@@ -1,0 +1,24 @@
+package com.softeer5.uniro_backend.map.dto.response;
+
+import com.softeer5.uniro_backend.admin.dto.response.ChangedRouteDTO;
+import com.softeer5.uniro_backend.admin.dto.response.LostRoutesDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Schema(name = "GetChangedRoutesByRevisionResDTO", description = "현재 버전과 특정 버전의 차이점 조회 응답 DTO")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetChangedRoutesByRevisionResDTO {
+    @Schema(description = "삭제된 길&노드 정보 정보", example = "")
+    private final LostRoutesDTO lostRoutes;
+    @Schema(description = "현재 버전과 비교하여 변경된 주의/위험 요소 정보", example = "")
+    private final List<ChangedRouteDTO> changedList;
+
+    public static GetChangedRoutesByRevisionResDTO of(LostRoutesDTO lostRoutes, List<ChangedRouteDTO> changedList) {
+        return new GetChangedRoutesByRevisionResDTO(lostRoutes,changedList);
+    }
+}

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
@@ -50,6 +50,7 @@ import jakarta.persistence.EntityManager;
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SqlGroup({
+	@Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
 	@Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 })
 class AdminServiceTest {
@@ -1057,7 +1058,6 @@ class AdminServiceTest {
 	}
 
 	@Test
-	@DisplayName("wiki 페이지 TC.6")
 	void 특정_버전_차이점_조회_테스트_with_위험_주의요소_변경(){
 		Node node1 = NodeFixture.createNode(1, 1);
 		Node node2 = NodeFixture.createNode(1, 2);

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
@@ -741,6 +741,372 @@ class AdminServiceTest {
 
 	}
 
+	@Test
+	void 특정_버전_차이점_조회_테스트_with_길추가(){
+		Node node1 = NodeFixture.createNode(1, 1);
+		Node node2 = NodeFixture.createNode(1, 2);
+		Node node3 = NodeFixture.createNode(1, 3);
+		Node node4 = NodeFixture.createNode(2,2);
+
+		Route route1 = RouteFixture.createRoute(node1, node2);
+		Route route2 = RouteFixture.createRoute(node2, node3);
+		Route route3 = RouteFixture.createRoute(node3, node4);
+
+		nodeRepository.saveAll(List.of(node1, node2));  // ver 1
+		routeRepository.saveAll(List.of(route1)); // ver 2
+		nodeRepository.saveAll(List.of(node3,node4));  // ver 3
+		routeRepository.saveAll(List.of(route2, route3)); // ver 4
+
+		//when
+		GetChangedRoutesByRevisionResDTO getChangedRoutesByRevisionResDTO = adminService.getChangedRoutesByRevision(1001L, 2L);
+
+		//then
+		LostRoutesDTO lostRoutes = getChangedRoutesByRevisionResDTO.getLostRoutes();  // 버전 3,4에 생성하여 버전2엔 존재하지 않는 routes
+
+
+		//a. version2에 존재하지 않는 맵 정보 확인
+
+		//a-1. ver 2에 존재하지 않는 노드가 3개인지? (node2, node3, node4)
+		List<NodeInfoResDTO> lostNodes = lostRoutes.getNodeInfos();
+		assertThat(lostNodes).hasSize(3);
+
+		//a-2. ver 2에 존재하는 코어route가 1개인지?
+		List<CoreRouteResDTO> lostCoreRoutes = lostRoutes.getCoreRoutes();
+		assertThat(lostCoreRoutes).hasSize(1);
+
+		//a-3. ver 2에 존재하는 간선이 2개인지? (route2, route3)
+		List<RouteCoordinatesInfoResDTO> lostRouteInfos = lostRoutes.getCoreRoutes().get(0).getRoutes();
+		assertThat(lostRouteInfos).hasSize(2);
+
+		//a-4. ver 2에 존재하지 않는 route가 route2, route3 인지?
+		List<Long> lostRouteIds = lostRouteInfos.stream()
+				.map(RouteCoordinatesInfoResDTO::getRouteId)
+				.collect(Collectors.toList());
+
+		assertThat(lostRouteIds)
+				.containsExactlyInAnyOrder(route2.getId(), route3.getId());
+
+
+	}
+
+	@Test
+	void 특정_버전_차이점_조회_테스트_with_서로다른_길_추가(){
+		Node node1 = NodeFixture.createNode(1, 1);
+		Node node2 = NodeFixture.createNode(1, 2);
+		Node node3 = NodeFixture.createNode(1, 3);
+		Node node4 = NodeFixture.createNode(2,2);
+		Node node5 = NodeFixture.createNode(0, 0);
+		Node node6 = NodeFixture.createNode(-1, -1);
+
+		Route route1 = RouteFixture.createRoute(node1, node2);
+		Route route2 = RouteFixture.createRoute(node2, node3);
+		Route route3 = RouteFixture.createRoute(node3, node4);
+		Route route4 = RouteFixture.createRoute(node1, node5);
+		Route route5 = RouteFixture.createRoute(node5, node6);
+
+		nodeRepository.saveAll(List.of(node1, node2));  // ver 1
+		routeRepository.saveAll(List.of(route1)); // ver 2
+
+		nodeRepository.saveAll(List.of(node3,node4));  // ver 3
+		routeRepository.saveAll(List.of(route2, route3)); // ver 4
+
+		nodeRepository.saveAll(List.of(node5,node6));  // ver 5
+		routeRepository.saveAll(List.of(route4, route5)); // ver 6
+
+		//when
+		GetChangedRoutesByRevisionResDTO getChangedRoutesByRevisionResDTO = adminService.getChangedRoutesByRevision(1001L, 2L);
+
+		//then
+		LostRoutesDTO lostRoutes = getChangedRoutesByRevisionResDTO.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
+
+		//a. version2에 존재하지 않는 맵 정보 확인
+
+		//a-1. ver 2에 존재하지 않는 노드가 6개인지? (node1, node2, node3, node4, node5, node6)
+		List<NodeInfoResDTO> lostNodes = lostRoutes.getNodeInfos();
+		assertThat(lostNodes).hasSize(6);
+
+		//a-2. ver 2에 존재하지 않는 코어route가 2개인지?
+		List<CoreRouteResDTO> lostCoreRoutes = lostRoutes.getCoreRoutes();
+		assertThat(lostCoreRoutes).hasSize(2);
+
+		//a-3. ver 2에 존재하지 않는 루트가 4개인지? (route2, route3, route4, route5)
+		int cnt = 0;
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			cnt += coreRoute.getRoutes().size();
+		}
+		assertThat(cnt).isEqualTo(4);
+
+		//a-4. ver 2에 존재하지 않는 route가 route2, route3, route4, route5 인지?
+		List<Long> lostRouteIds = new ArrayList<>();
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			for(RouteCoordinatesInfoResDTO route : coreRoute.getRoutes()) {
+				lostRouteIds.add(route.getRouteId());
+			}
+		}
+
+		assertThat(lostRouteIds)
+				.containsExactlyInAnyOrder(route2.getId(), route3.getId(), route4.getId(), route5.getId());
+
+
+	}
+
+	@Test
+	void 특정_버전_차이점_조회_테스트_with_서로다른_길_여러개_추가(){
+		Node node1 = NodeFixture.createNode(1, 1);
+		Node node2 = NodeFixture.createNode(1, 2);
+		Node node3 = NodeFixture.createNode(1, 3);
+		Node node4 = NodeFixture.createNode(2,2);
+		Node node5 = NodeFixture.createNode(0, 0);
+		Node node6 = NodeFixture.createNode(-1, -1);
+		Node node7 = NodeFixture.createNode(3, 3);
+		Node node8 = NodeFixture.createNode(2, 3);
+
+		Route route1 = RouteFixture.createRoute(node1, node2);
+		Route route2 = RouteFixture.createRoute(node2, node3);
+		Route route3 = RouteFixture.createRoute(node3, node4);
+		Route route4 = RouteFixture.createRoute(node1, node5);
+		Route route5 = RouteFixture.createRoute(node5, node6);
+		Route route6 = RouteFixture.createRoute(node4, node7);
+		Route route7 = RouteFixture.createRoute(node4, node8);
+
+		node4.setCore(true);
+
+		nodeRepository.saveAll(List.of(node1, node2));  // ver 1
+		routeRepository.saveAll(List.of(route1)); // ver 2
+
+		nodeRepository.saveAll(List.of(node3,node4, node7, node8));  // ver 3
+		routeRepository.saveAll(List.of(route2, route3, route6, route7)); // ver 4
+
+		nodeRepository.saveAll(List.of(node5,node6));  // ver 5
+		routeRepository.saveAll(List.of(route4, route5)); // ver 6
+
+		//when
+		GetChangedRoutesByRevisionResDTO getChangedRoutesByRevisionResDTO = adminService.getChangedRoutesByRevision(1001L, 2L);
+
+		//then
+		LostRoutesDTO lostRoutes = getChangedRoutesByRevisionResDTO.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
+
+		//a. version2에 존재하지 않는 맵 정보 확인
+
+		//a-1. ver 2에 존재하지 않는 노드가 8개인지? (node1, node2, node3, node4, node5, node6, node7, node8)
+		List<NodeInfoResDTO> lostNodes = lostRoutes.getNodeInfos();
+		assertThat(lostNodes).hasSize(8);
+
+		//a-2. ver 2에 존재하지 않는 코어route가 4개인지?
+		List<CoreRouteResDTO> lostCoreRoutes = lostRoutes.getCoreRoutes();
+		assertThat(lostCoreRoutes).hasSize(4);
+
+		//a-3. ver 2에 존재하지 않는 루트가 6개인지? (route2, route3, route4, route5, route6, route7)
+		int cnt = 0;
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			cnt += coreRoute.getRoutes().size();
+		}
+		assertThat(cnt).isEqualTo(6);
+
+		//a-4. ver 2에 존재하지 않는 route가 route2, route3, route4, route5, route6, route7 인지?
+		List<Long> lostRouteIds = new ArrayList<>();
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			for(RouteCoordinatesInfoResDTO route : coreRoute.getRoutes()) {
+				lostRouteIds.add(route.getRouteId());
+			}
+		}
+
+		assertThat(lostRouteIds)
+				.containsExactlyInAnyOrder(route2.getId(), route3.getId(), route4.getId(), route5.getId()
+						, route6.getId(), route7.getId());
+
+
+	}
+
+	@Test
+	void 특정_버전_차이점_조회_테스트_with_사이클이_있는_서로다른_길_여러개_추가(){
+		Node node1 = NodeFixture.createNode(1, 1);
+		Node node2 = NodeFixture.createNode(1, 2);
+		Node node3 = NodeFixture.createNode(1, 3);
+		Node node4 = NodeFixture.createNode(2,2);
+		Node node5 = NodeFixture.createNode(0, 0);
+		Node node6 = NodeFixture.createNode(-1, -1);
+		Node node7 = NodeFixture.createNode(3, 3);
+		Node node8 = NodeFixture.createNode(2, 3);
+
+		Route route1 = RouteFixture.createRoute(node1, node2);
+		Route route2 = RouteFixture.createRoute(node2, node3);
+		Route route3 = RouteFixture.createRoute(node3, node4);
+		Route route4 = RouteFixture.createRoute(node1, node5);
+		Route route5 = RouteFixture.createRoute(node5, node6);
+		Route route6 = RouteFixture.createRoute(node4, node7);
+		Route route7 = RouteFixture.createRoute(node4, node8);
+		Route route8 = RouteFixture.createRoute(node7, node8);
+
+		node4.setCore(true);
+
+		nodeRepository.saveAll(List.of(node1, node2, node3));  // ver 1
+		routeRepository.saveAll(List.of(route1, route2)); // ver 2
+
+		nodeRepository.saveAll(List.of(node4, node7, node8));  // ver 3
+		routeRepository.saveAll(List.of(route3, route6, route7, route8)); // ver 4
+
+		nodeRepository.saveAll(List.of(node5,node6));  // ver 5
+		routeRepository.saveAll(List.of(route4, route5)); // ver 6
+
+		//when
+		GetChangedRoutesByRevisionResDTO getChangedRoutesByRevisionResDTO = adminService.getChangedRoutesByRevision(1001L, 2L);
+
+		//then
+		LostRoutesDTO lostRoutes = getChangedRoutesByRevisionResDTO.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
+
+		//a. version2에 존재하지 않는 맵 정보 확인
+
+		//a-1. ver 2에 존재하지 않는 노드가 7개인지? (node1, node3, node4, node5, node6, node7, node8)
+		List<NodeInfoResDTO> lostNodes = lostRoutes.getNodeInfos();
+		assertThat(lostNodes).hasSize(7);
+
+		//a-2. ver 2에 존재하지 않는 코어route가 3개인지?
+		List<CoreRouteResDTO> lostCoreRoutes = lostRoutes.getCoreRoutes();
+		assertThat(lostCoreRoutes).hasSize(3);
+
+		//a-3. ver 2에 존재하지 않는 루트가 6개인지? (route3, route4, route5, route6, route7, route8)
+		int cnt = 0;
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			cnt += coreRoute.getRoutes().size();
+		}
+		assertThat(cnt).isEqualTo(6);
+
+		//a-4. ver 2에 존재하지 않는 route가 route3, route4, route5, route6, route7, route8 인지?
+		List<Long> lostRouteIds = new ArrayList<>();
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			for(RouteCoordinatesInfoResDTO route : coreRoute.getRoutes()) {
+				lostRouteIds.add(route.getRouteId());
+			}
+		}
+
+		assertThat(lostRouteIds)
+				.containsExactlyInAnyOrder(route3.getId(), route4.getId(), route5.getId()
+						, route6.getId(), route7.getId(), route8.getId());
+
+
+	}
+
+
+	@Test
+	void 특정_버전_차이점_조회_테스트_with_사이클이_있으며_완전그래프인_서로다른_길_여러개_추가(){
+		Node node1 = NodeFixture.createNode(1, 1);
+		Node node2 = NodeFixture.createNode(1, 2);
+		Node node3 = NodeFixture.createNode(1, 3);
+		Node node4 = NodeFixture.createNode(2,2);
+		Node node5 = NodeFixture.createNode(0, 0);
+		Node node6 = NodeFixture.createNode(-1, -1);
+		Node node7 = NodeFixture.createNode(3, 3);
+		Node node8 = NodeFixture.createNode(2, 3);
+
+		Route route1 = RouteFixture.createRoute(node1, node2);
+		Route route2 = RouteFixture.createRoute(node2, node3);
+		Route route3 = RouteFixture.createRoute(node3, node4);
+		Route route4 = RouteFixture.createRoute(node1, node5);
+		Route route5 = RouteFixture.createRoute(node5, node6);
+		Route route6 = RouteFixture.createRoute(node4, node7);
+		Route route7 = RouteFixture.createRoute(node4, node8);
+		Route route8 = RouteFixture.createRoute(node7, node8);
+
+		nodeRepository.saveAll(List.of(node1, node2, node3, node4));  // ver 1
+		routeRepository.saveAll(List.of(route1, route2, route3)); // ver 2
+
+		nodeRepository.saveAll(List.of(node5,node6));  // ver 3
+		routeRepository.saveAll(List.of(route4, route5)); // ver 4
+
+		node4.setCore(true);
+		nodeRepository.saveAll(List.of(node4, node7, node8));  // ver 5
+		routeRepository.saveAll(List.of(route6, route7, route8)); // ver 6
+
+		//when
+		GetChangedRoutesByRevisionResDTO getChangedRoutesByRevisionResDTO = adminService.getChangedRoutesByRevision(1001L, 2L);
+
+		//then
+		LostRoutesDTO lostRoutes = getChangedRoutesByRevisionResDTO.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
+
+		//a. version2에 존재하지 않는 맵 정보 확인
+
+		//a-1. ver 2에 존재하지 않는 노드가 6개인지? (node1, node4, node5, node6, node7, node8)
+		List<NodeInfoResDTO> lostNodes = lostRoutes.getNodeInfos();
+		assertThat(lostNodes).hasSize(6);
+
+		//a-2. ver 2에 존재하지 않는 코어route가 2개인지?
+		List<CoreRouteResDTO> lostCoreRoutes = lostRoutes.getCoreRoutes();
+		assertThat(lostCoreRoutes).hasSize(2);
+
+		//a-3. ver 2에 존재하지 않는 루트가 5개인지? (route4, route5, route6, route7, route8)
+		int cnt = 0;
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			cnt += coreRoute.getRoutes().size();
+		}
+		assertThat(cnt).isEqualTo(5);
+
+		//a-4. ver 2에 존재하지 않는 route가 route4, route5, route6, route7, route8 인지?
+		List<Long> lostRouteIds = new ArrayList<>();
+		for(CoreRouteResDTO coreRoute : lostCoreRoutes) {
+			for(RouteCoordinatesInfoResDTO route : coreRoute.getRoutes()) {
+				lostRouteIds.add(route.getRouteId());
+			}
+		}
+
+		assertThat(lostRouteIds)
+				.containsExactlyInAnyOrder(route4.getId(), route5.getId()
+						, route6.getId(), route7.getId(), route8.getId());
+
+
+	}
+
+	@Test
+	@DisplayName("wiki 페이지 TC.6")
+	void 특정_버전_차이점_조회_테스트_with_위험_주의요소_변경(){
+		Node node1 = NodeFixture.createNode(1, 1);
+		Node node2 = NodeFixture.createNode(1, 2);
+		Node node3 = NodeFixture.createNode(1, 3);
+		Node node4 = NodeFixture.createNode(2,2);
+		Node node5 = NodeFixture.createNode(3, 3);
+
+		Route route1 = RouteFixture.createRouteWithPath(node1, node2);
+		Route route2 = RouteFixture.createRouteWithPath(node2, node3);
+		Route route3 = RouteFixture.createRouteWithPath(node3, node4);
+		Route route4 = RouteFixture.createRouteWithPath(node4, node5);
+
+		List<CautionFactor> cautionFactorsList1 = new ArrayList<>();
+		cautionFactorsList1.add(CautionFactor.ETC);
+		route1.setCautionFactorsByList(cautionFactorsList1);
+
+		nodeRepository.saveAll(List.of(node1, node2, node3));  // ver 1
+		routeRepository.saveAll(List.of(route1, route2)); // ver 2
+		nodeRepository.saveAll(List.of(node4,node5));  // ver 3
+		routeRepository.saveAll(List.of(route3, route4)); // ver 4
+
+		List<CautionFactor> cautionFactorsList2 = new ArrayList<>();
+		cautionFactorsList2.add(CautionFactor.CRACK);
+		route2.setCautionFactorsByList(cautionFactorsList2);
+
+		List<DangerFactor> dangerFactorsList = new ArrayList<>();
+		dangerFactorsList.add(DangerFactor.SLOPE);
+		route3.setDangerFactorsByList(dangerFactorsList);
+
+		routeRepository.save(route2); // ver 5
+		routeRepository.save(route3); // ver 6
+
+		//when
+		GetChangedRoutesByRevisionResDTO getChangedRoutesByRevisionResDTO = adminService.getChangedRoutesByRevision(1001L, 2L);
+
+		//then
+		List<ChangedRouteDTO> changedList = getChangedRoutesByRevisionResDTO.getChangedList();
+
+		//a. version 2에 존재하는 맵 정보 확인
+
+		//a-1. 변경된 caution이 1개인지? (route2)
+		assertThat(changedList).hasSize(1);
+
+		//a-2. 변경된 caution이 route2인지?
+		assertThat(changedList.get(0).getRouteId()).isEqualTo(route2.getId());
+
+
+	}
+
 
 }
 

--- a/uniro_backend/src/test/resources/sql/delete-all-data.sql
+++ b/uniro_backend/src/test/resources/sql/delete-all-data.sql
@@ -16,6 +16,8 @@ ALTER TABLE `uniro-test`.node AUTO_INCREMENT = 1;
 ALTER TABLE `uniro-test`.rev_info AUTO_INCREMENT = 1;
 ALTER TABLE `uniro-test`.route AUTO_INCREMENT = 1;
 ALTER TABLE `uniro-test`.univ AUTO_INCREMENT = 1;
+ALTER TABLE `uniro-test`.route_aud AUTO_INCREMENT = 1;
+ALTER TABLE `uniro-test`.node_aud AUTO_INCREMENT = 1;
 
 -- 외래 키 제약 조건 활성화
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 🚀 변경 사항
## 특정 버전과 현재 버전의 차이점을 조회하는 API 개발
### 로직 구현 배경 및 목적
   - 현재 저희 서비스에서 지도를 불러오는 로직은 무거운 로직입니다. 이로 인하여 매번 지도를 불러올 경우 사용자 경험에 영향을 주었고, 이를 해결하고자 하였습니다.
   - 우선 클라이언트 단에서 캐시되어있는 지도 데이터를 사용자에게 제공하여 First Contentful Paint (첫 컨텐츠 렌더링 시점)를 단축시켰습니다.
   - 이후 별도의 API호출을 통해 변경사항들을 후처리함으로써 데이터의 최신성을 보장할 수 있게 되었습니다.

### 구현내용
- https://github.com/softeer5th/Team2-Getit/pull/124 의 API를 응용하여 특정 버전과 현재 버전의 차이점을 조회할 수 있도록 구현하였습니다.
- @mikekks 님의 코드리뷰를 반영하여 해당 시점 이후의 변경사항들만 조회하여 더욱 응답시간을 단축시킬 수 있었습니다.

# 🧪 테스트 결과
- 테스트코드를 확인해보시면 좋을 것 같습니다
<img width="640" alt="스크린샷 2025-02-15 오후 7 17 38" src="https://github.com/user-attachments/assets/49b39095-5cd2-473a-857a-5408dd2d19c5" />

