### PR TITLE
[UNI-279] fix : IOS Safari Browser 레이아웃 깨짐 해결

### DIFF
--- a/uniro_frontend/src/components/customInput.tsx
+++ b/uniro_frontend/src/components/customInput.tsx
@@ -43,13 +43,13 @@ export default function Input({ onChangeDebounce, placeholder, handleVoiceInput,
 
 	return (
 		<div
-			className={`h-[60px] w-full max-w-[450px] px-[14px] flex flex-row items-center justify-between border ${isFocus ? "border-gray-700" : "border-gray-400"} rounded-200`}
+			className={`h-[60px] flex-1 min-w-0 flex flex-row max-w-[450px] px-[14px] items-center justify-between border ${isFocus ? "border-gray-700" : "border-gray-400"} rounded-200`}
 		>
 			{isFocus ? <ChevronLeft stroke="#161616" /> : <Search stroke="#161616" />}
 			<input
 				placeholder={placeholder}
 				value={value}
-				className="h-full flex-1 mx-[14px] leading-[160%] font-medium text-gray-900 text-kor-body2 placeholder:text-gray-700 placeholder:font-medium caret-primary-500"
+				className="h-full flex-1 min-w-0 mx-[14px] leading-[160%] font-medium text-gray-900 text-kor-body2 placeholder:text-gray-700 placeholder:font-medium caret-primary-500 appearance-none"
 				{...rest}
 				onChange={handleChange}
 				onFocus={onFoucs}

--- a/uniro_frontend/src/pages/buildingSearch.tsx
+++ b/uniro_frontend/src/pages/buildingSearch.tsx
@@ -17,24 +17,23 @@ export default function BuildingSearchPage() {
 
 	if (!university) return;
 
-	const [input, setInput] = useState<string>('');
+	const [input, setInput] = useState<string>("");
 
 	const { data: buildings } = useQuery({
 		queryKey: [university.id, "buildings", input],
-		queryFn: () =>
-			getSearchBuildings(university.id, { name: input })
-	},)
+		queryFn: () => getSearchBuildings(university.id, { name: input }),
+	});
 
 	const handleBack = () => {
 		navigate(-1);
-	}
+	};
 
 	useRedirectUndefined<University | undefined>([university]);
 
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center">
-			<div className="flex flex-row px-[14px] py-4 border-b-[1px] border-gray-400">
-				<Input onChangeDebounce={(e) => setInput(e)} handleVoiceInput={() => { }} placeholder="" />
+			<div className="flex flex-row px-[14px] py-4 border-b-[1px] border-gray-400 ">
+				<Input onChangeDebounce={(e) => setInput(e)} handleVoiceInput={() => {}} placeholder="" />
 				<button onClick={handleBack} className="cursor-pointer p-1 rounded-[8px] active:bg-gray-200">
 					<CloseIcon />
 				</button>
@@ -50,7 +49,6 @@ export default function BuildingSearchPage() {
 					))}
 				</ul>
 			</div>
-
 		</div>
 	);
-}	
+}


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### Safari flexbox 레이아웃 호환성 개선

Input 컴포넌트와 검색 페이지의 flexbox 레이아웃 호환성을 개선했습니다.

#### Input 컴포넌트
```typescript
- className={h-[60px] w-full max-w-[450px] px-[14px] flex flex-row ...}
+ className={h-[60px] flex-1 min-w-0 flex flex-row max-w-[450px] px-[14px] ...}
```
#### Input 필드
```typescript
- className="h-full flex-1 mx-[14px] ..."
+ className="h-full flex-1 min-w-0 mx-[14px] ... appearance-none"
```

Safari의 WebKit 엔진은 flexbox 명세를 엄격하게 해석하여, min-width: auto(기본값)일 때 컨텐츠 크기 이하로 축소되지 않는 문제가 있습니다. 이로 인해 flex 레이아웃이 의도한 대로 동작하지 않았습니다.

다음은 각 엔진을 비교한 표인데, Webkit이 상대적으로 flex에 대해 엄격하다는 것을 알 수 있고, min-content를 명시해주지 않는 이상, w-full을 그대로(부모에 꽉차게) 사용하려고 한다는 것을 알 수 있습니다. 그래서 음성인식 버튼이나, 닫는 버튼이 옆으로 밀려난 것을 볼 수 있습니다.

WebKit | 컨텐츠 기반 강제 적용 | min-content 이상
Blink | 컨테이너 공간 우선 | 0까지 허용
Gecko | 유연한 가변 처리 | 상황에 따라 조정

#### appearance-none

iOS Safari나 macOS Safari 브라우저의 입력 요소는 각 브라우저의 CSS처럼 기본 스타일 가져, 레이아웃이 깨질 상황을 대비해 제거해주었습니다.

## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과

### AS IS

#### iOS
https://github.com/user-attachments/assets/4216274d-e3e1-4596-92d9-6d9748c664b1
#### iPad OS
https://github.com/user-attachments/assets/75f607ea-067c-46bc-8716-6b69d6c50de0
### Galaxy
![IMG_9630](https://github.com/user-attachments/assets/b90fc610-ce41-44b5-8951-b837c62ee0e7)
![IMG_9631](https://github.com/user-attachments/assets/6eb2f8c9-2b40-499b-a732-f922d03c03f8)

### TO BE

https://github.com/user-attachments/assets/bfda4974-8980-4bdc-9795-cc64ab83f56b

## ✅ 반영 브랜치
fe