### PR TITLE
[UNI-277] hotfix : QueryClient Stale default 값 설정

### DIFF
--- a/uniro_admin_frontend/src/AppRouter.tsx
+++ b/uniro_admin_frontend/src/AppRouter.tsx
@@ -6,7 +6,13 @@ import SimulationPage from "./page/simulationPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 300000
+    }
+  }
+});
 
 function AppRouter() {
   return (

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -18,7 +18,13 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ErrorBoundary from "./components/error/ErrorBoundary";
 import Errortest from "./pages/errorTest";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			staleTime: 300000
+		}
+	}
+});
 
 function App() {
 	const { location, fallback } = useDynamicSuspense();


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
- react-query client stale Time 5분 설정
- 기존에 클라이언트에서 작은 데이터 통신과정에서 캐시 stale 타임을 설정하지 않았는데, revision 비교 API가 서버에 많은 부담이 되어 캐시를 위해 stale 타임을 추가합니다.

## 💡 To Reviewer

## 🧪 테스트 결과


## ✅ 반영 브랜치
