### PR TITLE
[UNI-249] feat: 현재 버전에 대한 버전 반환 기능 구현

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/GetAllRoutesByRevisionResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/dto/response/GetAllRoutesByRevisionResDTO.java
@@ -1,6 +1,6 @@
 package com.softeer5.uniro_backend.admin.dto.response;
 
-import com.softeer5.uniro_backend.map.dto.response.GetAllRoutesResDTO;
+import com.softeer5.uniro_backend.map.dto.response.AllRoutesInfo;
 import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -14,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetAllRoutesByRevisionResDTO {
     @Schema(description = "특정 버전에 존재하는 길&노드 스냅샷 정보", example = "")
-    private final GetAllRoutesResDTO routesInfo;
+    private final AllRoutesInfo routesInfo;
     @Schema(description = "특정 버전에 존재하는 위험 요소 스냅샷 정보", example = "")
     private final GetRiskRoutesResDTO getRiskRoutesResDTO;
     @Schema(description = "삭제된 길&노드 정보 정보", example = "")
@@ -22,7 +22,7 @@ public class GetAllRoutesByRevisionResDTO {
     @Schema(description = "현재 버전과 비교하여 변경된 주의/위험 요소 정보", example = "")
     private final List<ChangedRouteDTO> changedList;
 
-    public static GetAllRoutesByRevisionResDTO of(GetAllRoutesResDTO routesInfo, GetRiskRoutesResDTO getRiskRoutesResDTO,
+    public static GetAllRoutesByRevisionResDTO of(AllRoutesInfo routesInfo, GetRiskRoutesResDTO getRiskRoutesResDTO,
                                                   LostRoutesDTO lostRoutes, List<ChangedRouteDTO> changedList) {
         return new GetAllRoutesByRevisionResDTO(routesInfo, getRiskRoutesResDTO, lostRoutes, changedList);
     }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RevInfoRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RevInfoRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
+import java.util.Optional;
 
 public interface RevInfoRepository extends JpaRepository<RevInfo,Long> {
     List<RevInfo> findAllByUnivId(Long univId);
@@ -16,4 +16,6 @@ public interface RevInfoRepository extends JpaRepository<RevInfo,Long> {
     @Transactional
     @Query("DELETE FROM RevInfo r WHERE r.univId = :univId AND r.rev > :versionId")
     void deleteAllAfterVersionId(Long univId, Long versionId);
+
+    Optional<RevInfo> findFirstByUnivIdOrderByRevDesc(Long univId);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -11,7 +11,7 @@ import com.softeer5.uniro_backend.admin.repository.RouteAuditRepository;
 import com.softeer5.uniro_backend.building.repository.BuildingRepository;
 import com.softeer5.uniro_backend.common.exception.custom.AdminException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteException;
-import com.softeer5.uniro_backend.map.dto.response.GetAllRoutesResDTO;
+import com.softeer5.uniro_backend.map.dto.response.AllRoutesInfo;
 import com.softeer5.uniro_backend.map.dto.response.GetChangedRoutesByRevisionResDTO;
 import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;
 import com.softeer5.uniro_backend.map.dto.response.NodeInfoResDTO;
@@ -100,7 +100,7 @@ public class AdminService {
 
     public GetAllRoutesByRevisionResDTO getAllRoutesByRevision(Long univId, Long versionId){
         List<Route> revRoutes = getRevRoutes(univId,versionId);
-        GetAllRoutesResDTO routesInfo = routeCalculator.assembleRoutes(revRoutes, versionId);
+        AllRoutesInfo routesInfo = routeCalculator.assembleRoutes(revRoutes, versionId);
 
         Map<Long, Route> revRouteMap = new HashMap<>();
         for(Route revRoute : revRoutes){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -134,7 +134,10 @@ public class AdminService {
     }
 
     public GetChangedRoutesByRevisionResDTO getChangedRoutesByRevision(Long univId, Long versionId) {
-        List<Route> revRoutes = getRevRoutes(univId,versionId);
+        List<Route> revRoutes = getRevRoutes(univId, versionId);
+
+        RevInfo revInfo = revInfoRepository.findFirstByUnivIdOrderByRevDesc(univId)
+            .orElseThrow(() -> new RouteException("Revision not found", RECENT_REVISION_NOT_FOUND));
 
         Map<Long, Route> revRouteMap = new HashMap<>();
         for(Route revRoute : revRoutes){
@@ -161,7 +164,7 @@ public class AdminService {
         List<Node> endNodes = determineEndNodes(lostAdjMap, lostNodeMap);
         LostRoutesDTO lostRouteDTO = LostRoutesDTO.of(mapNodeInfo(lostNodeMap), routeCalculator.getCoreRoutes(lostAdjMap, endNodes));
 
-        return GetChangedRoutesByRevisionResDTO.of(lostRouteDTO,changedRoutes);
+        return GetChangedRoutesByRevisionResDTO.of(lostRouteDTO, changedRoutes, revInfo.getRev());
     }
 
     private List<Route> getRevRoutes(Long univId, Long versionId) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -100,7 +100,7 @@ public class AdminService {
 
     public GetAllRoutesByRevisionResDTO getAllRoutesByRevision(Long univId, Long versionId){
         List<Route> revRoutes = getRevRoutes(univId,versionId);
-        GetAllRoutesResDTO routesInfo = routeCalculator.assembleRoutes(revRoutes);
+        GetAllRoutesResDTO routesInfo = routeCalculator.assembleRoutes(revRoutes, versionId);
 
         Map<Long, Route> revRouteMap = new HashMap<>();
         for(Route revRoute : revRoutes){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -100,7 +100,7 @@ public class AdminService {
 
     public GetAllRoutesByRevisionResDTO getAllRoutesByRevision(Long univId, Long versionId){
         List<Route> revRoutes = getRevRoutes(univId,versionId);
-        AllRoutesInfo routesInfo = routeCalculator.assembleRoutes(revRoutes, versionId);
+        AllRoutesInfo routesInfo = routeCalculator.assembleRoutes(revRoutes);
 
         Map<Long, Route> revRouteMap = new HashMap<>();
         for(Route revRoute : revRoutes){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     UNAUTHORIZED_UNIV(401, "해당 대학교의 권한이 없습니다."),
     INVALID_UNIV_ID(400, "유효하지 않은 대학교 id 입니다."),
+    RECENT_REVISION_NOT_FOUND(404, "최신 버전을 찾을 수 없습니다."),
     ;
 
     private final int httpStatus;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
@@ -27,7 +27,7 @@ public interface MapApi {
 			@ApiResponse(responseCode = "200", description = "모든 지도 조회 성공"),
 			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
-	ResponseEntity<AllRoutesInfo> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
+	ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
 
 	@Operation(summary = "위험&주의 요소 조회")
 	@ApiResponses(value = {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
@@ -27,7 +27,7 @@ public interface MapApi {
 			@ApiResponse(responseCode = "200", description = "모든 지도 조회 성공"),
 			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
-	ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
+	ResponseEntity<AllRoutesInfo> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
 
 	@Operation(summary = "위험&주의 요소 조회")
 	@ApiResponses(value = {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
@@ -26,8 +26,8 @@ public class MapController implements MapApi {
 
 	@Override
 	@GetMapping("/{univId}/routes")
-	public ResponseEntity<AllRoutesInfo> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
-		AllRoutesInfo allRoutes = mapService.getAllRoutes(univId);
+	public ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
+		GetAllRoutesResDTO allRoutes = mapService.getAllRoutes(univId);
 		return ResponseEntity.ok().body(allRoutes);
 	}
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
@@ -5,7 +5,6 @@ import com.softeer5.uniro_backend.map.dto.request.CreateBuildingRouteReqDTO;
 import com.softeer5.uniro_backend.map.dto.request.CreateRoutesReqDTO;
 import com.softeer5.uniro_backend.map.dto.response.*;
 import com.softeer5.uniro_backend.map.dto.request.PostRiskReqDTO;
-import com.softeer5.uniro_backend.map.service.RouteCalculator;
 
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -27,8 +26,8 @@ public class MapController implements MapApi {
 
 	@Override
 	@GetMapping("/{univId}/routes")
-	public ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
-		GetAllRoutesResDTO allRoutes = mapService.getAllRoutes(univId);
+	public ResponseEntity<AllRoutesInfo> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
+		AllRoutesInfo allRoutes = mapService.getAllRoutes(univId);
 		return ResponseEntity.ok().body(allRoutes);
 	}
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/AllRoutesInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/AllRoutesInfo.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class GetAllRoutesResDTO {
+public class AllRoutesInfo {
 
     @Schema(description = "노드 정보 (id, 좌표)", example = "")
     private final List<NodeInfoResDTO> nodeInfos;
@@ -21,8 +21,8 @@ public class GetAllRoutesResDTO {
     @Schema(description = "버전 id", example = "230")
     private final Long versionId;
 
-    public static GetAllRoutesResDTO of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
+    public static AllRoutesInfo of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
                                         List<BuildingRouteResDTO> buildingRoutes, Long versionId) {
-        return new GetAllRoutesResDTO(nodeInfos, coreRoutes, buildingRoutes, versionId);
+        return new AllRoutesInfo(nodeInfos, coreRoutes, buildingRoutes, versionId);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/AllRoutesInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/AllRoutesInfo.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import java.util.List;
 
 @Getter
-@Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
+@Schema(name = "AllRoutesInfo", description = "모든 노드,루트 데이터")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class AllRoutesInfo {
 
@@ -18,11 +18,9 @@ public class AllRoutesInfo {
     private final List<CoreRouteResDTO> coreRoutes;
     @Schema(description = "빌딩 루트 정보 (id, startNodeId, endNodeId)", example = "")
     private final List<BuildingRouteResDTO> buildingRoutes;
-    @Schema(description = "버전 id", example = "230")
-    private final Long versionId;
 
     public static AllRoutesInfo of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
-                                        List<BuildingRouteResDTO> buildingRoutes, Long versionId) {
-        return new AllRoutesInfo(nodeInfos, coreRoutes, buildingRoutes, versionId);
+                                        List<BuildingRouteResDTO> buildingRoutes) {
+        return new AllRoutesInfo(nodeInfos, coreRoutes, buildingRoutes);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetAllRoutesResDTO.java
@@ -18,9 +18,11 @@ public class GetAllRoutesResDTO {
     private final List<CoreRouteResDTO> coreRoutes;
     @Schema(description = "빌딩 루트 정보 (id, startNodeId, endNodeId)", example = "")
     private final List<BuildingRouteResDTO> buildingRoutes;
+    @Schema(description = "버전 id", example = "230")
+    private final Long versionId;
 
     public static GetAllRoutesResDTO of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
-                                        List<BuildingRouteResDTO> buildingRoutes){
-        return new GetAllRoutesResDTO(nodeInfos, coreRoutes, buildingRoutes);
+                                        List<BuildingRouteResDTO> buildingRoutes, Long versionId) {
+        return new GetAllRoutesResDTO(nodeInfos, coreRoutes, buildingRoutes, versionId);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetAllRoutesResDTO.java
@@ -1,0 +1,28 @@
+package com.softeer5.uniro_backend.map.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(name = "GetAllRoutesResDTO", description = "모든 노드,루트 조회 DTO")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetAllRoutesResDTO {
+
+	@Schema(description = "노드 정보 (id, 좌표)", example = "")
+	private final List<NodeInfoResDTO> nodeInfos;
+	@Schema(description = "루트 정보 (id, startNodeId, endNodeId)", example = "")
+	private final List<CoreRouteResDTO> coreRoutes;
+	@Schema(description = "빌딩 루트 정보 (id, startNodeId, endNodeId)", example = "")
+	private final List<BuildingRouteResDTO> buildingRoutes;
+	@Schema(description = "버전 id", example = "230")
+	private final Long versionId;
+
+	public static GetAllRoutesResDTO of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
+		List<BuildingRouteResDTO> buildingRoutes, Long versionId) {
+		return new GetAllRoutesResDTO(nodeInfos, coreRoutes, buildingRoutes, versionId);
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetChangedRoutesByRevisionResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetChangedRoutesByRevisionResDTO.java
@@ -17,8 +17,10 @@ public class GetChangedRoutesByRevisionResDTO {
     private final LostRoutesDTO lostRoutes;
     @Schema(description = "현재 버전과 비교하여 변경된 주의/위험 요소 정보", example = "")
     private final List<ChangedRouteDTO> changedList;
+    @Schema(description = "최신 버전 id", example = "233")
+    private final Long versionId;
 
-    public static GetChangedRoutesByRevisionResDTO of(LostRoutesDTO lostRoutes, List<ChangedRouteDTO> changedList) {
-        return new GetChangedRoutesByRevisionResDTO(lostRoutes,changedList);
+    public static GetChangedRoutesByRevisionResDTO of(LostRoutesDTO lostRoutes, List<ChangedRouteDTO> changedList, Long versionId) {
+        return new GetChangedRoutesByRevisionResDTO(lostRoutes,changedList, versionId);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -49,7 +49,7 @@ public class MapService {
 
 	private final MapClient mapClient;
 
-	public AllRoutesInfo getAllRoutes(Long univId) {
+	public GetAllRoutesResDTO getAllRoutes(Long univId) {
 		List<Route> routes = routeRepository.findAllRouteByUnivIdWithNodes(univId);
 
 		// 맵이 존재하지 않을 경우 예외
@@ -60,7 +60,10 @@ public class MapService {
 		RevInfo revInfo = revInfoRepository.findFirstByUnivIdOrderByRevDesc(univId)
 			.orElseThrow(() -> new RouteException("Revision not found", RECENT_REVISION_NOT_FOUND));
 
-		return routeCalculator.assembleRoutes(routes, revInfo.getRev());
+		AllRoutesInfo allRoutesInfo = routeCalculator.assembleRoutes(routes);
+
+		return GetAllRoutesResDTO.of(allRoutesInfo.getNodeInfos(), allRoutesInfo.getCoreRoutes(),
+			allRoutesInfo.getBuildingRoutes(), revInfo.getRev());
 	}
 
 	public List<FastestRouteResDTO> findFastestRoute(Long univId, Long startNodeId, Long endNodeId){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -8,7 +8,9 @@ import static com.softeer5.uniro_backend.common.utils.GeoUtils.getInstance;
 import java.util.*;
 
 import com.softeer5.uniro_backend.admin.annotation.RevisionOperation;
+import com.softeer5.uniro_backend.admin.entity.RevInfo;
 import com.softeer5.uniro_backend.admin.enums.RevisionOperationType;
+import com.softeer5.uniro_backend.admin.repository.RevInfoRepository;
 import com.softeer5.uniro_backend.building.entity.Building;
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.BuildingException;
@@ -41,6 +43,7 @@ public class MapService {
 	private final RouteRepository routeRepository;
 	private final NodeRepository nodeRepository;
 	private final BuildingRepository buildingRepository;
+	private final RevInfoRepository revInfoRepository;
 
 	private final RouteCalculator routeCalculator;
 
@@ -54,7 +57,10 @@ public class MapService {
 			throw new RouteException("Route Not Found", ROUTE_NOT_FOUND);
 		}
 
-		return routeCalculator.assembleRoutes(routes);
+		RevInfo revInfo = revInfoRepository.findFirstByUnivIdOrderByRevDesc(univId)
+			.orElseThrow(() -> new RouteException("Revision not found", RECENT_REVISION_NOT_FOUND));
+
+		return routeCalculator.assembleRoutes(routes, revInfo.getRev());
 	}
 
 	public List<FastestRouteResDTO> findFastestRoute(Long univId, Long startNodeId, Long endNodeId){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -49,7 +49,7 @@ public class MapService {
 
 	private final MapClient mapClient;
 
-	public GetAllRoutesResDTO getAllRoutes(Long univId) {
+	public AllRoutesInfo getAllRoutes(Long univId) {
 		List<Route> routes = routeRepository.findAllRouteByUnivIdWithNodes(univId);
 
 		// 맵이 존재하지 않을 경우 예외

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -50,7 +50,7 @@ public class RouteCalculator {
         }
     }
 
-    public GetAllRoutesResDTO assembleRoutes(List<Route> routes) {
+    public GetAllRoutesResDTO assembleRoutes(List<Route> routes, Long versionId) {
         Map<Long, List<Route>> adjMap = new HashMap<>();
         Map<Long, Node> nodeMap = new HashMap<>();
         List<BuildingRouteResDTO> buildingRoutes = new ArrayList<>();
@@ -82,7 +82,7 @@ public class RouteCalculator {
 
         startNode = determineStartNode(startNode, adjMap, nodeMap, routes);
 
-        return GetAllRoutesResDTO.of(nodeInfos, getCoreRoutes(adjMap, List.of(startNode)), buildingRoutes);
+        return GetAllRoutesResDTO.of(nodeInfos, getCoreRoutes(adjMap, List.of(startNode)), buildingRoutes, versionId);
     }
 
     private Node determineStartNode(Node startNode, Map<Long, List<Route>> adjMap, Map<Long, Node> nodeMap, List<Route> routes) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -50,7 +50,7 @@ public class RouteCalculator {
         }
     }
 
-    public GetAllRoutesResDTO assembleRoutes(List<Route> routes, Long versionId) {
+    public AllRoutesInfo assembleRoutes(List<Route> routes, Long versionId) {
         Map<Long, List<Route>> adjMap = new HashMap<>();
         Map<Long, Node> nodeMap = new HashMap<>();
         List<BuildingRouteResDTO> buildingRoutes = new ArrayList<>();
@@ -82,7 +82,7 @@ public class RouteCalculator {
 
         startNode = determineStartNode(startNode, adjMap, nodeMap, routes);
 
-        return GetAllRoutesResDTO.of(nodeInfos, getCoreRoutes(adjMap, List.of(startNode)), buildingRoutes, versionId);
+        return AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, List.of(startNode)), buildingRoutes, versionId);
     }
 
     private Node determineStartNode(Node startNode, Map<Long, List<Route>> adjMap, Map<Long, Node> nodeMap, List<Route> routes) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -50,7 +50,7 @@ public class RouteCalculator {
         }
     }
 
-    public AllRoutesInfo assembleRoutes(List<Route> routes, Long versionId) {
+    public AllRoutesInfo assembleRoutes(List<Route> routes) {
         Map<Long, List<Route>> adjMap = new HashMap<>();
         Map<Long, Node> nodeMap = new HashMap<>();
         List<BuildingRouteResDTO> buildingRoutes = new ArrayList<>();
@@ -82,7 +82,7 @@ public class RouteCalculator {
 
         startNode = determineStartNode(startNode, adjMap, nodeMap, routes);
 
-        return AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, List.of(startNode)), buildingRoutes, versionId);
+        return AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, List.of(startNode)), buildingRoutes);
     }
 
     private Node determineStartNode(Node startNode, Map<Long, List<Route>> adjMap, Map<Long, Node> nodeMap, List<Route> routes) {

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
@@ -293,7 +293,7 @@ class AdminServiceTest {
 		GetAllRoutesByRevisionResDTO allRoutesByRevision = adminService.getAllRoutesByRevision(1001L, 2L);
 
 		//then
-		GetAllRoutesResDTO routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
+		AllRoutesInfo routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
 		LostRoutesDTO lostRoutes = allRoutesByRevision.getLostRoutes();  // 버전 3,4에 생성하여 버전2엔 존재하지 않는 routes
 
 		//a. version2에 존재하는 맵 정보 확인
@@ -370,7 +370,7 @@ class AdminServiceTest {
 		GetAllRoutesByRevisionResDTO allRoutesByRevision = adminService.getAllRoutesByRevision(1001L, 2L);
 
 		//then
-		GetAllRoutesResDTO routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
+		AllRoutesInfo routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
 		LostRoutesDTO lostRoutes = allRoutesByRevision.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
 
 		//a. version2에 존재하는 맵 정보 확인
@@ -458,7 +458,7 @@ class AdminServiceTest {
 		GetAllRoutesByRevisionResDTO allRoutesByRevision = adminService.getAllRoutesByRevision(1001L, 2L);
 
 		//then
-		GetAllRoutesResDTO routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
+		AllRoutesInfo routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
 		LostRoutesDTO lostRoutes = allRoutesByRevision.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
 
 		//a. version2에 존재하는 맵 정보 확인
@@ -548,7 +548,7 @@ class AdminServiceTest {
 		GetAllRoutesByRevisionResDTO allRoutesByRevision = adminService.getAllRoutesByRevision(1001L, 2L);
 
 		//then
-		GetAllRoutesResDTO routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
+		AllRoutesInfo routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
 		LostRoutesDTO lostRoutes = allRoutesByRevision.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
 
 		//a. version2에 존재하는 맵 정보 확인
@@ -634,7 +634,7 @@ class AdminServiceTest {
 		GetAllRoutesByRevisionResDTO allRoutesByRevision = adminService.getAllRoutesByRevision(1001L, 2L);
 
 		//then
-		GetAllRoutesResDTO routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
+		AllRoutesInfo routesInfo = allRoutesByRevision.getRoutesInfo(); // 버전 2에 존재하는 map 정보
 		LostRoutesDTO lostRoutes = allRoutesByRevision.getLostRoutes();  // 버전 3,4,5,6에 생성하여 버전2엔 존재하지 않는 routes
 
 		//a. version2에 존재하는 맵 정보 확인


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 버전 id 데이터를 줘야하는 요구사항을 위해 구현했습니다.
- Calculator 로직은 변동하지 않았고, Calculator 반환값과 MapController의 반환값이 같았는데 이를 분리했습니다.
- Calculator 반환 DTO의 네이밍이 기존에는 ~~ResDTO 였지만 이제 이를 그대로 반환하지 않기 때문에 이름을 수정했습니다.

### AS-IS
<img width="554" alt="스크린샷 2025-02-16 오전 12 43 23" src="https://github.com/user-attachments/assets/b63a5040-4802-4751-aac9-66c7ac5945bb" />

### TO-BE
<img width="669" alt="스크린샷 2025-02-16 오전 1 16 50" src="https://github.com/user-attachments/assets/7cde7032-c273-4092-af8c-8416e41737e0" />

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="717" alt="스크린샷 2025-02-16 오전 12 44 05" src="https://github.com/user-attachments/assets/cbb8cd08-01eb-4dff-a844-2a541ce29c8c" />


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/