### PR TITLE
[UNI-256] feat : 길찾기 페이지 주의 요소 클릭 시 지도 및 바텀 시트 이동

### DIFF
--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -29,7 +29,7 @@ type MapProps = {
 	bottomPadding?: number;
 	currentRouteIdx: number;
 	handleCautionMarkerClick: (index: number) => void;
-	setDangerRouteIdx: Dispatch<SetStateAction<number>>;
+	setCautionRouteIdx: Dispatch<SetStateAction<number>>;
 };
 
 // TODO: useEffect로 경로가 모두 로딩된 이후에 마커가 생성되도록 수정하기
@@ -68,7 +68,7 @@ const NavigationMap = ({
 	bottomPadding = 0,
 	currentRouteIdx,
 	handleCautionMarkerClick,
-	setDangerRouteIdx,
+	setCautionRouteIdx,
 }: MapProps) => {
 	const { mapRef, map, AdvancedMarker, Polyline } = useMap();
 	const { origin, destination } = useRoutePoint();
@@ -266,7 +266,7 @@ const NavigationMap = ({
 
 				const marker = createAdvancedMarker(AdvancedMarker, map, coordinates, markerElement, () => {
 					handleCautionMarkerClick(index + 1);
-					setDangerRouteIdx(index + 1);
+					setCautionRouteIdx(index + 1);
 				});
 				markers.push(marker);
 			}

--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useMap from "../hooks/useMap";
 import {
 	CautionRoute,
@@ -28,6 +28,8 @@ type MapProps = {
 	topPadding?: number;
 	bottomPadding?: number;
 	currentRouteIdx: number;
+	handleCautionMarkerClick: (index: number) => void;
+	setDangerRouteIdx: Dispatch<SetStateAction<number>>;
 };
 
 // TODO: useEffect로 경로가 모두 로딩된 이후에 마커가 생성되도록 수정하기
@@ -65,6 +67,8 @@ const NavigationMap = ({
 	topPadding = 0,
 	bottomPadding = 0,
 	currentRouteIdx,
+	handleCautionMarkerClick,
+	setDangerRouteIdx,
 }: MapProps) => {
 	const { mapRef, map, AdvancedMarker, Polyline } = useMap();
 	const { origin, destination } = useRoutePoint();
@@ -260,7 +264,10 @@ const NavigationMap = ({
 					hasAnimation,
 				});
 
-				const marker = createAdvancedMarker(AdvancedMarker, map, coordinates, markerElement);
+				const marker = createAdvancedMarker(AdvancedMarker, map, coordinates, markerElement, () => {
+					handleCautionMarkerClick(index + 1);
+					setDangerRouteIdx(index + 1);
+				});
 				markers.push(marker);
 			}
 		});

--- a/uniro_frontend/src/components/navigation/route/routeList.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeList.tsx
@@ -8,12 +8,14 @@ type RouteListProps = {
 	changeCurrentRouteIdx: (index: number) => void;
 	currentRouteIdx: number;
 	routes?: RouteDetail[] | null;
+	cautionRouteIdx: number;
 };
 
 const Divider = () => <div className="border-[0.5px] border-gray-200 w-full"></div>;
 
-const RouteList = ({ changeCurrentRouteIdx, currentRouteIdx, routes }: RouteListProps) => {
+const RouteList = ({ changeCurrentRouteIdx, currentRouteIdx, routes, cautionRouteIdx }: RouteListProps) => {
 	const { origin, destination } = useRoutePoint();
+	const currentItemRef = useRef<HTMLDivElement | null>(null);
 
 	const addOriginAndDestination = (routes: RouteDetail[]) => {
 		return [
@@ -33,13 +35,25 @@ const RouteList = ({ changeCurrentRouteIdx, currentRouteIdx, routes }: RouteList
 		];
 	};
 
+	useEffect(() => {
+		if (cautionRouteIdx === -1) return;
+		const target = document.getElementById(`route-${cautionRouteIdx}`);
+		if (target) {
+			target.scrollIntoView({ behavior: "smooth", block: "center" });
+		}
+	}, [cautionRouteIdx]);
+
 	return (
 		<div className="w-full">
 			{routes &&
 				addOriginAndDestination(routes).map((route, index) => (
 					<Fragment key={`${route.dist}-${route.coordinates.lat}-fragment`}>
 						<Divider />
-						<div className="flex flex-col">
+						<div
+							id={`route-${index}`}
+							className="flex flex-col"
+							ref={currentRouteIdx === index ? currentItemRef : null}
+						>
 							<RouteCard
 								changeCurrentRouteIdx={changeCurrentRouteIdx}
 								currentRouteIdx={currentRouteIdx}

--- a/uniro_frontend/src/components/navigation/route/routeList.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeList.tsx
@@ -15,7 +15,6 @@ const Divider = () => <div className="border-[0.5px] border-gray-200 w-full"></d
 
 const RouteList = ({ changeCurrentRouteIdx, currentRouteIdx, routes, cautionRouteIdx }: RouteListProps) => {
 	const { origin, destination } = useRoutePoint();
-	const currentItemRef = useRef<HTMLDivElement | null>(null);
 
 	const addOriginAndDestination = (routes: RouteDetail[]) => {
 		return [
@@ -49,11 +48,7 @@ const RouteList = ({ changeCurrentRouteIdx, currentRouteIdx, routes, cautionRout
 				addOriginAndDestination(routes).map((route, index) => (
 					<Fragment key={`${route.dist}-${route.coordinates.lat}-fragment`}>
 						<Divider />
-						<div
-							id={`route-${index}`}
-							className="flex flex-col"
-							ref={currentRouteIdx === index ? currentItemRef : null}
-						>
+						<div id={`route-${index}`} className="flex flex-col">
 							<RouteCard
 								changeCurrentRouteIdx={changeCurrentRouteIdx}
 								currentRouteIdx={currentRouteIdx}

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -128,7 +128,7 @@ const NavigationResultPage = () => {
 				bottomPadding={sheetHeight}
 				handleCautionMarkerClick={handleCautionMarkerClick}
 				currentRouteIdx={currentRouteIdx}
-				setDangerRouteIdx={setCautionRouteIdx}
+				setCautionRouteIdx={setCautionRouteIdx}
 			/>
 
 			<AnimatedContainer

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useSuspenseQueries } from "@tanstack/react-query";
 
 import RouteList from "../components/navigation/route/routeList";
@@ -41,6 +41,8 @@ const NavigationResultPage = () => {
 
 	const [buttonState, setButtonState] = useState<NavigationButtonRouteType>("PEDES & SAFE");
 	const [currentRouteIdx, setCurrentRouteIdx] = useState(-1);
+	// Caution 마커를 위한 routeIdx state
+	const [cautionRouteIdx, setCautionRouteIdx] = useState(-1);
 
 	useRedirectUndefined<University | Building | undefined>([university, origin, destination]);
 
@@ -82,6 +84,7 @@ const NavigationResultPage = () => {
 	});
 
 	const resetCurrentIndex = () => {
+		setCautionRouteIdx(-1);
 		setCurrentRouteIdx(-1);
 	};
 
@@ -107,6 +110,11 @@ const NavigationResultPage = () => {
 		setButtonState(buttonType);
 	};
 
+	const handleCautionMarkerClick = (index: number) => {
+		showDetailView();
+		setCurrentRouteIdx(index);
+	};
+
 	return (
 		<div className="relative h-dvh w-full max-w-[450px] mx-auto">
 			{/* 지도 영역 */}
@@ -118,7 +126,9 @@ const NavigationResultPage = () => {
 				risks={risks.data}
 				topPadding={topBarHeight}
 				bottomPadding={sheetHeight}
+				handleCautionMarkerClick={handleCautionMarkerClick}
 				currentRouteIdx={currentRouteIdx}
+				setDangerRouteIdx={setCautionRouteIdx}
 			/>
 
 			<AnimatedContainer
@@ -169,7 +179,7 @@ const NavigationResultPage = () => {
 				isVisible={isDetailView}
 				className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto"
 				positionDelta={MAX_SHEET_HEIGHT}
-				transition={{ type: "spring", damping: 20, duration: 0.3 }}
+				transition={{ type: "spring", damping: 20, duration: 0.7 }}
 				motionProps={{
 					drag: "y",
 					dragControls,
@@ -209,6 +219,7 @@ const NavigationResultPage = () => {
 								? routeList.data![buttonState]?.routeDetails
 								: null
 						}
+						cautionRouteIdx={cautionRouteIdx}
 					/>
 				</div>
 			</AnimatedContainer>


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

###  클릭시 이동을 위한 cautionRouteIdx state 도입
```typescript
// Caution 마커를 위한 routeIdx state
	const [cautionRouteIdx, setCautionRouteIdx] = useState(-1);
```

#### 따로 state를 도입하게 된 배경

본래 ref를 이동시키는 함수를, useRef로 RouteCard를 이동하고, fowardRef로 부모에게 ref와 useImperativeValue로 ref를 transform하는 함수를 부모에게 넘겨주어, Navigation Map event를 걸어주려고 했었습니다.
하지만 ref가 바텀시트가 올라오지 않으면, useImperativeValue에서 cardRef가 존재하지 않아 cardRef를 transform하는 함수가 undefined가 되어, 함수 호출이 안되는 문제가 발생하였습니다.

그래서 추가적인 state로 관리하고, cautionRouteIdx로 기존 routeIdx로 이동하는 방식과 동일한 방식으로 구현했습니다.

## 🧪 동작 결과

https://github.com/user-attachments/assets/5cfcb8ec-57d0-4c7e-a1bd-40553d1a823c

## ✅ 반영 브랜치
fe