### PR TITLE
[UNI-260] fix : CORS allowedHeaders에 Authorization 명시

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/CorsConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/CorsConfig.java
@@ -15,7 +15,7 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
-                .allowedHeaders("*")
+                .allowedHeaders("Authorization", "Content-Type", "Accept", "X-Requested-With")
                 .allowCredentials(true);
     }
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
CORS config의 allowedHeaders에 Authorization를 명시하여 preflight 관련 문제를 해결하였습니다.

## 🧪 테스트 결과
<img width="649" alt="image" src="https://github.com/user-attachments/assets/1149a1a7-347a-4d0c-8b55-da894c7f6a5e" />
