### PR TITLE
[UNI-257] feat : 지도 메인 페이지 2차 UX 개선 (줌 레벨 조정에 따른 건물 이름 노출 로직 적용, 출발 도착 선택 시 지도 줌 변경)

### DIFF
--- a/uniro_frontend/src/components/map/mapBottomSheet.tsx
+++ b/uniro_frontend/src/components/map/mapBottomSheet.tsx
@@ -21,7 +21,7 @@ export default function MapBottomSheet({ isVisible, selectedMarker, selectRouteP
 	return (
 		<AnimatedContainer
 			isVisible={isVisible}
-			className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto z-20"
+			className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto z-20 pt-3"
 			positionDelta={500}
 			transition={{
 				duration: 0.3,
@@ -29,7 +29,6 @@ export default function MapBottomSheet({ isVisible, selectedMarker, selectRouteP
 				damping: 20,
 			}}
 		>
-			<BottomSheetHandle dragControls={dragControls} />
 			<div ref={scrollRef} className="w-full overflow-y-auto h-fit" onScroll={preventScroll}>
 				<MapBottomSheetFromMarker
 					building={selectedMarker}

--- a/uniro_frontend/src/index.css
+++ b/uniro_frontend/src/index.css
@@ -139,6 +139,10 @@
 	transform: translateY(+4px);
 }
 
+@utility translate-building {
+	transform: translateY(10px);
+}
+
 @keyframes markerAppear {
 	0% {
 		transform: scale(0);

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -33,7 +33,6 @@ import useQueryError from "../hooks/useQueryError";
 import { Coord } from "../data/types/coord";
 import AnimatedContainer from "../container/animatedContainer";
 
-
 export type SelectedMarkerTypes = {
 	type: MarkerTypes;
 	id: NodeId | RouteId;
@@ -52,7 +51,9 @@ export default function MapPage() {
 
 	const [selectedMarker, setSelectedMarker] = useState<SelectedMarkerTypes>();
 	const buildingBoundary = useRef<google.maps.LatLngBounds | null>(null);
-	const [buildingMarkers, setBuildingMarkers] = useState<{ element: AdvancedMarker; nodeId: NodeId }[]>([]);
+	const [buildingMarkers, setBuildingMarkers] = useState<{ element: AdvancedMarker; nodeId: NodeId; name: string }[]>(
+		[],
+	);
 
 	const [dangerMarkers, setDangerMarkers] = useState<{ element: AdvancedMarker; routeId: RouteId }[]>([]);
 	const [isDangerAcitve, setIsDangerActive] = useState<boolean>(false);
@@ -76,11 +77,12 @@ export default function MapPage() {
 	const [FailModal, { status, data, refetch: findFastRoute }] = useQueryError(
 		{
 			queryKey: ["fastRoute", university.id, origin?.nodeId, destination?.nodeId],
-			queryFn: () => getNavigationResult(
-				university.id,
-				origin ? origin?.nodeId : -1,
-				destination ? destination?.nodeId : -1,
-			),
+			queryFn: () =>
+				getNavigationResult(
+					university.id,
+					origin ? origin?.nodeId : -1,
+					destination ? destination?.nodeId : -1,
+				),
 			enabled: false,
 			retry: 0,
 		},
@@ -126,9 +128,7 @@ export default function MapPage() {
 
 	const moveToBound = (coord: Coord) => {
 		buildingBoundary.current = new google.maps.LatLngBounds();
-		buildingBoundary.current.extend(
-			coord
-		);
+		buildingBoundary.current.extend(coord);
 		// 라이브러리를 다양한 화면을 관찰해보았을 때, h-가 377인것을 확인했습니다.
 		map?.fitBounds(buildingBoundary.current, {
 			top: 0,
@@ -170,16 +170,16 @@ export default function MapPage() {
 		if (AdvancedMarker === null || map === null) return;
 
 		const buildingList = buildings.data;
-		const buildingMarkersWithID: { nodeId: NodeId; element: AdvancedMarker }[] = [];
+		const buildingMarkersWithID: { nodeId: NodeId; element: AdvancedMarker; name: string }[] = [];
 
 		for (const building of buildingList) {
 			const { nodeId, lat, lng, buildingName } = building;
 
 			const buildingMarker = createAdvancedMarker(
 				AdvancedMarker,
-				(nodeId === origin?.nodeId || nodeId === destination?.nodeId) ? map : null,
+				map,
 				new google.maps.LatLng(lat, lng),
-				createMarkerElement({ type: Markers.BUILDING, title: buildingName, className: "translate-marker" }),
+				createMarkerElement({ type: Markers.BUILDING, title: "", className: "translate-building" }),
 				() => {
 					setSelectedMarker({
 						id: nodeId,
@@ -191,7 +191,7 @@ export default function MapPage() {
 				},
 			);
 
-			buildingMarkersWithID.push({ nodeId: nodeId ? nodeId : -1, element: buildingMarker });
+			buildingMarkersWithID.push({ nodeId: nodeId ? nodeId : -1, element: buildingMarker, name: buildingName });
 		}
 
 		setBuildingMarkers(buildingMarkersWithID);
@@ -354,7 +354,6 @@ export default function MapPage() {
 				return;
 			}
 
-
 			if (isSelect) {
 				marker.element.content = createMarkerElement({
 					type: Markers.SELECTED_BUILDING,
@@ -417,7 +416,6 @@ export default function MapPage() {
 
 	/** 빌딩 리스트에서 넘어온 경우, 일치하는 BuildingMarkerElement를 탐색 */
 	useEffect(() => {
-
 		if (buildingMarkers.length === 0 || !selectedBuilding || !selectedBuilding.nodeId) return;
 
 		if (!selectedMarker) {
@@ -425,7 +423,6 @@ export default function MapPage() {
 
 			if (!matchedMarker) return;
 			if (searchMode === "BUILDING") {
-
 				setSelectedMarker({
 					id: selectedBuilding.nodeId,
 					type: Markers.BUILDING,
@@ -433,7 +430,7 @@ export default function MapPage() {
 					from: "List",
 					property: selectedBuilding,
 				});
-				return
+				return;
 			}
 			if (searchMode === "ORIGIN") {
 				setOrigin(selectedBuilding);
@@ -505,10 +502,9 @@ export default function MapPage() {
 		if (origin && destination) {
 			const newBound = new google.maps.LatLngBounds();
 			newBound.extend(origin);
-			newBound.extend(destination)
-			map?.fitBounds(newBound)
+			newBound.extend(destination);
+			map?.fitBounds(newBound);
 		}
-
 	}, [origin, destination]);
 
 	useEffect(() => {
@@ -518,9 +514,35 @@ export default function MapPage() {
 		}
 
 		return () => {
-			setBuilding(undefined)
-		}
+			setBuilding(undefined);
+		};
 	}, [selectedMarker]);
+
+	const toggleBuildingMarker = (isTitleShown: boolean) => {
+		if (isTitleShown) {
+			buildingMarkers
+				.filter((el) => el.nodeId !== destination?.nodeId && el.nodeId !== origin?.nodeId)
+				.forEach(
+					(marker) =>
+						(marker.element.content = createMarkerElement({
+							type: Markers.BUILDING,
+							title: marker.name,
+							className: "translate-marker",
+						})),
+				);
+			return;
+		}
+
+		buildingMarkers
+			.filter((el) => el.nodeId !== destination?.nodeId && el.nodeId !== origin?.nodeId)
+			.forEach(
+				(marker) =>
+					(marker.element.content = createMarkerElement({
+						type: Markers.BUILDING,
+						className: "translate-building",
+					})),
+			);
+	};
 
 	useEffect(() => {
 		if (!map) return;
@@ -542,7 +564,7 @@ export default function MapPage() {
 			}
 
 			toggleMarkers(true, universityMarker ? [universityMarker] : [], map);
-			toggleMarkers(false, buildingMarkers.filter(el => el.nodeId !== origin?.nodeId && el.nodeId !== destination?.nodeId).map(el => el.element), map);
+			toggleBuildingMarker(false);
 		} else if (prevZoom.current <= 16 && zoom >= 17) {
 			if (isCautionAcitve) {
 				toggleMarkers(
@@ -558,16 +580,19 @@ export default function MapPage() {
 					map,
 				);
 			}
-
 			toggleMarkers(false, universityMarker ? [universityMarker] : [], map);
-			toggleMarkers(true, buildingMarkers.map(el => el.element), map);
+			toggleBuildingMarker(true);
 		}
 	}, [map, zoom]);
 
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center">
-			<MapTopBuildingSheet isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode === "BUILDING"} />
-			<MapTopRouteSheet isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode != "BUILDING"} />
+			<MapTopBuildingSheet
+				isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode === "BUILDING"}
+			/>
+			<MapTopRouteSheet
+				isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode != "BUILDING"}
+			/>
 			<div ref={mapRef} className="w-full h-full" />
 			<MapBottomSheet
 				selectRoutePoint={selectRoutePoint}
@@ -580,7 +605,7 @@ export default function MapPage() {
 				positionDelta={200}
 				transition={{
 					duration: 0.3,
-					type: 'spring',
+					type: "spring",
 					damping: 20,
 				}}
 				className=""
@@ -596,7 +621,7 @@ export default function MapPage() {
 				positionDelta={200}
 				transition={{
 					duration: 0.3,
-					type: 'spring',
+					type: "spring",
 					damping: 20,
 				}}
 				className=""

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -618,7 +618,7 @@ export default function MapPage() {
 				isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode === "BUILDING"}
 			/>
 			<MapTopRouteSheet
-				isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode != "BUILDING"}
+				isVisible={(selectedMarker?.type === Markers.BUILDING ? false : true) && searchMode !== "BUILDING"}
 			/>
 			<div ref={mapRef} className="w-full h-full" />
 			<MapBottomSheet


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### 줌 레벨 조정에 따른 건물 이름 노출 로직 적용

- #138 에서 건물 마커 이미지가 변경되면서, 건물들의 마커가 항상 노출되고 줌이 바뀜에따라 건물 이름이 보여지는지 결정되는 것이 더 사용자에게 친화적인 UX라는 의견이 들어와서 반영하였습니다.
```typescript
const toggleBuildingMarker = (isTitleShown: boolean) => {
		if (isTitleShown) {
			buildingMarkers
				.filter((el) => el.nodeId !== destination?.nodeId && el.nodeId !== origin?.nodeId && el.nodeId !== selectedMarker?.id)
				.forEach(
					(marker) =>
						(marker.element.content = createMarkerElement({
							type: Markers.BUILDING,
							title: marker.name,
							className: "translate-marker",
						})),
				);
			return;
		}

		buildingMarkers
			.filter((el) => el.nodeId !== destination?.nodeId && el.nodeId !== origin?.nodeId && el.nodeId !== selectedMarker?.id)
			.forEach(
				(marker) =>
					(marker.element.content = createMarkerElement({
						type: Markers.BUILDING,
						className: "translate-building",
					})),
			);
	};
```
- 기존 줌이 바뀌는 useEffect에서 `toggleMarkers` 함수로 마커가 보일지 말지를 결정하던 것에서 분리하여, `toggleBuildingMarker`로 분리하였습니다.
- 이때, 줌이 바뀌어도 변경되지 말아야하는, 출발 도착 마커, 선택된 건물 마커는 변경에서 제외됩니다.

### 출발 도착지 선택 이후, 이전 줌으로 되돌리기
- 다른 사용자 인터뷰 결과, 출발 도착지를 선택한 경우 다른 곳을 선택하기 위해 다시 축소를 하고 지도를 이동시키는 과정이 번거롭다는 의견을 수용하여 출발 도착지를 선택한 경우에는 줌을 이전 상태의 줌 `prevZoom`으로 변경하였습니다.
- 기존에 prevZoom을 ref로 관리하고 있어서 해당 변수를 재사용하였습니다.
```typescript
/** 도착지 결정 시, Marker Content 변경 */
	useEffect(() => {
		if (!destination || !destination.nodeId) return;

		const destinationMarker = findBuildingMarker(destination.nodeId);
		if (!destinationMarker) return;

		destinationMarker.map = map;

		destinationMarker.content = createMarkerElement({
			type: Markers.DESTINATION,
			title: destination.buildingName,
			className: "translate-pinmarker",
		});

		if (destination !== undefined && origin === undefined) {
			moveToBound(destination);
			map?.setZoom(prevZoom.current)
		}

		return () => {
			const curZoom = map?.getZoom() as number;

			const destinationMarker = findBuildingMarker(destination.nodeId);
			if (!destinationMarker) return;

			destinationMarker.content = createMarkerElement({
				type: Markers.BUILDING,
				...(curZoom <= 16 ? {
					className: "translate-building",
				} : {
					title: destination.buildingName,
					className: "translate-marker",
				})
			});
		};
	}, [destination, buildingMarkers]);
```
- 출발, 도착지가 모두 선택된 경우에는`origin` 과 `destination` 을 모두 가지는 useEffect에서 변경되기를 원하고 자기 자신이 출발 도착지가 설정이후 해제될 때는 줌이 변하기를 원하지 않아 각 useEffect내부에서는 자기 자신만 값이 존재하는 경우에만 값을 변환하였습니다.
- 그리고 해제되는 경우에는, 현재 지도 줌 상태에 따라, 이름이 보이는 건물마커와 이름이 보이지 않는 건물마커 2가지 경우를 모두 고려하여 cleanup 함수를 변경하였습니다.

## 🧪 동작 결과

### 줌 레벨 조정에 따른 건물 이름 노출 로직 적용


| before  | after |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/7f94a231-df68-422f-9162-dfe2164e6d6a">  | <video src="https://github.com/user-attachments/assets/1578b429-075e-4bc4-94e4-9ecc4b08c488">|



### 출발 도착 선택 이후, 지도 줌 변경하기

| before  | after |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/1aaf00c4-5a0c-427e-803a-f8c827c0d3f5">  | <video src="https://github.com/user-attachments/assets/c4e0f2d9-7d4d-49ad-8e3a-0507bdcf6f69">|

## 연관 이슈
UNI-258, UNI-259