### PR TITLE
[UNI-290] 각 페이지 별 방어 코드 및 버그 수정

### DIFF
--- a/uniro_frontend/src/components/loading/loading.tsx
+++ b/uniro_frontend/src/components/loading/loading.tsx
@@ -20,11 +20,13 @@ const Loading = ({ isLoading, loadingContent }: Props) => {
 					className="fixed inset-0 flex flex-col items-center justify-center w-full max-w-[450px] mx-auto bg-white 
 					bg-[url(/public/loading/background.svg)] bg-no-repeat bg-center bg-contain z-50"
 				>
-					<div className="flex flex-row items-center justify-center bg-white rounded-3xl space-x-1">
-						<img src={university?.imageUrl} className="h-4 w-4 ml-2 my-2" />
-						<p className="text-kor-body2 mr-2 my-1">{university?.name}</p>
-					</div>
-					<p className="text-kor-body2 mt-3">{loadingContent}</p>
+					{university && (
+						<div className="flex flex-row items-center justify-center bg-white rounded-3xl space-x-1">
+							<img src={university?.imageUrl} className="h-4 w-4 ml-2 my-2" />
+							<p className="text-kor-body2 mr-2 my-1">{university?.name}</p>
+						</div>
+					)}
+					<p className="text-kor-body2 mt-3">{university ? loadingContent : "로딩중입니다."}</p>
 					<img src="/loading/spinner.gif" className="w-12 h-12 mt-8" />
 				</motion.div>
 			)}

--- a/uniro_frontend/src/hooks/useUniversityInfo.tsx
+++ b/uniro_frontend/src/hooks/useUniversityInfo.tsx
@@ -4,14 +4,14 @@ import { University } from "../data/types/university";
 
 interface UniversityInfoStore {
 	university: University | undefined;
-	setUniversity: (university: University) => void;
+	setUniversity: (university: University | undefined) => void;
 	resetUniversity: () => void;
 }
 const useUniversityInfo = create(
 	persist<UniversityInfoStore>(
 		(set) => ({
 			university: undefined,
-			setUniversity: (newUniversity: University) => {
+			setUniversity: (newUniversity: University | undefined) => {
 				set(() => ({ university: newUniversity }));
 			},
 			resetUniversity: () => {

--- a/uniro_frontend/src/pages/landing.tsx
+++ b/uniro_frontend/src/pages/landing.tsx
@@ -2,8 +2,24 @@ import LandingButton from "../components/landingButton";
 import Logo from "../assets/logo.svg?react";
 import UNIRO from "../assets/UNIRO.svg?react";
 import { Link } from "react-router";
+import useRoutePoint from "../hooks/useRoutePoint";
+import useUniversityInfo from "../hooks/useUniversityInfo";
+import { useEffect } from "react";
 
 export default function LandingPage() {
+	const { setUniversity } = useUniversityInfo();
+	const { setDestination, setOrigin } = useRoutePoint();
+
+	const initData = () => {
+		setDestination(undefined);
+		setOrigin(undefined);
+		setUniversity(undefined);
+	};
+
+	useEffect(() => {
+		initData();
+	}, []);
+
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center bg-[url(/public/background.png)] bg-cover">
 			<div>

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -166,7 +166,7 @@ export default function MapPage() {
 		const centerMarker = createUniversityMarker(
 			AdvancedMarker,
 			map,
-			HanyangUniversity,
+			university.centerPoint,
 			university ? university.name : "",
 		);
 		setUniversityMarker(centerMarker);

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -279,11 +279,11 @@ export default function MapPage() {
 	};
 
 	const toggleCautionButton = () => {
-		if (!map) return;
+		if (!map || !university) return;
 		if (zoom <= 16) {
 			map.setOptions({
 				zoom: 17,
-				center: HanyangUniversity,
+				center: university.centerPoint,
 			});
 		}
 		setIsCautionActive((isActive) => {
@@ -296,11 +296,11 @@ export default function MapPage() {
 		});
 	};
 	const toggleDangerButton = () => {
-		if (!map) return;
+		if (!map || !university) return;
 		if (zoom <= 16) {
 			map.setOptions({
 				zoom: 17,
-				center: HanyangUniversity,
+				center: university.centerPoint,
 			});
 		}
 		setIsDangerActive((isActive) => {
@@ -344,19 +344,21 @@ export default function MapPage() {
 		switch (marker.type) {
 			case Markers.CAUTION:
 				if (isSelect) {
-					marker.element.content = cautionMarkerElement({ factors: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]) });
+					marker.element.content = cautionMarkerElement({
+						factors: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]),
+					});
 					return;
-				}
-				else {
+				} else {
 					marker.element.content = cautionMarkerElement({});
 					return;
 				}
 			case Markers.DANGER:
 				if (isSelect) {
-					marker.element.content = dangerMarkerElement({ factors: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]) });
+					marker.element.content = dangerMarkerElement({
+						factors: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]),
+					});
 					return;
-				}
-				else {
+				} else {
 					marker.element.content = dangerMarkerElement({});
 					return;
 				}
@@ -364,13 +366,14 @@ export default function MapPage() {
 				if (!marker.property) return;
 
 				if (isSelect) {
-					marker.element.content = selectedBuildingMarkerElement({ name: marker.property.buildingName })
+					marker.element.content = selectedBuildingMarkerElement({ name: marker.property.buildingName });
 					return;
-				}
-				else {
-					marker.element.content = buildingMarkerElement({ name: marker.property.buildingName, className: "translate-namedmarker" })
+				} else {
+					marker.element.content = buildingMarkerElement({
+						name: marker.property.buildingName,
+						className: "translate-namedmarker",
+					});
 					return;
-
 				}
 		}
 	};
@@ -532,8 +535,7 @@ export default function MapPage() {
 						el.nodeId !== selectedMarker?.id,
 				)
 				.forEach(
-					(marker) =>
-						marker.element.content = buildingMarkerElement({ className: 'translate-building' })
+					(marker) => (marker.element.content = buildingMarkerElement({ className: "translate-building" })),
 				);
 			return;
 		}
@@ -547,7 +549,10 @@ export default function MapPage() {
 			)
 			.forEach(
 				(marker) =>
-					marker.element.content = buildingMarkerElement({ name: marker.name, className: 'translate-namedmarker' })
+					(marker.element.content = buildingMarkerElement({
+						name: marker.name,
+						className: "translate-namedmarker",
+					})),
 			);
 	};
 

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -39,12 +39,12 @@ const NavigationResultPage = () => {
 	const { university } = useUniversityInfo();
 	const { origin, destination } = useRoutePoint();
 
+	useRedirectUndefined<University | Building | undefined>([university, origin, destination]);
+
 	const [buttonState, setButtonState] = useState<NavigationButtonRouteType>("PEDES & SAFE");
 	const [currentRouteIdx, setCurrentRouteIdx] = useState(-1);
 	// Caution 마커를 위한 routeIdx state
 	const [cautionRouteIdx, setCautionRouteIdx] = useState(-1);
-
-	useRedirectUndefined<University | Building | undefined>([university, origin, destination]);
 
 	useScrollControl();
 
@@ -54,20 +54,11 @@ const NavigationResultPage = () => {
 				queryKey: ["fastRoute", university?.id, origin?.nodeId ?? 1, destination?.nodeId ?? 2],
 				queryFn: async () => {
 					try {
-						const response = await getNavigationResult(
-							university?.id ?? 1001,
-							origin?.nodeId ?? 1,
-							destination?.nodeId ?? 2,
-						);
+						const response = await getNavigationResult(university!.id, origin!.nodeId, destination!.nodeId);
 						return response;
 					} catch (e) {
-						// alert(`경로를 찾을 수 없습니다. (${e})`);
 						return null;
 					}
-					// return await fetchMockJson().then((data) => {
-					// 	const response = transformFastRoute(data);
-					// 	return response;
-					// });
 				},
 				retry: 1,
 				staleTime: 0,
@@ -114,114 +105,116 @@ const NavigationResultPage = () => {
 	};
 
 	return (
-		<div className="relative h-dvh w-full max-w-[450px] mx-auto">
-			{/* 지도 영역 */}
-			<NavigationMap
-				style={{ width: "100%", height: "100%" }}
-				routeResult={routeList.data!}
-				buttonState={buttonState}
-				isDetailView={isDetailView}
-				risks={risks.data}
-				topPadding={topBarHeight}
-				bottomPadding={sheetHeight}
-				handleCautionMarkerClick={handleCautionMarkerClick}
-				currentRouteIdx={currentRouteIdx}
-				setCautionRouteIdx={setCautionRouteIdx}
-			/>
-
-			<AnimatedContainer
-				isVisible={!isDetailView}
-				positionDelta={286}
-				className="absolute top-0 left-0 w-full flex flex-col space-y-2"
-				isTop={true}
-				transition={{ type: "spring", damping: 20, duration: 0.3 }}
-			>
-				<div className="max-w-[450px] w-full min-h-[143px] bg-gray-100 flex flex-col items-center justify-center rounded-b-4xl shadow-lg">
-					<NavigationDescription
-						isDetailView={false}
-						navigationRoute={routeList.data![buttonState]}
-						buttonType={buttonState}
-					/>
-				</div>
-				<NavigationNavBar
-					route={routeList.data!}
-					dataLength={routeList.data!.dataLength}
-					buttonType={buttonState}
-					setButtonState={handleButtonStateChange}
+		routeList.data && (
+			<div className="relative h-dvh w-full max-w-[450px] mx-auto">
+				{/* 지도 영역 */}
+				<NavigationMap
+					style={{ width: "100%", height: "100%" }}
+					routeResult={routeList.data!}
+					buttonState={buttonState}
+					isDetailView={isDetailView}
+					risks={risks.data}
+					topPadding={topBarHeight}
+					bottomPadding={sheetHeight}
+					handleCautionMarkerClick={handleCautionMarkerClick}
+					currentRouteIdx={currentRouteIdx}
+					setCautionRouteIdx={setCautionRouteIdx}
 				/>
-			</AnimatedContainer>
 
-			<AnimatedContainer
-				isVisible={!isDetailView}
-				className="absolute bottom-0 left-0 w-full mb-[30px] px-4"
-				positionDelta={88}
-			>
-				<BottomCardList
-					routeList={routeList.data!}
-					buttonType={buttonState}
-					showDetailView={showDetailView}
-					setButtonState={setButtonState}
-				></BottomCardList>
-			</AnimatedContainer>
-
-			<AnimatedContainer
-				isVisible={isDetailView}
-				className="absolute top-4 left-4 z-10"
-				positionDelta={60}
-				isTop={true}
-			>
-				<BackButton onClick={hideDetailView} />
-			</AnimatedContainer>
-
-			<AnimatedContainer
-				isVisible={isDetailView}
-				className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto"
-				positionDelta={MAX_SHEET_HEIGHT}
-				transition={{ type: "spring", damping: 20, duration: 0.7 }}
-				motionProps={{
-					drag: "y",
-					dragControls,
-					dragListener: false,
-					dragElastic: {
-						top: 0,
-						bottom: 0.3,
-					},
-					dragConstraints: {
-						top: 0,
-						bottom: MIN_SHEET_HEIGHT,
-					},
-					onDrag: handleDrag,
-					onDragEnd: handleDragEnd,
-				}}
-			>
-				<BottomSheetHandle resetCurrentIdx={resetCurrentIndex} dragControls={dragControls} />
-				<div
-					ref={scrollRef}
-					className="w-full overflow-y-auto"
-					style={{
-						height: MAX_SHEET_HEIGHT - BOTTOM_SHEET_HANDLE_HEIGHT,
-					}}
-					onScroll={preventScroll}
+				<AnimatedContainer
+					isVisible={!isDetailView}
+					positionDelta={286}
+					className="absolute top-0 left-0 w-full flex flex-col space-y-2"
+					isTop={true}
+					transition={{ type: "spring", damping: 20, duration: 0.3 }}
 				>
-					<NavigationDescription
-						resetCurrentRouteIdx={resetCurrentIndex}
-						isDetailView={true}
+					<div className="max-w-[450px] w-full min-h-[143px] bg-gray-100 flex flex-col items-center justify-center rounded-b-4xl shadow-lg">
+						<NavigationDescription
+							isDetailView={false}
+							navigationRoute={routeList.data![buttonState]}
+							buttonType={buttonState}
+						/>
+					</div>
+					<NavigationNavBar
+						route={routeList.data!}
+						dataLength={routeList.data!.dataLength}
 						buttonType={buttonState}
-						navigationRoute={routeList.data![buttonState]}
+						setButtonState={handleButtonStateChange}
 					/>
-					<RouteList
-						changeCurrentRouteIdx={changeCurrentIndex}
-						currentRouteIdx={currentRouteIdx}
-						routes={
-							routeList.data![buttonState]?.routeDetails
-								? routeList.data![buttonState]?.routeDetails
-								: null
-						}
-						cautionRouteIdx={cautionRouteIdx}
-					/>
-				</div>
-			</AnimatedContainer>
-		</div>
+				</AnimatedContainer>
+
+				<AnimatedContainer
+					isVisible={!isDetailView}
+					className="absolute bottom-0 left-0 w-full mb-[30px] px-4"
+					positionDelta={88}
+				>
+					<BottomCardList
+						routeList={routeList.data!}
+						buttonType={buttonState}
+						showDetailView={showDetailView}
+						setButtonState={setButtonState}
+					></BottomCardList>
+				</AnimatedContainer>
+
+				<AnimatedContainer
+					isVisible={isDetailView}
+					className="absolute top-4 left-4 z-10"
+					positionDelta={60}
+					isTop={true}
+				>
+					<BackButton onClick={hideDetailView} />
+				</AnimatedContainer>
+
+				<AnimatedContainer
+					isVisible={isDetailView}
+					className="absolute bottom-0 w-full left-0 bg-white rounded-t-2xl shadow-xl overflow-auto"
+					positionDelta={MAX_SHEET_HEIGHT}
+					transition={{ type: "spring", damping: 20, duration: 0.7 }}
+					motionProps={{
+						drag: "y",
+						dragControls,
+						dragListener: false,
+						dragElastic: {
+							top: 0,
+							bottom: 0.3,
+						},
+						dragConstraints: {
+							top: 0,
+							bottom: MIN_SHEET_HEIGHT,
+						},
+						onDrag: handleDrag,
+						onDragEnd: handleDragEnd,
+					}}
+				>
+					<BottomSheetHandle resetCurrentIdx={resetCurrentIndex} dragControls={dragControls} />
+					<div
+						ref={scrollRef}
+						className="w-full overflow-y-auto"
+						style={{
+							height: MAX_SHEET_HEIGHT - BOTTOM_SHEET_HANDLE_HEIGHT,
+						}}
+						onScroll={preventScroll}
+					>
+						<NavigationDescription
+							resetCurrentRouteIdx={resetCurrentIndex}
+							isDetailView={true}
+							buttonType={buttonState}
+							navigationRoute={routeList.data![buttonState]}
+						/>
+						<RouteList
+							changeCurrentRouteIdx={changeCurrentIndex}
+							currentRouteIdx={currentRouteIdx}
+							routes={
+								routeList.data![buttonState]?.routeDetails
+									? routeList.data![buttonState]?.routeDetails
+									: null
+							}
+							cautionRouteIdx={cautionRouteIdx}
+						/>
+					</div>
+				</AnimatedContainer>
+			</div>
+		)
 	);
 };
 

--- a/uniro_frontend/src/pages/universitySearch.tsx
+++ b/uniro_frontend/src/pages/universitySearch.tsx
@@ -7,10 +7,12 @@ import useUniversityInfo from "../hooks/useUniversityInfo";
 import { useQuery } from "@tanstack/react-query";
 import { getUniversityList } from "../api/search";
 import { University } from "../data/types/university";
+import useRoutePoint from "../hooks/useRoutePoint";
 
 export default function UniversitySearchPage() {
 	const [selectedUniv, setSelectedUniv] = useState<University>();
 	const { university, setUniversity } = useUniversityInfo();
+	const { setDestination, setOrigin } = useRoutePoint();
 	const [input, setInput] = useState<string>("");
 
 	const { data: universityList } = useQuery({
@@ -22,6 +24,13 @@ export default function UniversitySearchPage() {
 		if (university) {
 			setSelectedUniv(university);
 		}
+	}, []);
+
+	// 경로가 선택된 상태에서 이 페이지에 들어올 수 있는 가능성은 거의 없지만,
+	// Origin과 Destination이 남아있을 가능성을 방어한 코드입니다.
+	useEffect(() => {
+		setDestination(undefined);
+		setOrigin(undefined);
 	}, []);
 
 	return (


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

1. 주의요소 위험요소 마커 클릭시 한양대학교로 이동하는 현상 수정
2. Landing 페이지, 학교 선택 페이지에서 Persist 지우기
3. 학교 없이 로딩 화면 조회 시 학교 제거 및 Default 메세지 설정하기
4. origin, destination 없을 때 메인 화면으로 돌아가지 않는 문제 해결
5. 지도 메인 페이지 center point 수정

## 💡 To Reviewer
이슈 별로 1~2줄 수정했기 때문에, 커밋별로 봐주시면 감사하겠습니다.

## 🧪 테스트 결과

### 1. 주의요소 위험요소 마커 클릭시 한양대학교로 이동하는 현상 수정 & 지도 메인 페이지 center point 수정

https://github.com/user-attachments/assets/45049d2d-54aa-48a0-8c69-3f246bbdd934


### 2. Landing 페이지, 학교 선택 페이지에서 Persist 지우기

https://github.com/user-attachments/assets/a80ddff6-15b4-474a-af07-1992cfda9062

### 3. 학교 없이 로딩 화면 조회 시 학교 제거 및 Default 메세지 설정하기

-> 보여지는 화면은 없지만, 혹시 모를 상황을 대비해서 만들어놓았습니다.

### 4. origin, destination 없을 때 메인 화면으로 돌아가지 않는 문제 해결
#### AS IS

https://github.com/user-attachments/assets/331d6246-37fc-4f96-b8a3-2b3fbe329a3f

#### TO BE

https://github.com/user-attachments/assets/217c15a8-8739-4753-915f-434be56b6bfe


## ✅ 반영 브랜치
fe


## 하위 이슈

UNI-291, UNI-292,UNI-293,UNI-295