### PR TITLE
[UNI-268] feat & fix : 제보 페이지 UI / UX 개선

### DIFF
--- a/uniro_frontend/src/components/map/backButton.tsx
+++ b/uniro_frontend/src/components/map/backButton.tsx
@@ -10,7 +10,7 @@ export default function BackButton({ className = "", onClick }: BackButtonProps)
     const navigate = useNavigate();
 
     const handleBack = () => {
-        navigate(-1);
+        navigate('/map');
     }
 
     return (

--- a/uniro_frontend/src/components/map/floatingButtons.tsx
+++ b/uniro_frontend/src/components/map/floatingButtons.tsx
@@ -42,7 +42,7 @@ export function UndoButton({ onClick, disabled }: UndoButtonProps) {
 		<button
 			disabled={disabled}
 			onClick={onClick}
-			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full  bg-gray-100 border-gray-400 text-gray-700 ${disabled ? "bg-gray-300" : "active:bg-gray-200  active:text-gray-700"}`}
+			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full border-2  ${disabled ? "bg-gray-300 border-gray-400 text-gray-500" : "active:bg-gray-200  active:text-gray-700 bg-primary-500 border-primary-500 text-gray-100"}`}
 		>
 			<UndoIcon />
 		</button>

--- a/uniro_frontend/src/components/map/floatingButtons.tsx
+++ b/uniro_frontend/src/components/map/floatingButtons.tsx
@@ -44,10 +44,23 @@ export function UndoButton({ onClick, disabled }: UndoButtonProps) {
 			onClick={onClick}
 			className={`w-fit h-fit p-[14px] flex items-center justify-center rounded-full border-2  ${disabled ? "bg-gray-300 border-gray-400 text-gray-500" : "active:bg-gray-200  active:text-gray-700 bg-primary-500 border-primary-500 text-gray-100"}`}
 		>
-			<UndoIcon />
+			<UndoIcon width={24} height={24} />
 		</button>
 	);
 }
+
+export function ResetButton({ onClick, disabled }: UndoButtonProps) {
+	return (
+		<button
+			disabled={disabled}
+			onClick={onClick}
+			className={`w-[56px] h-[56px] px-[6px] py-[14px] flex items-center justify-center rounded-full border-2  ${disabled ? "bg-gray-300 border-gray-400 text-gray-500" : "active:bg-gray-200  active:text-gray-700 bg-primary-500 border-primary-500 text-gray-100"}`}
+		>
+			<p className="text-kor-caption">초기화</p>
+		</button>
+	);
+}
+
 
 export function ReportButton({ ...rest }: ButtonHTMLAttributes<HTMLButtonElement>) {
 	return (

--- a/uniro_frontend/src/components/map/tutorialModal.tsx
+++ b/uniro_frontend/src/components/map/tutorialModal.tsx
@@ -1,0 +1,16 @@
+interface TutorialModalProps {
+    onClose: () => void;
+    messages: string[];
+}
+
+export default function TutorialModal({ messages, onClose }: TutorialModalProps) {
+    return (
+        <div onClick={onClose} className='w-screen h-dvh flex items-center justify-center absolute top-0 bg-[rgba(0,0,0,0.5)] z-10 py-3 px-4'>
+            {messages.map((message, idx) =>
+                <p key={`route_tutorial_msg_${idx}`} className="text-gray-100 text-kor-body2 font-medium text-center">
+                    {message}
+                </p>
+            )}
+        </div>
+    )
+}

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -138,17 +138,7 @@ export default function ReportRiskPage() {
 		if (!Polyline || !AdvancedMarker || !map) return;
 
 		for (const coreRoutes of coreRouteList) {
-			const { coreNode1Id, coreNode2Id, routes: subRoutes } = coreRoutes;
-
-			// 가장 끝쪽 Core Node 그리기
-			const endNode = subRoutes[subRoutes.length - 1].node2;
-
-			createAdvancedMarker(
-				AdvancedMarker,
-				map,
-				endNode,
-				createMarkerElement({ type: Markers.WAYPOINT, className: "translate-waypoint" }),
-			);
+			const { routes: subRoutes } = coreRoutes;
 
 			const subNodes = [subRoutes[0].node1, ...subRoutes.map((el) => el.node2)];
 
@@ -189,15 +179,6 @@ export default function ReportRiskPage() {
 					};
 				});
 			});
-
-			const startNode = subRoutes[0].node1;
-
-			createAdvancedMarker(
-				AdvancedMarker,
-				map,
-				startNode,
-				createMarkerElement({ type: Markers.WAYPOINT, className: "translate-waypoint" }),
-			);
 		}
 	};
 

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -9,7 +9,7 @@ import { LatLngToLiteral } from "../utils/coordinates/coordinateTransform";
 import findNearestSubEdge from "../utils/polylines/findNearestEdge";
 import { AdvancedMarker } from "../data/types/marker";
 import Button from "../components/customButton";
-import { CautionToggleButton, DangerToggleButton, UndoButton } from "../components/map/floatingButtons";
+import { CautionToggleButton, DangerToggleButton, ResetButton, UndoButton } from "../components/map/floatingButtons";
 import toggleMarkers from "../utils/markers/toggleMarkers";
 import BackButton from "../components/map/backButton";
 import useUniversityInfo from "../hooks/useUniversityInfo";
@@ -397,6 +397,34 @@ export default function ReportRoutePage() {
 		});
 	};
 
+	/** Reset 함수
+	 * 모든 새로운 점 초기화, 시작점 초기화, waypoint 마커 초기화
+	 */
+	const resetPoints = () => {
+		setTempWayPoints((prevPoints) => {
+			const lastMarker = prevPoints.slice(-1)[0];
+
+			lastMarker.map = null;
+
+			return [...prevPoints.slice(0, -1)];
+		});
+
+		setNewPoints((prev) => {
+			if (prev.element) {
+				prev.element.map = null;
+			}
+			return {
+				element: null,
+				coords: []
+			}
+		})
+		if (originPoint.current) {
+			originPoint.current.element.map = null;
+		}
+		setIsActive(false);
+		originPoint.current = undefined;
+	}
+
 	useEffect(() => {
 		if (newPolyLine.current) {
 			newPolyLine.current.setPath(newPoints.coords);
@@ -481,7 +509,7 @@ export default function ReportRoutePage() {
 	return (
 		<div className="relative w-full h-dvh">
 			{isTutorialShown && <TutorialModal onClose={closeTutorial} messages={['회색 선에서 시작할 점을 선택해주세요']} />}
-			<BackButton className="absolute top-[73px] left-4 z-5" />
+			<BackButton className="absolute top-4 left-4 z-5" />
 			<div ref={mapRef} className="w-full h-full" />
 			{isActive && (
 				<div className="absolute w-full bottom-6 px-4">
@@ -494,6 +522,7 @@ export default function ReportRoutePage() {
 				</div>
 			)}
 			<div className="absolute right-4 bottom-[90px] space-y-2">
+				<ResetButton disabled={newPoints.coords.length === 0} onClick={resetPoints} />
 				<UndoButton disabled={newPoints.coords.length === 0} onClick={undoPoints} />
 				<CautionToggleButton isActive={isCautionAcitve} onClick={toggleCautionButton} />
 				<DangerToggleButton isActive={isDangerAcitve} onClick={toggleDangerButton} />

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -262,16 +262,6 @@ export default function ReportRoutePage() {
 		for (const coreRoutes of coreRouteList) {
 			const { coreNode1Id, coreNode2Id, routes: subRoutes } = coreRoutes;
 
-			// 가장 끝쪽 Core Node 그리기
-			const endNode = subRoutes[subRoutes.length - 1].node2;
-
-			createAdvancedMarker(
-				AdvancedMarker,
-				map,
-				endNode,
-				createMarkerElement({ type: Markers.WAYPOINT, className: "translate-waypoint" }),
-			);
-
 			const subNodes = [subRoutes[0].node1, ...subRoutes.map((el) => el.node2)];
 
 			const routePolyLine = new Polyline({
@@ -340,15 +330,6 @@ export default function ReportRoutePage() {
 					});
 				}
 			});
-
-			const startNode = subRoutes[0].node1;
-
-			createAdvancedMarker(
-				AdvancedMarker,
-				map,
-				startNode,
-				createMarkerElement({ type: Markers.WAYPOINT, className: "translate-waypoint" }),
-			);
 		}
 	};
 

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -27,6 +27,7 @@ import { CautionIssueType, DangerIssueType } from "../data/types/enum";
 import { CautionIssue, DangerIssue } from "../constant/enum/reportEnum";
 import removeMarkers from "../utils/markers/removeMarkers";
 import useMutationError from "../hooks/useMutationError";
+import TutorialModal from "../components/map/tutorialModal";
 
 type SelectedMarkerTypes = {
 	type: Markers.CAUTION | Markers.DANGER;
@@ -61,6 +62,7 @@ export default function ReportRoutePage() {
 		navigate("/map");
 	});
 	const [tempWaypoints, setTempWayPoints] = useState<AdvancedMarker[]>([]);
+	const [isTutorialShown, setIsTutorialShown] = useState<boolean>(true);
 
 	if (!university) return;
 
@@ -139,6 +141,14 @@ export default function ReportRoutePage() {
 			},
 		},
 	);
+
+	const closeTutorial = () => {
+		setIsTutorialShown(false);
+	}
+
+	const openTutorial = () => {
+		setIsTutorialShown(true);
+	}
 
 	const addRiskMarker = () => {
 		if (AdvancedMarker === null || map === null) return;
@@ -360,6 +370,7 @@ export default function ReportRoutePage() {
 					coords: [prevPoints.coords[0]],
 				};
 			});
+			setIsActive(false);
 			return;
 		} else if (newPoints.coords.length === 1) {
 			if (originPoint.current) {
@@ -424,6 +435,9 @@ export default function ReportRoutePage() {
 						}
 					});
 				}
+				else {
+					openTutorial();
+				}
 			});
 		}
 	}, [map]);
@@ -466,11 +480,7 @@ export default function ReportRoutePage() {
 
 	return (
 		<div className="relative w-full h-dvh">
-			<div className="w-full h-[57px] flex items-center justify-center absolute top-0 bg-black opacity-50 z-10 py-3 px-4">
-				<p className="text-gray-100 text-kor-body2 font-medium text-center">
-					선 위 또는 기존 지점을 선택하세요
-				</p>
-			</div>
+			{isTutorialShown && <TutorialModal onClose={closeTutorial} messages={['회색 선에서 시작할 점을 선택해주세요']} />}
 			<BackButton className="absolute top-[73px] left-4 z-5" />
 			<div ref={mapRef} className="w-full h-full" />
 			{isActive && (

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -290,6 +290,8 @@ export default function ReportRoutePage() {
 				const point = LatLngToLiteral(e.latLng);
 				const { edge: nearestEdge, point: nearestPoint } = findNearestSubEdge(edges, point);
 
+				setSelectedMarker(undefined);
+
 				const tempWaypointMarker = createAdvancedMarker(
 					AdvancedMarker,
 					map,
@@ -448,17 +450,15 @@ export default function ReportRoutePage() {
 
 		if (isSelect) {
 			if (marker.type === Markers.DANGER) {
-				const key = marker.factors[0] as DangerIssueType;
 				marker.element.content = createMarkerElement({
 					type: marker.type,
-					title: key && DangerIssue[key],
+					title: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]),
 					hasTopContent: true,
 				});
 			} else if (marker.type === Markers.CAUTION) {
-				const key = marker.factors[0] as CautionIssueType;
 				marker.element.content = createMarkerElement({
 					type: marker.type,
-					title: key && CautionIssue[key],
+					title: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]),
 					hasTopContent: true,
 				});
 			}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### waypoint 제거
- 불편한 길 제보, 새로운 길 제보 페이지의 모든 waypoint를 제거하였습니다.
- waypoint는 새로운 길 제보에서 이미 존재하는 길을 선택한 경우에만 보여지게 됩니다.


### 튜토리얼 모달 생성
- 멘토님들과 사용자들에게 피드백을 받아 제보 화면에서 Tutorial Modal을 생성하였습니다.
- 튜토리얼 모달은 초기 화면 접속시와 잘못된 행동 (지도 클릭 등)을 했을 경우에만 등장합니다.
- 튜토리얼 모달이 생겼을 경우, 한 번 더 터치를 하여 제거할 수 있습니다.

#### 새로운 길 제보 페이지 
| before  | after |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/828df0e2-90a1-447f-ab7d-af512ccad7d0">  | <video src="https://github.com/user-attachments/assets/b6954fc6-6a01-4a2b-8835-2bf39fae8491">|

#### 불편한 길 제보 페이지 
| before  | after |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/940e2c17-6107-4c7b-95df-03dd8fe26643">  | <video src="https://github.com/user-attachments/assets/716f335f-a7f7-4cb7-8822-f5704add4c6d">|


### 새로운 길 제보페이지, 위험 주의 마커 요소 노출 버그 수정
- 새로운 길 제보 페이지에서 위험 주의 마커를 터치하였을 경우 노출되는 요소가 한 글자만 보이던 버그를 수정하였습니다.

| before  | after |
| ------------- | ------------- |
| <img width="390" alt="스크린샷 2025-02-17 오후 5 19 49" src="https://github.com/user-attachments/assets/d80b8365-ff36-4751-bcb3-723554ae59da" />  | <img width="390" alt="스크린샷 2025-02-17 오후 5 19 39" src="https://github.com/user-attachments/assets/984de4b6-fdaa-447f-a667-4737a5501594" />|

### 새로운 길 제보페이지 Undo 버튼 가시성 개선 및 초기화 버튼 생성
- Undo 버튼을 지난번 회의에서 결정된 사항대로 배경을 primary-500으로 설정하였습니다.
- 사용자 피드백 과정에서 제안되었던 초기화 버튼을 추가하였습니다.
```typescript
	/** Reset 함수
	 * 모든 새로운 점 초기화, 시작점 초기화, waypoint 마커 초기화
	 */
	const resetPoints = () => {
		setTempWayPoints((prevPoints) => {
			const lastMarker = prevPoints.slice(-1)[0];

			lastMarker.map = null;

			return [...prevPoints.slice(0, -1)];
		});

		setNewPoints((prev) => {
			if (prev.element) {
				prev.element.map = null;
			}
			return {
				element: null,
				coords: []
			}
		})
		if (originPoint.current) {
			originPoint.current.element.map = null;
		}
		setIsActive(false);
		originPoint.current = undefined;
	}
```
- 초기화 함수는 다음과 같습니다.
- 현재 존재하는 모든 waypoint를 제거합니다.
- 지금까지 선택된 모든 새로운 점들을 제거합니다. 또한 도착 마커를 제거합니다. (현재는 제거하지만 추후 재사용 로직을 고민해보겠습니다.)
- 시작점 마커를 제거합니다. (이또한 재사용을 고민해보겠습니다.)
- 초기화 버튼의 스타일은 간단하게 Undo 버튼과 동일하게 설정하였습니다. 원하시는 스타일이 있다면 변경해주시면 감사하겠습니다.


| before  | after |
| ------------- | ------------- |
| <img width="114" alt="스크린샷 2025-02-17 오후 5 22 06" src="https://github.com/user-attachments/assets/d057963f-1bb4-4e4e-b2cf-454c1a45e1e9" /> | <img width="114" alt="스크린샷 2025-02-17 오후 5 21 57" src="https://github.com/user-attachments/assets/fd03ec72-e2c3-4d1e-9d42-e8cb7eae6a5e" />|



## ✅ 연관 이슈
- UNI-270, UNI-271