### PR TITLE
[UNI-250] feat : 길찾기 바텀시트 번호 클릭시 이동 (hotfix 포함)

### DIFF
--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -6,6 +6,7 @@ import {
 	NavigationButtonRouteType,
 	NavigationRouteList,
 	NavigationRouteListRecordWithMetaData,
+	RouteDetail,
 } from "../data/types/route";
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
 import createMarkerElement from "../components/map/mapMarkers";
@@ -13,6 +14,7 @@ import { Markers } from "../constant/enum/markerEnum";
 import useRoutePoint from "../hooks/useRoutePoint";
 import { AdvancedMarker } from "../data/types/marker";
 import { interpolate } from "../utils/interpolate";
+import { Direction } from "framer-motion";
 
 type MapProps = {
 	style?: React.CSSProperties;
@@ -25,6 +27,7 @@ type MapProps = {
 	isDetailView: boolean;
 	topPadding?: number;
 	bottomPadding?: number;
+	currentRouteIdx: number;
 };
 
 // TODO: useEffect로 경로가 모두 로딩된 이후에 마커가 생성되도록 수정하기
@@ -61,6 +64,7 @@ const NavigationMap = ({
 	buttonState,
 	topPadding = 0,
 	bottomPadding = 0,
+	currentRouteIdx,
 }: MapProps) => {
 	const { mapRef, map, AdvancedMarker, Polyline } = useMap();
 	const { origin, destination } = useRoutePoint();
@@ -319,6 +323,7 @@ const NavigationMap = ({
 			dyamicMarkersRef.current = [];
 			// [그림] 마커 찍기
 			routeDetails.forEach((routeDetail, index) => {
+				if (index === routeDetails.length - 1) return;
 				const { coordinates } = routeDetail;
 				const markerElement = createMarkerElement({
 					type: Markers.NUMBERED_WAYPOINT,
@@ -348,15 +353,71 @@ const NavigationMap = ({
 		dyamicMarkersRef.current = [];
 	};
 
+	const saveAllBounds = () => {
+		if (!map || !compositeRoutes) return;
+		const bounds = new google.maps.LatLngBounds();
+		Object.values(compositeRoutes).forEach((composite) => {
+			bounds.extend(composite!.bounds.getNorthEast());
+			bounds.extend(composite!.bounds.getSouthWest());
+		});
+		boundsRef.current = bounds;
+	};
+
 	useEffect(() => {
+		if (currentRouteIdx !== -1) return;
 		if (!map || !boundsRef.current) return;
+		saveAllBounds();
 		map.fitBounds(boundsRef.current, {
 			top: topPadding,
 			right: 50,
 			bottom: bottomPadding,
 			left: 50,
 		});
-	}, [map, bottomPadding, topPadding]);
+	}, [map, bottomPadding, topPadding, currentRouteIdx]);
+
+	useEffect(() => {
+		if (!map) return;
+		if (currentRouteIdx === -1) return;
+		const currentRoute = routeResult[buttonState];
+		if (!currentRoute) return;
+
+		const addOriginAndDestination = (routes: RouteDetail[]) => {
+			return [
+				{
+					dist: 0,
+					directionType: "origin" as Direction,
+					coordinates: { lat: origin!.lat, lng: origin!.lng },
+					cautionFactors: [],
+				},
+				...routes.slice(0, -1),
+				{
+					dist: 0,
+					directionType: "finish" as Direction,
+					coordinates: { lat: destination!.lat, lng: destination!.lng },
+					cautionFactors: [],
+				},
+			];
+		};
+
+		// 다음 구간까지의 길을 합쳐서 bounds를 계산
+		const { routeDetails } = currentRoute;
+		const modifiedRouteDetails = addOriginAndDestination(routeDetails);
+		const currentRouteDetail = modifiedRouteDetails[currentRouteIdx];
+
+		const bounds = new google.maps.LatLngBounds();
+		bounds.extend(currentRouteDetail.coordinates);
+		if (currentRouteIdx !== modifiedRouteDetails.length - 1) {
+			const nextRouteDetail = modifiedRouteDetails[currentRouteIdx + 1];
+			bounds.extend(nextRouteDetail.coordinates);
+		}
+		boundsRef.current = bounds;
+		map.fitBounds(bounds, {
+			top: topPadding,
+			right: 50,
+			bottom: bottomPadding,
+			left: 50,
+		});
+	}, [map, currentRouteIdx, buttonState, routeResult]);
 
 	useEffect(() => {
 		if (!AdvancedMarker || !map) return;

--- a/uniro_frontend/src/components/navigation/bottomSheet/bottomSheetHandle.tsx
+++ b/uniro_frontend/src/components/navigation/bottomSheet/bottomSheetHandle.tsx
@@ -3,14 +3,19 @@ import React from "react";
 
 type HandleProps = {
 	dragControls: DragControls;
+	resetCurrentIdx: () => void;
 };
 
-const BottomSheetHandle = ({ dragControls }: HandleProps) => {
+const BottomSheetHandle = ({ dragControls, resetCurrentIdx }: HandleProps) => {
 	return (
 		<div
+			onClick={resetCurrentIdx}
 			className="w-full h-[40px] flex flex-col justify-center items-center cursor-grab"
 			style={{ touchAction: "none" }}
-			onPointerDown={(e) => dragControls.start(e)}
+			onPointerDown={(e) => {
+				resetCurrentIdx();
+				return dragControls.start(e);
+			}}
 		>
 			<div className="w-1/6 h-[4px] bg-[#CACACA] rounded-full" />
 		</div>

--- a/uniro_frontend/src/components/navigation/card/bottomCardList.tsx
+++ b/uniro_frontend/src/components/navigation/card/bottomCardList.tsx
@@ -54,11 +54,11 @@ const BottomCardList = ({ routeList, buttonType = "PEDES & SAFE", showDetailView
 					keyExists("MANUAL & CAUTION") || keyExists("ELECTRIC & CAUTION")
 						? {
 								totalCost: buttonType.includes("MANUAL")
-									? routeList["MANUAL & CAUTION"].totalCost
-									: routeList["ELECTRIC & CAUTION"].totalCost,
+									? routeList["MANUAL & CAUTION"]?.totalCost
+									: routeList["ELECTRIC & CAUTION"]?.totalCost,
 								totalDistance: buttonType.includes("MANUAL")
-									? routeList["MANUAL & CAUTION"].totalDistance
-									: routeList["ELECTRIC & CAUTION"].totalDistance,
+									? routeList["MANUAL & CAUTION"]?.totalDistance
+									: routeList["ELECTRIC & CAUTION"]?.totalDistance,
 							}
 						: undefined
 				}
@@ -83,11 +83,11 @@ const BottomCardList = ({ routeList, buttonType = "PEDES & SAFE", showDetailView
 					routeList[buttonType]
 						? {
 								totalCost: buttonType.includes("MANUAL")
-									? routeList["MANUAL & SAFE"].totalCost
-									: routeList["ELECTRIC & SAFE"].totalCost,
+									? routeList["MANUAL & SAFE"]?.totalCost
+									: routeList["ELECTRIC & SAFE"]?.totalCost,
 								totalDistance: buttonType.includes("MANUAL")
-									? routeList["MANUAL & SAFE"].totalDistance
-									: routeList["ELECTRIC & SAFE"].totalDistance,
+									? routeList["MANUAL & SAFE"]?.totalDistance
+									: routeList["ELECTRIC & SAFE"]?.totalDistance,
 							}
 						: undefined
 				}

--- a/uniro_frontend/src/components/navigation/navigationDescription.tsx
+++ b/uniro_frontend/src/components/navigation/navigationDescription.tsx
@@ -18,6 +18,7 @@ const TITLE = "전동휠체어 예상소요시간";
 type TopBarProps = {
 	isDetailView: boolean;
 	navigationRoute: NavigationRouteList;
+	resetCurrentRouteIdx?: () => void;
 };
 
 type AnimatedValueProps = {
@@ -42,7 +43,7 @@ const AnimatedValue = ({ value, className }: AnimatedValueProps) => {
 	);
 };
 
-const NavigationDescription = ({ isDetailView, navigationRoute }: TopBarProps) => {
+const NavigationDescription = ({ isDetailView, navigationRoute, resetCurrentRouteIdx }: TopBarProps) => {
 	const { origin, destination } = useRoutePoint();
 
 	const { university } = useUniversityInfo();
@@ -54,7 +55,7 @@ const NavigationDescription = ({ isDetailView, navigationRoute }: TopBarProps) =
 	};
 
 	return (
-		<div className="w-full p-5">
+		<div className="w-full p-5" onClick={resetCurrentRouteIdx ? resetCurrentRouteIdx : () => {}}>
 			<div className={`w-full flex flex-row items-center ${isDetailView ? "justify-start" : "justify-between"}`}>
 				<span className="text-left text-kor-body3 text-primary-500 flex-1 font-semibold">{TITLE}</span>
 				{!isDetailView && (

--- a/uniro_frontend/src/components/navigation/navigationDescription.tsx
+++ b/uniro_frontend/src/components/navigation/navigationDescription.tsx
@@ -48,8 +48,7 @@ const AnimatedValue = ({ value, className }: AnimatedValueProps) => {
 	);
 };
 
-const NavigationDescription = ({ isDetailView, navigationRoute, buttonType }: TopBarProps) => {
-const NavigationDescription = ({ isDetailView, navigationRoute, resetCurrentRouteIdx }: TopBarProps) => {
+const NavigationDescription = ({ isDetailView, navigationRoute, buttonType, resetCurrentRouteIdx }: TopBarProps) => {
 	const { origin, destination } = useRoutePoint();
 
 	const { university } = useUniversityInfo();

--- a/uniro_frontend/src/components/navigation/route/routeCard.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeCard.tsx
@@ -17,14 +17,30 @@ const NumberIcon = ({ index }: { index: number }) => {
 	);
 };
 
-export const RouteCard = ({ index, route }: { index: number; route: RouteDetail }) => {
+export const RouteCard = ({
+	changeCurrentRouteIdx,
+	currentRouteIdx,
+	index,
+	route,
+}: {
+	changeCurrentRouteIdx: (index: number) => void;
+	currentRouteIdx: number;
+	index: number;
+	route: RouteDetail;
+}) => {
 	const { dist: distance, directionType, cautionFactors } = route;
 	const formattedDistance = formatDistance(distance);
 	const { origin, destination } = useRoutePoint();
+	const onClick = () => {
+		changeCurrentRouteIdx(index);
+	};
 	switch (directionType.toLocaleLowerCase()) {
 		case "straight":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors active:shadow-inner ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<StraightIcon />
 						<div className="text-primary-400 text-kor-body3 text-[12px]">{formattedDistance}</div>
@@ -37,7 +53,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "right":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<RightIcon />
 						<div className="text-primary-400 text-kor-body3 text-[12px]">{formattedDistance}</div>
@@ -50,7 +69,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "sharp_right":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<RightIcon />
 						<div className="text-primary-400 text-kor-body3 text-[12px]">{formattedDistance}</div>
@@ -63,7 +85,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "left":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<LeftIcon />
 						<div className="text-primary-400 text-kor-body3 text-[12px]">{formattedDistance}</div>
@@ -76,7 +101,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "sharp_left":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<LeftIcon />
 						<div className="text-primary-400 text-kor-body3 text-[12px]">{formattedDistance}</div>
@@ -89,7 +117,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "uturn":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<StraightIcon />
 						<div className="text-primary-400 text-kor-body3 text-[12px]">{formattedDistance}</div>
@@ -102,7 +133,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "origin":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<OriginIcon />
 						<div className="text-[#5F5F5F] text-kor-body3 text-[12px]">출발</div>
@@ -115,7 +149,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "finish":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<DestinationIcon />
 						<div className="text-[#5F5F5F] text-kor-body3 text-[12px]">도착</div>
@@ -128,7 +165,10 @@ export const RouteCard = ({ index, route }: { index: number; route: RouteDetail 
 			);
 		case "caution":
 			return (
-				<div className="flex flex-row items-center justify-start ml-8 my-5">
+				<div
+					onClick={onClick}
+					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+				>
 					<div className="flex flex-col items-center justify-start space-y-1">
 						<CautionText />
 						<div className="text-system-orange text-kor-body3 text-[12px]">{formattedDistance}</div>

--- a/uniro_frontend/src/components/navigation/route/routeList.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeList.tsx
@@ -1,19 +1,19 @@
-import { Fragment } from "react";
+import { Fragment, useEffect, useRef } from "react";
 import { RouteCard } from "./routeCard";
 import useRoutePoint from "../../../hooks/useRoutePoint";
 import { RouteDetail } from "../../../data/types/route";
 import { Direction } from "../../../data/types/route";
 
 type RouteListProps = {
+	changeCurrentRouteIdx: (index: number) => void;
+	currentRouteIdx: number;
 	routes?: RouteDetail[] | null;
 };
 
 const Divider = () => <div className="border-[0.5px] border-gray-200 w-full"></div>;
 
-const RouteList = ({ routes }: RouteListProps) => {
+const RouteList = ({ changeCurrentRouteIdx, currentRouteIdx, routes }: RouteListProps) => {
 	const { origin, destination } = useRoutePoint();
-
-	if (!routes) return null;
 
 	const addOriginAndDestination = (routes: RouteDetail[]) => {
 		return [
@@ -40,7 +40,12 @@ const RouteList = ({ routes }: RouteListProps) => {
 					<Fragment key={`${route.dist}-${route.coordinates.lat}-fragment`}>
 						<Divider />
 						<div className="flex flex-col">
-							<RouteCard index={index} route={route} />
+							<RouteCard
+								changeCurrentRouteIdx={changeCurrentRouteIdx}
+								currentRouteIdx={currentRouteIdx}
+								index={index}
+								route={route}
+							/>
 						</div>
 					</Fragment>
 				))}

--- a/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
+++ b/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 const MAX_SHEET_HEIGHT = window.innerHeight * 0.7;
 const MIN_SHEET_HEIGHT = window.innerHeight * 0.35;
 const CLOSED_SHEET_HEIGHT = 0;
-const ERROR_MARGIN_OF_DRAG = 0.95;
+const ERROR_MARGIN_OF_DRAG = 0.7;
 
 export const useNavigationBottomSheet = () => {
 	const [sheetHeight, setSheetHeight] = useState(CLOSED_SHEET_HEIGHT);
@@ -13,11 +13,37 @@ export const useNavigationBottomSheet = () => {
 	const scrollRef = useRef<HTMLDivElement>(null);
 
 	const handleDrag = useCallback((event: Event, info: PanInfo) => {
-		setSheetHeight((prev) => {
-			const newHeight = prev - info.delta.y;
-			return Math.min(Math.max(newHeight, MIN_SHEET_HEIGHT), MAX_SHEET_HEIGHT);
+		requestAnimationFrame(() => {
+			setSheetHeight((prev) => {
+				const newHeight = prev - info.delta.y;
+				return Math.min(Math.max(newHeight, MIN_SHEET_HEIGHT), MAX_SHEET_HEIGHT);
+			});
 		});
 	}, []);
+
+	const handleDragEnd = useCallback(
+		(event: Event, info: PanInfo) => {
+			const velocityY = info.velocity.y;
+			let finalHeight = sheetHeight;
+
+			if (velocityY > 500) {
+				finalHeight = MIN_SHEET_HEIGHT;
+			} else if (velocityY < -500) {
+				finalHeight = MAX_SHEET_HEIGHT;
+			} else {
+				// 가까운 위치로 스냅
+				const distances = [
+					{ height: CLOSED_SHEET_HEIGHT, distance: Math.abs(sheetHeight - CLOSED_SHEET_HEIGHT) },
+					{ height: MIN_SHEET_HEIGHT, distance: Math.abs(sheetHeight - MIN_SHEET_HEIGHT) },
+					{ height: MAX_SHEET_HEIGHT, distance: Math.abs(sheetHeight - MAX_SHEET_HEIGHT) },
+				];
+				finalHeight = distances.sort((a, b) => a.distance - b.distance)[0].height;
+			}
+
+			setSheetHeight(finalHeight);
+		},
+		[sheetHeight],
+	);
 
 	const preventScroll = useCallback(
 		(event: React.UIEvent<HTMLDivElement>) => {
@@ -31,19 +57,15 @@ export const useNavigationBottomSheet = () => {
 		[sheetHeight],
 	);
 	useEffect(() => {
-		if (scrollRef.current) {
-			if (sheetHeight > MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_DRAG) {
-				scrollRef.current.style.overflowY = "auto";
-			} else {
-				scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });
-				setTimeout(() => {
-					if (scrollRef.current) {
-						scrollRef.current.style.overflowY = "hidden";
-					}
-				}, 300);
-			}
+		if (!scrollRef.current) return;
+
+		const isBelowErrorMargin = sheetHeight > MAX_SHEET_HEIGHT * ERROR_MARGIN_OF_DRAG;
+		scrollRef.current.style.overflowY = isBelowErrorMargin ? "auto" : "hidden";
+
+		if (!isBelowErrorMargin) {
+			scrollRef.current.scrollTo({ top: 0, behavior: "smooth" });
 		}
 	}, [sheetHeight]);
 
-	return { sheetHeight, setSheetHeight, dragControls, handleDrag, preventScroll, scrollRef };
+	return { sheetHeight, setSheetHeight, dragControls, handleDrag, preventScroll, scrollRef, handleDragEnd };
 };

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -196,10 +196,10 @@ const NavigationResultPage = () => {
 					onScroll={preventScroll}
 				>
 					<NavigationDescription
+						resetCurrentRouteIdx={resetCurrentIndex}
 						isDetailView={true}
 						buttonType={buttonState}
 						navigationRoute={routeList.data![buttonState]}
-                        resetCurrentRouteIdx={resetCurrentIndex}
 					/>
 					<RouteList
 						changeCurrentRouteIdx={changeCurrentIndex}

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -37,9 +37,10 @@ const NavigationResultPage = () => {
 	const { sheetHeight, setSheetHeight, dragControls, handleDrag, preventScroll, scrollRef } =
 		useNavigationBottomSheet();
 	const { university } = useUniversityInfo();
-	const { origin, destination, setOriginCoord, setDestinationCoord } = useRoutePoint();
+	const { origin, destination } = useRoutePoint();
 
 	const [buttonState, setButtonState] = useState<NavigationButtonRouteType>("PEDES & SAFE");
+	const [currentRouteIdx, setCurrentRouteIdx] = useState(-1);
 
 	useRedirectUndefined<University | Building | undefined>([university, origin, destination]);
 
@@ -80,15 +81,25 @@ const NavigationResultPage = () => {
 		],
 	});
 
+	const resetCurrentIndex = () => {
+		setCurrentRouteIdx(-1);
+	};
+
+	const changeCurrentIndex = (index: number) => {
+		setCurrentRouteIdx(index);
+	};
+
 	const showDetailView = () => {
 		setSheetHeight(MAX_SHEET_HEIGHT);
 		setTopBarHeight(PADDING_FOR_MAP_BOUNDARY);
+		resetCurrentIndex();
 		setIsDetailView(true);
 	};
 
 	const hideDetailView = () => {
 		setSheetHeight(CLOSED_SHEET_HEIGHT);
 		setTopBarHeight(INITIAL_TOP_BAR_HEIGHT);
+		resetCurrentIndex();
 		setIsDetailView(false);
 	};
 
@@ -126,6 +137,7 @@ const NavigationResultPage = () => {
 				risks={risks.data}
 				topPadding={topBarHeight}
 				bottomPadding={sheetHeight}
+				currentRouteIdx={currentRouteIdx}
 			/>
 
 			<AnimatedContainer
@@ -173,11 +185,12 @@ const NavigationResultPage = () => {
 				isVisible={isDetailView}
 				className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto"
 				positionDelta={MAX_SHEET_HEIGHT}
-				transition={{ type: "spring", damping: 20, duration: 0.3 }}
+				transition={{ type: "tween", duration: 0.3 }}
 				motionProps={{
 					drag: "y",
 					dragControls,
 					dragListener: false,
+					dragElastic: false,
 					dragConstraints: {
 						top: 0,
 						bottom: MIN_SHEET_HEIGHT,
@@ -186,7 +199,7 @@ const NavigationResultPage = () => {
 					onDragEnd: handleDrag,
 				}}
 			>
-				<BottomSheetHandle dragControls={dragControls} />
+				<BottomSheetHandle resetCurrentIdx={resetCurrentIndex} dragControls={dragControls} />
 				<div
 					ref={scrollRef}
 					className="w-full overflow-y-auto"
@@ -195,8 +208,14 @@ const NavigationResultPage = () => {
 					}}
 					onScroll={preventScroll}
 				>
-					<NavigationDescription isDetailView={true} navigationRoute={routeList.data![buttonState]} />
+					<NavigationDescription
+						resetCurrentRouteIdx={resetCurrentIndex}
+						isDetailView={true}
+						navigationRoute={routeList.data![buttonState]}
+					/>
 					<RouteList
+						changeCurrentRouteIdx={changeCurrentIndex}
+						currentRouteIdx={currentRouteIdx}
 						routes={
 							routeList.data![buttonState]?.routeDetails
 								? routeList.data![buttonState]?.routeDetails

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -34,7 +34,7 @@ const NavigationResultPage = () => {
 	const [isDetailView, setIsDetailView] = useState(false);
 	const [topBarHeight, setTopBarHeight] = useState(INITIAL_TOP_BAR_HEIGHT);
 
-	const { sheetHeight, setSheetHeight, dragControls, handleDrag, preventScroll, scrollRef } =
+	const { sheetHeight, setSheetHeight, dragControls, handleDrag, preventScroll, scrollRef, handleDragEnd } =
 		useNavigationBottomSheet();
 	const { university } = useUniversityInfo();
 	const { origin, destination } = useRoutePoint();
@@ -185,18 +185,21 @@ const NavigationResultPage = () => {
 				isVisible={isDetailView}
 				className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto"
 				positionDelta={MAX_SHEET_HEIGHT}
-				transition={{ type: "tween", duration: 0.3 }}
+				transition={{ type: "spring", damping: 20, duration: 0.3 }}
 				motionProps={{
 					drag: "y",
 					dragControls,
 					dragListener: false,
-					dragElastic: false,
+					dragElastic: {
+						top: 0,
+						bottom: 0.3,
+					},
 					dragConstraints: {
 						top: 0,
 						bottom: MIN_SHEET_HEIGHT,
 					},
 					onDrag: handleDrag,
-					onDragEnd: handleDrag,
+					onDragEnd: handleDragEnd,
 				}}
 			>
 				<BottomSheetHandle resetCurrentIdx={resetCurrentIndex} dragControls={dragControls} />


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 길찾기 바텀시트 번호 클릭시 이동
2. 바텀시트의 스크롤 범위와 올릴 수 있는 범위를 수정

## 주요 기능

### 번호 클릭시 이동 로직 구현

번호 이동은 index로 관리했으며, route의 index로 관리했습니다.

```typescript
const [currentRouteIdx, setCurrentRouteIdx] = useState(-1);
```

index를 설정하는 함수와 reset하는 함수를 활용해, 필요한 곳마다 로직을 부여했습니다.
```typescript
	const resetCurrentIndex = () => {
		setCurrentRouteIdx(-1);
	};

	const changeCurrentIndex = (index: number) => {
		setCurrentRouteIdx(index);
	};
```

Navigation Map에서는, 

```typescript
const saveAllBounds = () => {
		if (!map || !compositeRoutes) return;
		const bounds = new google.maps.LatLngBounds();
		Object.values(compositeRoutes).forEach((composite) => {
			bounds.extend(composite!.bounds.getNorthEast());
			bounds.extend(composite!.bounds.getSouthWest());
		});
		boundsRef.current = bounds;
	};
```
bounds를 원래대로 되돌리는 함수를 제작하고,

```typescript
useEffect(() => {
		if (currentRouteIdx !== -1) return;
		if (!map || !boundsRef.current) return;
		saveAllBounds();
		map.fitBounds(boundsRef.current, {
			top: topPadding,
			right: 50,
			bottom: bottomPadding,
			left: 50,
		});
	}, [map, bottomPadding, topPadding, currentRouteIdx]);
```
index가 -1이 되면, 초기화 되게 로직을 바꿨습니다.

boundRef의 지속 활용을 위해 이런식으로 제작을 했고,
```typescript
	useEffect(() => {
		if (!map) return;
		if (currentRouteIdx === -1) return;
		const currentRoute = routeResult[buttonState];
		if (!currentRoute) return;

		const addOriginAndDestination = (routes: RouteDetail[]) => {
			return [
				{
					dist: 0,
					directionType: "origin" as Direction,
					coordinates: { lat: origin!.lat, lng: origin!.lng },
					cautionFactors: [],
				},
				...routes.slice(0, -1),
				{
					dist: 0,
					directionType: "finish" as Direction,
					coordinates: { lat: destination!.lat, lng: destination!.lng },
					cautionFactors: [],
				},
			];
		};

		// 다음 구간까지의 길을 합쳐서 bounds를 계산
		const { routeDetails } = currentRoute;
		const modifiedRouteDetails = addOriginAndDestination(routeDetails);
		const currentRouteDetail = modifiedRouteDetails[currentRouteIdx];

		const bounds = new google.maps.LatLngBounds();
		bounds.extend(currentRouteDetail.coordinates);
		if (currentRouteIdx !== modifiedRouteDetails.length - 1) {
			const nextRouteDetail = modifiedRouteDetails[currentRouteIdx + 1];
			bounds.extend(nextRouteDetail.coordinates);
		}
		boundsRef.current = bounds;
		map.fitBounds(bounds, {
			top: topPadding,
			right: 50,
			bottom: bottomPadding,
			left: 50,
		});
	}, [map, currentRouteIdx, buttonState, routeResult]);
```

다음 길의 거리까지 bound에 포함시켜 보여주게 되었습니다.

### 바텀 시트 뒷배경 제거 및 스크롤 범위 완화, snap 로직 제작

#### 바텀시트 뒷배경 제거
```typescript
dragElastic: {
		top: 0,
		bottom: 0.3,
	},
```
dragElastic 사용해, 더이상 위로 올리지 못하게 통제했습니다.

#### snap 로직
```typescript

	const handleDragEnd = useCallback(
		(event: Event, info: PanInfo) => {
			const velocityY = info.velocity.y;
			let finalHeight = sheetHeight;

			if (velocityY > 500) {
				finalHeight = MIN_SHEET_HEIGHT;
			} else if (velocityY < -500) {
				finalHeight = MAX_SHEET_HEIGHT;
			} else {
				// 가까운 위치로 스냅
				const distances = [
					{ height: CLOSED_SHEET_HEIGHT, distance: Math.abs(sheetHeight - CLOSED_SHEET_HEIGHT) },
					{ height: MIN_SHEET_HEIGHT, distance: Math.abs(sheetHeight - MIN_SHEET_HEIGHT) },
					{ height: MAX_SHEET_HEIGHT, distance: Math.abs(sheetHeight - MAX_SHEET_HEIGHT) },
				];
				finalHeight = distances.sort((a, b) => a.distance - b.distance)[0].height;
			}

			setSheetHeight(finalHeight);
		},
		[sheetHeight],
	);
```
유저의 드래그 속도가 과도하거나, 일정 distance 범위내에 있으면, snap하도록 만들었습니다.

#### 드래그 범위 완화
```typescript
const ERROR_MARGIN_OF_DRAG = 0.7;
```

0.95->0.7로 범위 조정해, 스크롤이 안되는 현상을 방지하였습니다.

### 긴급 HOTFIX (UNI-246)

https://github.com/user-attachments/assets/c05733da-fb80-4897-9892-745d32127dde

이전 PR이 머지된 이후로 발견된 에러로, WHEEL_SAFE가 존재하지 않을 때, undefined의 totalCost를 접근해 발생하는 문제였습니다.
해당 에러는 옵셔널 체이닝을 활용해 처리 완료했습니다.
#### AS IS
```typescript
totalCost: buttonType.includes("MANUAL")
	? routeList["MANUAL & SAFE"].totalCost
	: routeList["ELECTRIC & SAFE"].totalCost,
```

#### TO BE
````typescript
totalCost: buttonType.includes("MANUAL")
	? routeList["MANUAL & SAFE"]?.totalCost
	: routeList["ELECTRIC & SAFE"]?.totalCost,
````

### 동작 확인

#### 번호 클릭시 이동

https://github.com/user-attachments/assets/ffc28397-0d82-4957-9908-017b5712998d

#### 스크롤 고정

https://github.com/user-attachments/assets/86e475c8-331d-4ce1-a5c7-35c9cf9ac85b

### HOTFIX 정상 동작 확인

https://github.com/user-attachments/assets/b255b7bd-e2b3-4a3f-a7e8-df06720a71f4

### 관련 이슈

UNI-251, UNI-252, UNI-246