### PR TITLE
[UNI-267] refactor : createMarkerElement 재 함수화 및 적용

### DIFF
--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -197,7 +197,7 @@ const NavigationMap = ({
 		const originMarkerElement = createMarkerElement({
 			type: Markers.ORIGIN,
 			title: origin?.buildingName,
-			className: "translate-pinmarker",
+			className: "translate-namedmarker",
 			hasAnimation: true,
 		});
 		const originMarker = createAdvancedMarker(AdvancedMarker, map, origin, originMarkerElement);
@@ -206,7 +206,7 @@ const NavigationMap = ({
 		const destinationMarkerElement = createMarkerElement({
 			type: Markers.DESTINATION,
 			title: destination?.buildingName,
-			className: "translate-pinmarker",
+			className: "translate-namedmarker",
 			hasAnimation: true,
 		});
 		const destinationMarker = createAdvancedMarker(AdvancedMarker, map, destination, destinationMarkerElement);

--- a/uniro_frontend/src/data/types/marker.d.ts
+++ b/uniro_frontend/src/data/types/marker.d.ts
@@ -1,4 +1,5 @@
 import { Markers } from "../../constant/enum/markerEnum";
+import { MarkerTypes } from "./enum";
 
 export type AdvancedMarker = google.maps.marker.AdvancedMarkerElement;
 

--- a/uniro_frontend/src/index.css
+++ b/uniro_frontend/src/index.css
@@ -127,12 +127,12 @@
 	--text-eng-caption--line-height: 160%;
 }
 
-@utility translate-marker {
+@utility translate-namedmarker {
 	transform: translateY(40px);
 }
 
-@utility translate-pinmarker {
-	transform: translateY(40px);
+@utility translate-shadowmarker {
+	transform: translateY(2px);
 }
 
 @utility translate-waypoint {

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -55,8 +55,8 @@ export default function MapPage() {
 		dangerMarkerElement,
 		buildingMarkerElement,
 		selectedBuildingMarkerElement,
-		originMarkerElement,
-		destinationMarkerElement,
+		originMarkerElementWithName,
+		destinationMarkerElementWithName,
 	} = createMarkerElement();
 
 	const [selectedMarker, setSelectedMarker] = useState<SelectedMarkerTypes>();
@@ -435,7 +435,7 @@ export default function MapPage() {
 
 		originMarker.map = map;
 
-		originMarker.content = originMarkerElement({ name: origin.buildingName });
+		originMarker.content = originMarkerElementWithName({ name: origin.buildingName });
 
 		if (origin !== undefined && destination === undefined) {
 			moveToBound(origin);
@@ -464,7 +464,7 @@ export default function MapPage() {
 
 		destinationMarker.map = map;
 
-		destinationMarker.content = destinationMarkerElement({
+		destinationMarker.content = destinationMarkerElementWithName({
 			name: destination.buildingName,
 		});
 

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -1,7 +1,6 @@
 import { MouseEvent, useEffect, useState } from "react";
 import useMap from "../hooks/useMap";
 import createAdvancedMarker from "../utils/markers/createAdvanedMarker";
-import createMarkerElement from "../components/map/mapMarkers";
 import { CoreRoute, CoreRoutesList, RouteId } from "../data/types/route";
 import { Markers } from "../constant/enum/markerEnum";
 import { ClickEvent } from "../data/types/event";
@@ -26,6 +25,7 @@ import useReportRisk from "../hooks/useReportRisk";
 import { CautionIssueType, DangerIssueType } from "../data/types/enum";
 import { CautionIssue, DangerIssue } from "../constant/enum/reportEnum";
 import TutorialModal from "../components/map/tutorialModal";
+import createMarkerElement from "../utils/markers/createMarkerElement";
 
 interface reportMarkerTypes extends MarkerTypesWithElement {
 	route: RouteId;
@@ -41,6 +41,7 @@ export default function ReportRiskPage() {
 	const { setReportRouteId } = useReportRisk();
 	const { university } = useUniversityInfo();
 	const [isTutorialShown, setIsTutorialShown] = useState<boolean>(true);
+	const { dangerMarkerElement, cautionMarkerElement, reportMarkerElement } = createMarkerElement();
 
 	useRedirectUndefined<University | undefined>([university]);
 
@@ -80,9 +81,19 @@ export default function ReportRiskPage() {
 		if (prevMarker.type === Markers.REPORT) {
 			prevMarker.element.map = null;
 			return;
-		} else {
-			prevMarker.element.content = createMarkerElement({ type: prevMarker.type });
 		}
+
+		if (prevMarker.type === Markers.CAUTION) {
+			prevMarker.element.content = cautionMarkerElement({});
+			return;
+		}
+
+		if (prevMarker.type === Markers.DANGER) {
+			prevMarker.element.content = dangerMarkerElement({});
+			return;
+		}
+
+		return;
 	};
 
 	const addRiskMarker = () => {
@@ -100,7 +111,7 @@ export default function ReportRiskPage() {
 					lat: (node1.lat + node2.lat) / 2,
 					lng: (node1.lng + node2.lng) / 2,
 				}),
-				createMarkerElement({ type }),
+				dangerMarkerElement({}),
 				() => {
 					setReportMarker((prevMarker) => {
 						if (prevMarker) resetMarker(prevMarker);
@@ -127,7 +138,7 @@ export default function ReportRiskPage() {
 					lat: (node1.lat + node2.lat) / 2,
 					lng: (node1.lng + node2.lng) / 2,
 				}),
-				createMarkerElement({ type }),
+				cautionMarkerElement({}),
 				() => {
 					setReportMarker((prevMarker) => {
 						if (prevMarker) resetMarker(prevMarker);
@@ -172,10 +183,7 @@ export default function ReportRiskPage() {
 					AdvancedMarker,
 					map,
 					centerCoordinate(nearestEdge.node1, nearestEdge.node2),
-					createMarkerElement({
-						type: Markers.REPORT,
-						hasAnimation: true,
-					}),
+					reportMarkerElement({})
 				);
 
 				setReportMarker((prevMarker) => {
@@ -215,26 +223,26 @@ export default function ReportRiskPage() {
 	const changeMarkerStyle = (marker: reportMarkerTypes | undefined, isSelect: boolean) => {
 		if (!map || !marker) return;
 
-		if (isSelect) {
-			if (marker.type === Markers.DANGER) {
-				marker.element.content = createMarkerElement({
-					type: marker.type,
-					title: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]),
-					hasTopContent: true,
-				});
-			} else if (marker.type === Markers.CAUTION) {
-				marker.element.content = createMarkerElement({
-					type: marker.type,
-					title: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]),
-					hasTopContent: true,
-				});
-			}
-			return;
+		switch (marker.type) {
+			case Markers.DANGER:
+				if (isSelect) {
+					marker.element.content = dangerMarkerElement({ factors: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]) });
+					return;
+				}
+				else {
+					marker.element.content = dangerMarkerElement({});
+					return;
+				}
+			case Markers.CAUTION:
+				if (isSelect) {
+					marker.element.content = cautionMarkerElement({ factors: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]) });
+					return;
+				}
+				else {
+					marker.element.content = cautionMarkerElement({});
+					return;
+				}
 		}
-
-		marker.element.content = createMarkerElement({
-			type: marker.type,
-		});
 	};
 
 	/** 선택된 마커가 있는 경우 */

--- a/uniro_frontend/src/utils/markers/createMarkerElement.ts
+++ b/uniro_frontend/src/utils/markers/createMarkerElement.ts
@@ -1,0 +1,260 @@
+import { Markers } from "../../constant/enum/markerEnum";
+import { MarkerTypes } from "../../data/types/enum";
+import { animate } from "framer-motion";
+
+const markerImages = import.meta.glob("/src/assets/markers/*.svg", { eager: true });
+
+interface MarkerProps {
+	className?: string;
+	hasAnimation?: boolean;
+}
+
+interface NameMarkerProps extends MarkerProps {
+	name?: string;
+}
+
+interface RiskMarkerProps extends MarkerProps {
+	factors?: string[];
+}
+
+export default function createMarkerElement() {
+	const getImage = (type: MarkerTypes): string => {
+		return (markerImages[`/src/assets/markers/${type}.svg`] as { default: string })?.default;
+	};
+
+	const createTextElement = (type: MarkerTypes, title: string): HTMLElement => {
+		const markerTitle = document.createElement("p");
+		markerTitle.innerText = title;
+
+		switch (type) {
+			case Markers.CAUTION:
+				markerTitle.className =
+					"h-[38px] py-2 px-4 mb-2 text-kor-body3 font-semibold text-gray-100 bg-system-orange text-center rounded-200";
+				return markerTitle;
+			case Markers.DANGER:
+				markerTitle.className =
+					"h-[38px] py-2 px-4 mb-2 text-kor-body3 font-semibold text-gray-100 bg-system-red text-center rounded-200";
+				return markerTitle;
+			case Markers.BUILDING:
+				markerTitle.className =
+					"h-[22px] py-1 px-3 text-kor-caption font-medium text-gray-100 bg-gray-900 text-center rounded-200";
+				return markerTitle;
+			case Markers.SELECTED_BUILDING:
+				markerTitle.className =
+					"h-[22px] py-1 px-3 text-kor-caption font-medium text-gray-100 bg-gray-900 text-center rounded-200";
+				return markerTitle;
+			case Markers.ORIGIN:
+				markerTitle.className =
+					"h-[22px] py-1 px-3 text-kor-caption font-medium text-gray-100 bg-primary-500 text-center rounded-200";
+				return markerTitle;
+			case Markers.DESTINATION:
+				markerTitle.className =
+					"h-[22px] py-1 px-3 text-kor-caption font-medium text-gray-100 bg-primary-500 text-center rounded-200";
+				return markerTitle;
+			default:
+				return markerTitle;
+		}
+	};
+
+	const createAnimatedTextElement = (type: MarkerTypes, titles: string[]): HTMLElement => {
+		const titleContainer = document.createElement("div");
+
+		const elements = [];
+
+		const _title = [...titles, titles[0]];
+
+		for (const title of _title) {
+			const factorTitle = document.createElement("p");
+			factorTitle.innerText = title;
+			factorTitle.className = "block w-[128px] h-[22px] mb-4";
+
+			titleContainer.appendChild(factorTitle);
+			elements.push(factorTitle);
+		}
+
+		switch (type) {
+			case Markers.CAUTION:
+				titleContainer.className =
+					"overflow-hidden w-[160px] h-[38px] py-2 px-4 mb-2 text-kor-body3 font-semibold text-gray-100 bg-system-orange text-center rounded-200";
+				break;
+			case Markers.DANGER:
+				titleContainer.className =
+					"overflow-hidden w-[160px] h-[38px] py-2 px-4 mb-2 text-kor-body3 font-semibold text-gray-100 bg-system-red text-center rounded-200";
+				break;
+			default:
+				break;
+		}
+
+		const len = _title.length;
+
+		if (len >= 3) {
+			for (let i = 1; i < len; i++) {
+				elements.forEach((el, index) => {
+					setTimeout(() => {
+						animate(
+							el,
+							{
+								y: [-38 * (i - 1), -38 * i],
+							},
+							{
+								duration: 0.5,
+							},
+						);
+
+						if (i === len - 1) {
+							setTimeout(() => {
+								animate(
+									el,
+									{
+										y: [-38 * (len - 1), 0],
+									},
+									{ duration: 0 },
+								);
+							}, 1000);
+						}
+					}, 1000 * i);
+				});
+			}
+		}
+
+		return titleContainer;
+	};
+
+	const createImageElement = (type: MarkerTypes): HTMLElement => {
+		const markerImage = document.createElement("img");
+		markerImage.src = getImage(type);
+		return markerImage;
+	};
+
+	const createContainerElement = (className?: string): HTMLElement => {
+		const container = document.createElement("div");
+		container.className = `flex flex-col items-center space-y-[8px] ${className}`;
+
+		return container;
+	};
+
+	const attachAnimation = (container: HTMLElement, hasAnimation: boolean): HTMLElement => {
+		if (hasAnimation) {
+			const outerContainer = document.createElement("div");
+			outerContainer.className = "marker-appear";
+			outerContainer.appendChild(container);
+			return outerContainer;
+		}
+
+		return container;
+	};
+
+	const buildingMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(className);
+
+		const imageElement = createImageElement(Markers.BUILDING);
+
+		containerElement.appendChild(imageElement);
+
+		if (name) {
+			const nameElement = createTextElement(Markers.BUILDING, name);
+
+			containerElement.appendChild(nameElement);
+		}
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const selectedBuildingMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(`${className} translate-namedmarker`);
+
+		const imageElement = createImageElement(Markers.SELECTED_BUILDING);
+
+		containerElement.appendChild(imageElement);
+
+		if (name) {
+			const nameElement = createTextElement(Markers.BUILDING, name);
+
+			containerElement.appendChild(nameElement);
+		}
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const dangerMarkerElement = ({ className, factors, hasAnimation = false }: RiskMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(`translate-shadowmarker ${className}`);
+
+		const imageElement = createImageElement(Markers.DANGER);
+
+		if (factors) {
+			const factorElement = createAnimatedTextElement(Markers.DANGER, factors);
+			containerElement.appendChild(factorElement);
+		}
+
+		containerElement.appendChild(imageElement);
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const cautionMarkerElement = ({ className, factors, hasAnimation = false }: RiskMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(`translate-shadowmarker ${className}`);
+
+		const imageElement = createImageElement(Markers.CAUTION);
+
+		if (factors) {
+			const factorElement = createAnimatedTextElement(Markers.CAUTION, factors);
+			containerElement.appendChild(factorElement);
+		}
+
+		containerElement.appendChild(imageElement);
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const originMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(`${className} translate-namedmarker`);
+
+		const imageElement = createImageElement(Markers.ORIGIN);
+
+		containerElement.appendChild(imageElement);
+
+		if (name) {
+			const nameElement = createTextElement(Markers.ORIGIN, name);
+
+			containerElement.appendChild(nameElement);
+		}
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const destinationMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(`${className} translate-namedmarker`);
+
+		const imageElement = createImageElement(Markers.DESTINATION);
+
+		containerElement.appendChild(imageElement);
+
+		if (name) {
+			const nameElement = createTextElement(Markers.DESTINATION, name);
+
+			containerElement.appendChild(nameElement);
+		}
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const reportMarkerElement = ({ className, hasAnimation = true }: MarkerProps) => {
+		const containerElement = createContainerElement(`translate-shadowmarker ${className}`);
+
+		const imageElement = createImageElement(Markers.REPORT);
+
+		containerElement.appendChild(imageElement);
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	return {
+		dangerMarkerElement,
+		cautionMarkerElement,
+		buildingMarkerElement,
+		selectedBuildingMarkerElement,
+		originMarkerElement,
+		destinationMarkerElement,
+		reportMarkerElement,
+	};
+}

--- a/uniro_frontend/src/utils/markers/createMarkerElement.ts
+++ b/uniro_frontend/src/utils/markers/createMarkerElement.ts
@@ -1,4 +1,5 @@
 import { Markers } from "../../constant/enum/markerEnum";
+import { CautionIssue, DangerIssue } from "../../constant/enum/reportEnum";
 import { MarkerTypes } from "../../data/types/enum";
 import { animate } from "framer-motion";
 
@@ -14,7 +15,7 @@ interface NameMarkerProps extends MarkerProps {
 }
 
 interface RiskMarkerProps extends MarkerProps {
-	factors?: string[];
+	factors?: CautionIssue[] | DangerIssue[];
 }
 
 export default function createMarkerElement() {
@@ -206,7 +207,7 @@ export default function createMarkerElement() {
 		return attachAnimation(containerElement, hasAnimation);
 	};
 
-	const originMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+	const originMarkerElementWithName = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
 		const containerElement = createContainerElement(`${className} translate-namedmarker`);
 
 		const imageElement = createImageElement(Markers.ORIGIN);
@@ -222,8 +223,44 @@ export default function createMarkerElement() {
 		return attachAnimation(containerElement, hasAnimation);
 	};
 
-	const destinationMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+	const destinationMarkerElementWithName = ({
+		className,
+		name,
+		hasAnimation = false,
+	}: NameMarkerProps): HTMLElement => {
 		const containerElement = createContainerElement(`${className} translate-namedmarker`);
+
+		const imageElement = createImageElement(Markers.DESTINATION);
+
+		containerElement.appendChild(imageElement);
+
+		if (name) {
+			const nameElement = createTextElement(Markers.DESTINATION, name);
+
+			containerElement.appendChild(nameElement);
+		}
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const originMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(`${className} translate-shadowmarker`);
+
+		const imageElement = createImageElement(Markers.ORIGIN);
+
+		containerElement.appendChild(imageElement);
+
+		if (name) {
+			const nameElement = createTextElement(Markers.ORIGIN, name);
+
+			containerElement.appendChild(nameElement);
+		}
+
+		return attachAnimation(containerElement, hasAnimation);
+	};
+
+	const destinationMarkerElement = ({ className, name, hasAnimation = false }: NameMarkerProps): HTMLElement => {
+		const containerElement = createContainerElement(`${className} translate-shadowmarker`);
 
 		const imageElement = createImageElement(Markers.DESTINATION);
 
@@ -248,13 +285,26 @@ export default function createMarkerElement() {
 		return attachAnimation(containerElement, hasAnimation);
 	};
 
+	const waypointMarkerElement = ({ className }: MarkerProps) => {
+		const containerElement = createContainerElement(`translate-waypoint ${className}`);
+
+		const imageElement = createImageElement(Markers.WAYPOINT);
+
+		containerElement.appendChild(imageElement);
+
+		return containerElement;
+	};
+
 	return {
 		dangerMarkerElement,
 		cautionMarkerElement,
 		buildingMarkerElement,
 		selectedBuildingMarkerElement,
+		originMarkerElementWithName,
+		destinationMarkerElementWithName,
 		originMarkerElement,
 		destinationMarkerElement,
 		reportMarkerElement,
+		waypointMarkerElement,
 	};
 }

--- a/uniro_frontend/src/utils/markers/createRiskMarker.ts
+++ b/uniro_frontend/src/utils/markers/createRiskMarker.ts
@@ -16,7 +16,7 @@ export const createRiskMarkers = (
 	riskData.forEach((route) => {
 		const markerElement = createMarkerElement({
 			type: Markers.DANGER,
-			className: "translate-pinmarker",
+			className: "translate-shadowmarker",
 			hasAnimation: true,
 		});
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### createMarkerElement 리팩토링
- #18 에서 생성한 `createMarkerElement` 함수를 리팩토링 하였습니다.

```typescript
        createMarkerElement({
	        type: Markers.ORIGIN,
	        title: marker.property.buildingName,
	        className: "translate-pinmarker",
        });
```
- 기존 하나의 함수, `createMarkerElement`에 마커의 타입, 이름 등 정보를 입력하여 다양한 종류의 마커를 생성하던 과정을 각 종류별 마커를 생성하는 독립 함수로 분리하였습니다

```typescript
	const {
		cautionMarkerElement,
		dangerMarkerElement,
		buildingMarkerElement,
		selectedBuildingMarkerElement,
		originMarkerElement,
		destinationMarkerElement,
	} = createMarkerElement();

        originMarker.content = originMarkerElement({ name: origin.buildingName });
```
- 다음과 같이 분리하여 더 명확한 기능을 수행하는 함수로 분리하였습니다.
- 내부 함수들은 Closure로 안에서만 접근이 가능합니다.

### 마커 className 재정의
<img width="318" alt="image" src="https://github.com/user-attachments/assets/317b57e5-8e75-47dc-90c6-860c3a216ee9" />
- 다음과 같이 그림자가 있는 마커는 `translate-shadowmarker`

<img width="351" alt="image" src="https://github.com/user-attachments/assets/9b9b09b4-6ede-4ee0-a273-f8e2cc00da30" />
- 다음과 같이 아래 이름이 있는 마커는 `translate-namedmarker` 로 변경하였습니다.


## 💡 To Reviewer
- 현재와 동일 결과 확인하였습니다.
- PR이 승인되면 추후 Navigation등 현재 사용중인 로직을 모두 이관할 수 있습니다.
