### PR TITLE
[UNI-278] hotfix : 바텀 시트에서 초기화 버튼을 클릭했을 때, map의 bound가 이동하는 문제

### DIFF
--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
 import useMap from "../hooks/useMap";
 import {
 	CautionRoute,
@@ -340,21 +340,12 @@ const NavigationMap = ({
 		dyamicMarkersRef.current = [];
 	};
 
-	const saveAllBounds = () => {
-		if (!map || !compositeRoutes) return;
-		const bounds = new google.maps.LatLngBounds();
-		Object.values(compositeRoutes).forEach((composite) => {
-			bounds.extend(composite!.bounds.getNorthEast());
-			bounds.extend(composite!.bounds.getSouthWest());
-		});
-		boundsRef.current = bounds;
-	};
-
 	useEffect(() => {
 		if (currentRouteIdx !== -1) return;
 		if (!map || !boundsRef.current) return;
-		saveAllBounds();
-		map.fitBounds(boundsRef.current, {
+
+		const activeBounds = compositeRoutes[buttonState]?.bounds;
+		map.fitBounds(activeBounds!, {
 			top: topPadding,
 			right: 50,
 			bottom: bottomPadding,


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
1. 바텀 시트에서 초기화 버튼을 클릭했을 때, map의 bound가 이동하는 문제

기존 함수는 아래 함수를 활용해 초기화했지만, bound가 범위를 벗어나는 문제가 발생하였습니다.
```typescript
	const saveAllBounds = () => {
		if (!map || !compositeRoutes) return;
		const bounds = new google.maps.LatLngBounds();
		Object.values(compositeRoutes).forEach((composite) => {
			bounds.extend(composite!.bounds.getNorthEast());
			bounds.extend(composite!.bounds.getSouthWest());
		});
		boundsRef.current = bounds;
	};
```

기존 캐시해놓은 bound를 활용할 겸, Route들을 저장할 때, 저장한 bound로 초기화 하도록 하였습니다.(초기에 이 bound로 정상 동작해 적용해본 결과, 잘 동작하였습니다.)
```typescript
useEffect(() => {
		if (currentRouteIdx !== -1) return;
		if (!map || !boundsRef.current) return;

		const activeBounds = compositeRoutes[buttonState]?.bounds;
		map.fitBounds(activeBounds!, {
```

## 💡 To Reviewer
감사합니다.

## 🧪 테스트 결과



## ✅ 반영 브랜치

fe