### PR TITLE
[UNI-232] 길 찾기 알고리즘 마이그레이션 (다익스트라 -> A*)

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -10,4 +10,5 @@ public final class UniroConst {
 	public static final double EARTH_RADIUS = 6378137;
 	public static final double BUILDING_ROUTE_DISTANCE = 1e8;
 	public static final int IS_SINGLE_ROUTE = 2;
+	public static final double HEURISTIC_WEIGHT_NORMALIZATION_FACTOR = 10.0;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -224,7 +224,7 @@ public class RouteCalculator {
             for(Route route : adjMap.getOrDefault(currentNode.getId(), Collections.emptyList())){
                 Node nextNode = route.getNode1().getId().equals(currentNode.getId())?route.getNode2():route.getNode1();
                 double newDistance = currentDistance + route.getDistance()
-                                                + getHeightHeuristicWeight(maxHeight,minHeight,nextNode);
+                                                + getHeightHeuristicWeight(maxHeight,minHeight,nextNode, route.getDistance());
 
                 if(policy==RoadExclusionPolicy.WHEEL_FAST && !route.getCautionFactors().isEmpty()){
                     currentCautionCount++;
@@ -252,17 +252,17 @@ public class RouteCalculator {
     }
 
     // A* 알고리즘의 휴리스틱 중 max,min 해발고도를 벗어나는 경우 가중치를 부여
-    private double getHeightHeuristicWeight(double maxHeight, double minHeight, Node nextNode) {
+    private double getHeightHeuristicWeight(double maxHeight, double minHeight, Node nextNode, double routeDistance) {
         double currentHeight = nextNode.getHeight();
         double diff = 0.0;
         if(currentHeight > maxHeight) diff = currentHeight - maxHeight;
         if(currentHeight < minHeight) diff = minHeight - currentHeight;
-        return calculateWeight(diff);
+        return calculateWeight(diff, routeDistance);
     }
 
     // 차이에 따른 가중치를 계산하는 메서드
-    private double calculateWeight(double diff){
-        return Math.pow(diff,2);
+    private double calculateWeight(double diff, double routeDistance){
+        return (Math.pow(diff,2) * routeDistance) / HEURISTIC_WEIGHT_NORMALIZATION_FACTOR;
     }
 
     // 길찾기 결과를 파싱하여 출발지 -> 도착지 형태로 재배열하는 메서드

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -224,7 +224,7 @@ public class RouteCalculator {
             for(Route route : adjMap.getOrDefault(currentNode.getId(), Collections.emptyList())){
                 Node nextNode = route.getNode1().getId().equals(currentNode.getId())?route.getNode2():route.getNode1();
                 double newDistance = currentDistance + route.getDistance()
-                                                + getHeightHeuristicWeight(maxHeight,minHeight,nextNode, route.getDistance());
+                                                + getHeightHeuristicWeight(maxHeight,minHeight,nextNode, route.getDistance(), policy);
 
                 if(policy==RoadExclusionPolicy.WHEEL_FAST && !route.getCautionFactors().isEmpty()){
                     currentCautionCount++;
@@ -252,7 +252,8 @@ public class RouteCalculator {
     }
 
     // A* 알고리즘의 휴리스틱 중 max,min 해발고도를 벗어나는 경우 가중치를 부여
-    private double getHeightHeuristicWeight(double maxHeight, double minHeight, Node nextNode, double routeDistance) {
+    private double getHeightHeuristicWeight(double maxHeight, double minHeight, Node nextNode, double routeDistance, RoadExclusionPolicy policy) {
+        if(policy==RoadExclusionPolicy.PEDES)return 0.0;
         double currentHeight = nextNode.getHeight();
         double diff = 0.0;
         if(currentHeight > maxHeight) diff = currentHeight - maxHeight;

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/NodeFixture.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/NodeFixture.java
@@ -24,4 +24,13 @@ public class NodeFixture {
 			.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
 			.build();
 	}
+
+	public static Node createNodeWithHeight(double x, double y, double height){
+		return Node.builder()
+				.univId(1001L)
+				.isCore(false)
+				.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
+				.height(height)
+				.build();
+	}
 }

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
@@ -279,6 +279,99 @@ class RouteCalculatorTest {
 
         }
 
+        @Test
+        void 기본_길찾기_높이고려_휴리스틱() {
+            Node n1 = NodeFixture.createNodeWithHeight(0, 0, 10);
+            Node n2 = NodeFixture.createNodeWithHeight(0, 0, 10);
+            Node n3 = NodeFixture.createNodeWithHeight(0, 0, 1000);
+            Node n4 = NodeFixture.createNodeWithHeight(0, 0, 10);
+            Node n5 = NodeFixture.createNodeWithHeight(0, 0, 10);
+            Node n6 = NodeFixture.createNodeWithHeight(0, 0, 10);
+            Node n7 = NodeFixture.createNodeWithHeight(0, 0, 10);
+            Node n8 = NodeFixture.createNodeWithHeight(0, 0, 10);
+
+            Route r1 = RouteFixture.createRouteWithDistance(n1, n2, BUILDING_ROUTE_DISTANCE);
+            Route r2 = RouteFixture.createRouteWithDistance(n2, n3, 10);
+            Route r4 = RouteFixture.createRouteWithDistance(n3, n4, 6);
+            Route r5 = RouteFixture.createRouteWithDistance(n4, n5, BUILDING_ROUTE_DISTANCE);
+            Route r6 = RouteFixture.createRouteWithDistance(n5, n6, BUILDING_ROUTE_DISTANCE);
+            Route r7 = RouteFixture.createRouteWithDistance(n6, n7, 18);
+            Route r8 = RouteFixture.createRouteWithDistance(n7, n8, 3);
+            Route r9 = RouteFixture.createRouteWithDistance(n8, n1, BUILDING_ROUTE_DISTANCE);
+
+            Building b1 = Building.builder().nodeId(1L).univId(1001L).build();
+            Building b5 = Building.builder().nodeId(5L).univId(1001L).build();
+
+            nodeRepository.saveAll(List.of(n1, n2, n3, n4, n5, n6, n7, n8));
+            routeRepository.saveAll(List.of(r1, r2, r4, r5, r6, r7, r8, r9));
+            buildingRepository.saveAll(List.of(b1, b5));
+
+            List<FastestRouteResDTO> fastestRoute = mapService.findFastestRoute(1001L, 1L, 5L);
+
+
+            //a. distance 확안
+
+            //a-1. 보도, 휠체어안전, 휠체어위험 모두 가능한지?
+            assertThat(fastestRoute).hasSize(3);
+
+            //a-2. distance가 정상적으로 제공되는지?
+            double distance0 = fastestRoute.get(0).getTotalDistance();
+            assertThat(Math.abs(distance0 - 16.0)).isLessThan(epsilon);
+            double distance1 = fastestRoute.get(1).getTotalDistance();
+            assertThat(Math.abs(distance1 - 21.0)).isLessThan(epsilon);
+            double distance2 = fastestRoute.get(2).getTotalDistance();
+            assertThat(Math.abs(distance2 - 21.0)).isLessThan(epsilon);
+
+        }
+
+        @Test
+        void 주의요소가_포함된_길찾기_위험요소고려_휴리스틱() {
+            Node n1 = NodeFixture.createNode(0, 0);
+            Node n2 = NodeFixture.createNode(0, 0);
+            Node n3 = NodeFixture.createNode(0, 0);
+            Node n4 = NodeFixture.createNode(0, 0);
+            Node n5 = NodeFixture.createNode(0, 0);
+            Node n6 = NodeFixture.createNode(0, 0);
+            Node n7 = NodeFixture.createNode(0, 0);
+            Node n8 = NodeFixture.createNode(0, 0);
+
+            Route r1 = RouteFixture.createRouteWithDistance(n1, n2, BUILDING_ROUTE_DISTANCE);
+            Route r2 = RouteFixture.createRouteWithDistance(n2, n3, 14);
+            Route r4 = RouteFixture.createRouteWithDistance(n3, n4, 6);
+            Route r5 = RouteFixture.createRouteWithDistance(n4, n5, BUILDING_ROUTE_DISTANCE);
+            Route r6 = RouteFixture.createRouteWithDistance(n5, n6, BUILDING_ROUTE_DISTANCE);
+            Route r7 = RouteFixture.createRouteWithDistance(n6, n7, 18);
+            Route r8 = RouteFixture.createRouteWithDistance(n7, n8, 3);
+            Route r9 = RouteFixture.createRouteWithDistance(n8, n1, BUILDING_ROUTE_DISTANCE);
+
+            Building b1 = Building.builder().nodeId(1L).univId(1001L).build();
+            Building b5 = Building.builder().nodeId(5L).univId(1001L).build();
+
+            List<CautionFactor> cautionFactorsList = new ArrayList<>();
+            cautionFactorsList.add(CautionFactor.CRACK);
+            r2.setCautionFactorsByList(cautionFactorsList);
+            r4.setCautionFactorsByList(cautionFactorsList);
+
+            nodeRepository.saveAll(List.of(n1, n2, n3, n4, n5, n6, n7, n8));
+            routeRepository.saveAll(List.of(r1, r2, r4, r5, r6, r7, r8, r9));
+            buildingRepository.saveAll(List.of(b1, b5));
+
+            List<FastestRouteResDTO> fastestRoute = mapService.findFastestRoute(1001L, 1L, 5L);
+
+            //a. distance 확안
+
+            //a-1. 보도, 휠체어위험 모두 가능한지?
+            assertThat(fastestRoute).hasSize(3);
+
+            //a-2. distance가 정상적으로 제공되는지?
+            double distance0 = fastestRoute.get(0).getTotalDistance();
+            assertThat(Math.abs(distance0 - 20.0)).isLessThan(epsilon);
+            double distance1 = fastestRoute.get(1).getTotalDistance();
+            assertThat(Math.abs(distance1 - 21.0)).isLessThan(epsilon);
+            double distance2 = fastestRoute.get(2).getTotalDistance();
+            assertThat(Math.abs(distance2 - 21.0)).isLessThan(epsilon);
+        }
+
     }
 
 


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 길 찾기 알고리즘을 다익스트라 알고리즘에서 A* 알고리즘으로 변경
### 더 배리어프리한 서비스가 되기 위해 길 찾기 알고리즘을 A* 알고리즘으로 변경하였습니다.

### A* 알고리즘에서 고려된 휴리스틱은 다음과 같습니다.
- 휴리스틱 # 1 : 출발점, 도착점의 해발고도가 각각 15m, 20m일때, 지나가는 길의 해발고도가 이 15~20m 범위를 벗어나는 경우 가중치 부여 (for 휠체어)
    - 가중치 부여 정도 : (((벗어난 해발고도 차이)^2) / 10 ) * 해당 길의 거리
        - ex1. 해발고도가 20m->21m인 곳을 10m 진행 시 10+1^2 m를 진행한 것으로 간주
        - ex2. 해발고도가 22m->23m인 곳을 10m 진행 시 10+3^2 m를 진행한 것으로 간주
- 휴리스틱 # 2 : 지나온 주의요소의 길의 개수에 따른 가중치 부여 (only for 휠체어 빠른길)
    - 가중치 부여 정도 : (지나온 주의요소의 개수)^2
        - ex1. 지금까지 지나온 주의요소가 2개이고, 다음 진행할 3m짜리 길에 주의요소가 있다면 3+3^2 m를 진행한 것으로 간주

## 테스트 코드 작성
- 두 가지 휴리스틱이 잘 반영되는지 테스트 코드를 통해 확인하였습니다.

## 💡 To Reviewer
휴리스틱을 텍스트로 가독성있게 작성하기 어려워서 추후 오프라인으로 그림을 통해 이야기 나눠보면 좋을 것 같습니다!


## 🧪 테스트 결과
<img width="659" alt="image" src="https://github.com/user-attachments/assets/5fc19836-fcd6-4092-bf5e-6a8e8bf67354" />

