### PR TITLE
[UNI-254] feat : 위험 마커 축소, 위험 마커 Animation 및 마커 설명 삽입

### DIFF
--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -12,7 +12,8 @@ import createMarkerElement from "../components/map/mapMarkers";
 import { Markers } from "../constant/enum/markerEnum";
 import useRoutePoint from "../hooks/useRoutePoint";
 import { AdvancedMarker } from "../data/types/marker";
-import { interpolate } from "../utils/interpolate";
+import { Direction } from "framer-motion";
+import { createRiskMarkers } from "../utils/markers/createRiskMarker";
 
 type MapProps = {
 	style?: React.CSSProperties;
@@ -182,32 +183,6 @@ const NavigationMap = ({
 			});
 		};
 	}, [map, buttonState, compositeRoutes, topPadding, bottomPadding]);
-
-	const centerCoordinate = (origin: google.maps.LatLngLiteral, destination: google.maps.LatLngLiteral) => {
-		return interpolate(origin, destination, 0.5);
-	};
-
-	const createRiskMarkers = (
-		riskData: DangerRoute[] | CautionRoute[],
-		map: google.maps.Map,
-		AdvancedMarker: typeof google.maps.marker.AdvancedMarkerElement,
-	): AdvancedMarker[] => {
-		const markers: AdvancedMarker[] = [];
-		riskData.forEach((route) => {
-			const marker = createAdvancedMarker(
-				AdvancedMarker,
-				map,
-				centerCoordinate(route.node1, route.node2),
-				createMarkerElement({
-					type: Markers.DANGER,
-					className: "translate-marker",
-					hasAnimation: true,
-				}),
-			);
-			markers.push(marker);
-		});
-		return markers;
-	};
 
 	const createStartEndMarkers = () => {
 		if (!map || !origin || !destination || !AdvancedMarker) return;

--- a/uniro_frontend/src/components/map/mapMarkers.tsx
+++ b/uniro_frontend/src/components/map/mapMarkers.tsx
@@ -38,7 +38,7 @@ function createTextElement(type: MarkerTypes, title: string): HTMLElement {
 	}
 }
 
-function createAnimatedTextElement(type: MarkerTypes, titles: string[]): HTMLElement {
+export function createAnimatedTextElement(type: MarkerTypes, titles: string[]): HTMLElement {
 	const titleContainer = document.createElement("div");
 
 	const elements = [];

--- a/uniro_frontend/src/utils/markers/createRiskMarker.ts
+++ b/uniro_frontend/src/utils/markers/createRiskMarker.ts
@@ -1,0 +1,101 @@
+import createMarkerElement, { createAnimatedTextElement } from "../../components/map/mapMarkers";
+import { Markers } from "../../constant/enum/markerEnum";
+import { DangerIssue } from "../../constant/enum/reportEnum";
+import { DangerIssueType } from "../../data/types/enum";
+import { AdvancedMarker } from "../../data/types/marker";
+import { DangerRoute } from "../../data/types/route";
+import centerCoordinate from "../coordinates/centerCoordinate";
+import createAdvancedMarker from "./createAdvanedMarker";
+
+export const createRiskMarkers = (
+	riskData: DangerRoute[],
+	map: google.maps.Map,
+	AdvancedMarker: typeof google.maps.marker.AdvancedMarkerElement,
+): AdvancedMarker[] => {
+	const markers: AdvancedMarker[] = [];
+	riskData.forEach((route) => {
+		const markerElement = createMarkerElement({
+			type: Markers.DANGER,
+			className: "translate-pinmarker",
+			hasAnimation: true,
+		});
+
+		const marker = createAdvancedMarker(
+			AdvancedMarker,
+			map,
+			centerCoordinate(route.node1, route.node2),
+			markerElement,
+		);
+
+		const markerEl = marker.content as HTMLElement;
+		const innerEl = markerEl.querySelector("div");
+		const factors = (route.dangerFactors as DangerIssueType[]).map((key) => DangerIssue[key]);
+
+		if (innerEl) {
+			initializeMarkerStyles(innerEl);
+			const textElement = innerEl.querySelector("div");
+			if (textElement) {
+				innerEl.removeChild(textElement);
+			}
+		}
+
+		marker.addListener("click", () => {
+			toggleMarker(marker, factors);
+		});
+
+		["click", "zoom_changed", "drag", "bounds_changed"].forEach((e) => {
+			map.addListener(e, () => collapseMarker(marker));
+		});
+
+		markers.push(marker);
+	});
+	return markers;
+};
+const initializeMarkerStyles = (el: HTMLElement) => {
+	el.style.transformOrigin = "center bottom";
+	el.style.transform = "scale(0.5)";
+	el.style.transition = "transform 0.3s ease";
+	el.style.willChange = "transform";
+	el.style.zIndex = "0";
+};
+
+const toggleMarker = (marker: AdvancedMarker, factors: string[]) => {
+	const innerEl = (marker.content as HTMLElement)?.querySelector("div");
+	if (!innerEl) return;
+
+	if (innerEl.style.transform === "scale(1)") {
+		collapseMarker(marker);
+	} else {
+		expandMarker(marker, factors);
+	}
+};
+
+const collapseMarker = (marker: AdvancedMarker) => {
+	marker.zIndex = 0;
+	const innerEl = (marker.content as HTMLElement)?.querySelector("div");
+	if (!innerEl) return;
+
+	innerEl.style.transform = "scale(0.5)";
+	const existingText = innerEl.querySelector(".animated-text");
+	if (existingText) {
+		innerEl.removeChild(existingText);
+	}
+};
+
+const expandMarker = (marker: AdvancedMarker, factors: string[]) => {
+	marker.zIndex = 100;
+	const innerEl = (marker.content as HTMLElement)?.querySelector("div");
+	if (!innerEl) return;
+
+	innerEl.style.transform = "scale(1)";
+	innerEl.style.zIndex = "100";
+
+	const oldEl = innerEl.querySelector(".animated-text");
+	if (oldEl) {
+		innerEl.removeChild(oldEl);
+	}
+
+	const animatedTextEl = createAnimatedTextElement(Markers.DANGER, factors);
+	animatedTextEl.classList.add("animated-text");
+	innerEl.prepend(animatedTextEl);
+};


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 위험 마커 축소, 위험 마커 Animation 및 마커 설명 삽입

## 주요 기능

### 위험 애니메이션 마커 추가

네비게이션 페이지에서 사용하는 마커는 일반 마커와 다른 특성을 가지고 있습니다.
- 작은 상태에서 커져야 한다는 점
- 커질 때, 자연스럽게 어떤 위험 요소인지 보여야 한다는 점

때문에 기존 createElementMarker를 사용하기 어렵다고 느꼈고, 직접 DOM을 조작하는 방법을 연구해 따로 함수로 분리했습니다.

```typescript

export const createRiskMarkers = (
	riskData: DangerRoute[],
	map: google.maps.Map,
	AdvancedMarker: typeof google.maps.marker.AdvancedMarkerElement,
): AdvancedMarker[] => {
	const markers: AdvancedMarker[] = [];
	riskData.forEach((route) => {
		const markerElement = createMarkerElement({
			type: Markers.DANGER,
			className: "translate-pinmarker",
			hasAnimation: true,
		});

		const marker = createAdvancedMarker(
			AdvancedMarker,
			map,
			centerCoordinate(route.node1, route.node2),
			markerElement,
		);

		const markerEl = marker.content as HTMLElement;
		const innerEl = markerEl.querySelector("div");
		const factors = (route.dangerFactors as DangerIssueType[]).map((key) => DangerIssue[key]);

		if (innerEl) {
			initializeMarkerStyles(innerEl);
			const textElement = innerEl.querySelector("div");
			if (textElement) {
				innerEl.removeChild(textElement);
			}
		}

		marker.addListener("click", () => {
			toggleMarker(marker, factors);
		});

		["click", "zoom_changed", "drag", "bounds_changed"].forEach((e) => {
			map.addListener(e, () => collapseMarker(marker));
		});

		markers.push(marker);
	});
	return markers;
};
```
그 결과, marker 안의 div element에 직접 접근하여, style을 수정할 수 있다는 것을 알게 되었습니다.(개발자 도구를 사용해 분석했습니다.)
마커의 미리 텍스트 되는 부분이 터치 범위를 넓혀, inner.removeChild(textElement)로 터치 범위를 제한했습니다.

4가지 함수를 제작해 사용했습니다.

#### initializeMarkerStyles

```typescript
const initializeMarkerStyles = (el: HTMLElement) => {
	el.style.transformOrigin = "center bottom";
	el.style.transform = "scale(0.5)";
	el.style.transition = "transform 0.3s ease";
	el.style.willChange = "transform";
	el.style.zIndex = "0";
};
```

처음 등장하는 위치와 애니메이션의 위치를 보정해줍니다.

#### toggleMarker
```typescript
const toggleMarker = (marker: AdvancedMarker, factors: string[]) => {
	const innerEl = (marker.content as HTMLElement)?.querySelector("div");
	if (!innerEl) return;

	if (innerEl.style.transform === "scale(1)") {
		collapseMarker(marker);
	} else {
		expandMarker(marker, factors);
	}
};
```
마커의 스타일에 따라 켜고, 끄는 것을 관리해주는 함수입니다.

#### collapseMarker
```typescript
const collapseMarker = (marker: AdvancedMarker) => {
	marker.zIndex = 0;
	const innerEl = (marker.content as HTMLElement)?.querySelector("div");
	if (!innerEl) return;

	innerEl.style.transform = "scale(0.5)";
	const existingText = innerEl.querySelector(".animated-text");
	if (existingText) {
		innerEl.removeChild(existingText);
	}
};
```

마커를 끄는 책임을 갖고 있는 함수입니다.
작아질 때는, zIndex를 0으로 설정했습니다.

#### expandMarker
```typescript
const expandMarker = (marker: AdvancedMarker, factors: string[]) => {
	marker.zIndex = 100;
	const innerEl = (marker.content as HTMLElement)?.querySelector("div");
	if (!innerEl) return;

	innerEl.style.transform = "scale(1)";
	innerEl.style.zIndex = "100";

	const oldEl = innerEl.querySelector(".animated-text");
	if (oldEl) {
		innerEl.removeChild(oldEl);
	}

	const animatedTextEl = createAnimatedTextElement(Markers.DANGER, factors);
	animatedTextEl.classList.add("animated-text");
	innerEl.prepend(animatedTextEl);
};
```

마커를 키는 책임을 갖는 함수입니다.
커질 때는, zIndex를 0으로 설정했습니다.

다행히 같이 만들어놓은 createMarkerElement, createAnimatedTextElement,  createAdvancedMarker와 같은 좋은 함수들이 존재하여, 깔끔한 함수를 만들 수 있었습니다.
따로 state로 관리로 필요한 마커들이 아니라, 이런식으로 자유롭게 함수를 만들었습니다.

### 동작 확인

#### AS IS

https://github.com/user-attachments/assets/8b7a3c49-c4cd-49a5-b553-9c3964c00ec3

#### map에 걸려있는 "click", "zoom_changed", "drag", "bounds_changed" 에 대한 테스트

https://github.com/user-attachments/assets/ddac4539-722f-4e8b-8bc6-0e58c3d3ed92

#### zIndex에 대한 테스트

https://github.com/user-attachments/assets/c64232d9-606f-406a-886c-b7062a4aeb0c