### PR TITLE
[UNI-224] 배포(www<->admin) 주소 바뀌는 현상 fix

### DIFF
--- a/.github/workflows/fe-admin-deploy.yml
+++ b/.github/workflows/fe-admin-deploy.yml
@@ -4,6 +4,8 @@ on:
     push:
         branches:
             - fe
+        paths:
+            - 'uniro_admin_frontend/**'
 
 jobs:
     CI:

--- a/.github/workflows/fe-deploy.yml
+++ b/.github/workflows/fe-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - fe
+    paths:
+      - 'uniro_frontend/**'
 
 jobs:
   CI:


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
기존에는 admin PR, fe PR이 구분이 불가능해 fe-workflow와 fe-admin-workflow가 두번 돌아가며 ngnix가 바라보는 docker container가 꼬이는 현상이 발생했습니다.
해결책을 찾던 중, workflow의 path 조건을 배우게 되어, 폴더별로 실행이 가능하게 변경하였습니다.

## 💡 To Reviewer
감사합니다.

## 🧪 테스트 결과

테스트 없음.

## ✅ 반영 브랜치

fe