### PR TITLE
[UNI-264] refactor : aud 테이블에서 조회하던 쿼리문 최적화

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/repository/RouteAuditRepository.java
@@ -25,10 +25,18 @@ public class RouteAuditRepository {
 
 	public List<Route> getAllRoutesAtRevision(Long univId, Long versionId) {
 		AuditReader auditReader = AuditReaderFactory.get(entityManager);
-		return auditReader.createQuery()
-			.forEntitiesAtRevision(Route.class, versionId)
-			.add(AuditEntity.property("univId").eq(univId))
-			.getResultList();
+		List<Route> allRevisions = auditReader.createQuery()
+				.forRevisionsOfEntity(Route.class, true, true)
+				.add(AuditEntity.revisionNumber().le(versionId))
+				.add(AuditEntity.property("univId").eq(univId))
+				.addOrder(AuditEntity.revisionNumber().asc())
+				.getResultList();
+
+		Map<Long, Route> uniqueRoutesMap = new HashMap<>();
+		for (Route route : allRevisions) {
+			uniqueRoutesMap.put(route.getId(), route);
+		}
+		return new ArrayList<>(uniqueRoutesMap.values());
 	}
 
 	public void deleteAllAfterVersionId(Long univId, Long versionId) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -147,7 +147,7 @@ public class AdminService {
         }
 
         List<Route> changedRoutes = routeAuditRepository.findUpdatedRouteByUnivIdWithNodes(univId,versionId);
-        List<Node> nodes = nodeRepository.findByUnivId(univId);
+        List<Node> nodes = nodeRepository.findAllByUnivId(univId);
         fetchNodes(changedRoutes,nodes);
 
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -100,7 +100,8 @@ public class AdminService {
 
     public GetAllRoutesByRevisionResDTO getAllRoutesByRevision(Long univId, Long versionId){
         List<Route> revRoutes = getRevRoutes(univId,versionId);
-        fetchNode(univId,versionId,revRoutes);
+        List<Node> revNodes = nodeAuditRepository.getAllNodesAtRevision(univId, versionId);
+        fetchNodes(revRoutes,revNodes);
         AllRoutesInfo routesInfo = routeCalculator.assembleRoutes(revRoutes);
 
         Map<Long, Route> revRouteMap = new HashMap<>();
@@ -134,20 +135,6 @@ public class AdminService {
         return GetAllRoutesByRevisionResDTO.of(routesInfo, getRiskRoutesResDTO, lostRouteDTO, changedRoutes);
     }
 
-    private void fetchNode(Long univId, Long versionId, List<Route> revRoutes) {
-
-        List<Node> revNodes = nodeAuditRepository.getAllNodesAtRevision(univId, versionId);
-        Map<Long, Node> nodeMap = new HashMap<>();
-        for(Node revNode : revNodes){
-            nodeMap.put(revNode.getId(), revNode);
-        }
-        for(Route revRoute : revRoutes){
-            revRoute.setNode1(nodeMap.get(revRoute.getNode1().getId()));
-            revRoute.setNode2(nodeMap.get(revRoute.getNode2().getId()));
-        }
-
-    }
-
     public GetChangedRoutesByRevisionResDTO getChangedRoutesByRevision(Long univId, Long versionId) {
         List<Route> revRoutes = getRevRoutes(univId, versionId);
 
@@ -159,16 +146,19 @@ public class AdminService {
             revRouteMap.put(revRoute.getId(), revRoute);
         }
 
-        List<Route> routes = getChangedRoutes(univId, versionId);
+        List<Route> changedRoutes = routeAuditRepository.findUpdatedRouteByUnivIdWithNodes(univId,versionId);
+        List<Node> nodes = nodeRepository.findByUnivId(univId);
+        fetchNodes(changedRoutes,nodes);
+
 
         Map<Long, List<Route>> lostAdjMap = new HashMap<>();
         Map<Long, Node> lostNodeMap = new HashMap<>();
-        List<ChangedRouteDTO> changedRoutes = new ArrayList<>();
+        List<ChangedRouteDTO> changedRoutesDto = new ArrayList<>();
 
-        for(Route route : routes){
+        for(Route route : changedRoutes){
             if(revRouteMap.containsKey(route.getId())){
                 Route revRoute = revRouteMap.get(route.getId());
-                handleRevisionRoute(revRoute, route, changedRoutes);
+                handleRevisionRoute(revRoute, route, changedRoutesDto);
                 continue;
             }
             //해당 시점 이후에 생성된 루트들 (과거 시점엔 보이지 않는 루트)
@@ -179,22 +169,20 @@ public class AdminService {
         List<Node> endNodes = determineEndNodes(lostAdjMap, lostNodeMap);
         LostRoutesDTO lostRouteDTO = LostRoutesDTO.of(mapNodeInfo(lostNodeMap), routeCalculator.getCoreRoutes(lostAdjMap, endNodes));
 
-        return GetChangedRoutesByRevisionResDTO.of(lostRouteDTO, changedRoutes, revInfo.getRev());
+        return GetChangedRoutesByRevisionResDTO.of(lostRouteDTO, changedRoutesDto, revInfo.getRev());
     }
 
-    private List<Route> getChangedRoutes(Long univId, Long versionId) {
-        List<Route> changedRoutes = routeAuditRepository.findUpdatedRouteByUnivIdWithNodes(univId,versionId);
-        List<Node> Nodes = nodeRepository.findByUnivId(univId);
+    private void fetchNodes(List<Route> routes, List<Node> nodes) {
         Map<Long, Node> nodeMap = new HashMap<>();
-        for(Node revNode : Nodes){
+        for(Node revNode : nodes){
             nodeMap.put(revNode.getId(), revNode);
         }
-        for(Route revRoute : changedRoutes){
+        for(Route revRoute : routes){
             revRoute.setNode1(nodeMap.get(revRoute.getNode1().getId()));
             revRoute.setNode2(nodeMap.get(revRoute.getNode2().getId()));
         }
-        return changedRoutes;
     }
+
 
     private List<Route> getRevRoutes(Long univId, Long versionId) {
         revInfoRepository.findById(versionId)

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Route.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Route.java
@@ -109,6 +109,13 @@ public class Route {
 		return true;
 	}
 
+	public void setNode1(Node node1) {
+		this.node1 = node1;
+	}
+	public void setNode2(Node node2) {
+		this.node2 = node2;
+	}
+
 	@Builder
 	private Route(double distance, LineString path, Node node1, Node node2, Long univId,
 				  Set<CautionFactor> cautionFactors, Set<DangerFactor> dangerFactors) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 public interface NodeRepository extends JpaRepository<Node, Long> {
@@ -15,4 +16,6 @@ public interface NodeRepository extends JpaRepository<Node, Long> {
     @Transactional
     @Query("DELETE FROM Node n WHERE n.univId = :univId AND n.createdAt > :versionTimeStamp")
     void deleteAllByCreatedAt(Long univId, LocalDateTime versionTimeStamp);
+
+    List<Node> findByUnivId(Long univId);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
@@ -17,5 +17,5 @@ public interface NodeRepository extends JpaRepository<Node, Long> {
     @Query("DELETE FROM Node n WHERE n.univId = :univId AND n.createdAt > :versionTimeStamp")
     void deleteAllByCreatedAt(Long univId, LocalDateTime versionTimeStamp);
 
-    List<Node> findByUnivId(Long univId);
+    List<Node> findAllByUnivId(Long univId);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### forEntitiesAtRevision 에서 발생하는 쿼리 지연 문제 해결
- forEntitiesAtRevision을 사용했을 때, N+1 문제가 발생하여 forRevisionsOfEntity로 쿼리문을 변경하였습니다.
- forRevisionsOfEntity에서 조회한 route는 node가 fetch되어있지 않기 떄문에 매핑해주는 코드를 추가하였습니다.

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="643" alt="image" src="https://github.com/user-attachments/assets/a6f41a7e-4ce4-45f6-9590-77fdc470e7a1" />
<img width="673" alt="image" src="https://github.com/user-attachments/assets/213f6f93-0b77-46eb-bb73-f02f09eeb957" />
<img width="654" alt="image" src="https://github.com/user-attachments/assets/896ae338-4c86-4ed1-8e8b-7fb72474eeba" />
