### PR TITLE
[UNI-296] feat : 404 페이지 제작 및 오류 발생 시 돌아가는 버튼 추가

### DIFF
--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -17,13 +17,14 @@ import { Suspense } from "react";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ErrorBoundary from "./components/error/ErrorBoundary";
 import Errortest from "./pages/errorTest";
+import NotFoundPage from "./pages/notFound";
 
 const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
-			staleTime: 300000
-		}
-	}
+			staleTime: 300000,
+		},
+	},
 });
 
 function App() {
@@ -46,6 +47,7 @@ function App() {
 						<Route path="/error" element={<ErrorPage />} />
 						<Route path="/error/offline" element={<OfflinePage />} />
 						<Route path="/error/test" element={<Errortest />} />
+						<Route path="*" element={<NotFoundPage />} />
 					</Routes>
 				</Suspense>
 			</ErrorBoundary>

--- a/uniro_frontend/src/components/error/NotFound.tsx
+++ b/uniro_frontend/src/components/error/NotFound.tsx
@@ -1,0 +1,13 @@
+import ErrorIcon from "../../assets/error/error.svg?react";
+
+export default function NotFound() {
+	return (
+		<div className="w-[285px] h-[198px] flex flex-col items-center py-2 space-y-[14px]">
+			<ErrorIcon />
+			<div className="space-y-[6px]">
+				<h3 className="text-kor-heading2 font-semibold text-gray-900">잘못된 접근입니다.</h3>
+				<p className="text-kor-body2 font-medium text-gray-700">다른 페이지로 이동해주세요.</p>
+			</div>
+		</div>
+	);
+}

--- a/uniro_frontend/src/pages/notFound.tsx
+++ b/uniro_frontend/src/pages/notFound.tsx
@@ -1,8 +1,8 @@
 import { useNavigate } from "react-router";
 import Button from "../components/customButton";
-import Error from "../components/error/Error";
+import NotFound from "../components/error/NotFound";
 
-export default function ErrorPage() {
+export default function NotFoundPage() {
 	const navigate = useNavigate();
 
 	const handleGoBack = () => {
@@ -15,7 +15,7 @@ export default function ErrorPage() {
 
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center items-center">
-			<Error />
+			<NotFound />
 			<div onClick={handleGoBack} className="absolute bottom-6 space-y-2 w-full px-4">
 				<Button variant="primary">{window.history.length > 1 ? "뒤로 가기" : "홈으로 이동"}</Button>
 			</div>


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
접근할 수 없는 경로에 피드백이 필요할 것으로 보여, 404 페이지를 추가하고, 오류가 발생했을때도 돌아갈 수 있도록 하였습니다.

### 돌아가는 버튼을 눌렀을 때 로직을 분리
```typescript
	const handleGoBack = () => {
		if (window.history.length > 1) {
			navigate(-1);
		} else {
			navigate("/");
		}
	};
```
동현님 말대로, 사용자가 뒤로가기를 제스처로 고려하는 경우도 있고, 오류가 발생해도 바로 뒤로 가는 것이 자연스럽다고 느껴져 해당 로직을 반영했습니다.
다만, 사용자가 변형된 링크(카카오톡 공유 etc..)로 바로 접속했을 경우도 대비를 해야하기 때문에, history 객체를 사용해 구분했습니다.

버튼 children에도 차이점을 뒀습니다.
```typescript
<div onClick={handleGoBack} className="absolute bottom-6 space-y-2 w-full px-4">
          <Button variant="primary">{window.history.length > 1 ? "뒤로 가기" : "홈으로 이동"}</Button>
</div>
```

## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과

### History 존재시

https://github.com/user-attachments/assets/36d81634-258d-4092-bda3-7db81d7bcb11

### History 존재하지 않을 시

https://github.com/user-attachments/assets/47eb1543-ef5e-41f3-8c0f-4a974e82a655


## ✅ 반영 브랜치
fe

## 하위 이슈
UNI-298, UNI-299

