### PR TITLE
[UNI-305] feat : 랜딩페이지, 학교 검색 관련 기능 추가

### DIFF
--- a/uniro_frontend/src/components/universityButton.tsx
+++ b/uniro_frontend/src/components/universityButton.tsx
@@ -19,20 +19,22 @@ export default function UniversityButton({ name, img, selected, loading, onClick
 		<li className="my-[6px]">
 			<button
 				onClick={handleClick}
-				className={`w-full h-full p-6 flex flex-row items-center border rounded-400 ${
+				className={`w-full h-full p-6 border rounded-400 text-left ${
 					selected ? "border-primary-400 bg-system-skyblue text-primary-500" : "border-gray-400"
 				}`}
 			>
-				{!imageLoaded && <div className="w-[30px] h-[30px] bg-gray-300 rounded-full  animate-pulse" />}
-				<img
-					src={img}
-					className={`mr-4 transition-opacity duration-300 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
-					alt={`${name} 로고`}
-					onLoad={() => setImageLoaded(true)}
-					onError={() => setImageLoaded(true)} // 에러 발생 시에도 로딩 완료로 간주
-				/>
+				<span className="inline-block w-[30px] h-[30px] relative align-middle">
+					{!imageLoaded && <div className="absolute inset-0 bg-gray-300 rounded-full animate-pulse" />}
+					<img
+						src={img}
+						className={`absolute inset-0 w-full h-full transition-opacity duration-300 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
+						alt={`${name} 로고`}
+						onLoad={() => setImageLoaded(true)}
+						onError={() => setImageLoaded(true)}
+					/>
+				</span>
 
-				<span className="text-kor-body2 font-medium leading-[140%]">{name}</span>
+				<span className="ml-4 inline-block align-middle text-kor-body2 font-medium leading-[140%]">{name}</span>
 			</button>
 		</li>
 	);

--- a/uniro_frontend/src/components/universityButton.tsx
+++ b/uniro_frontend/src/components/universityButton.tsx
@@ -1,13 +1,15 @@
-import { MouseEvent } from "react";
+import { MouseEvent, useState } from "react";
 
 interface UniversityButtonProps {
 	name: string;
 	img: string;
 	selected: boolean;
+	loading?: boolean;
 	onClick: () => void;
 }
 
-export default function UniversityButton({ name, img, selected, onClick }: UniversityButtonProps) {
+export default function UniversityButton({ name, img, selected, loading, onClick }: UniversityButtonProps) {
+	const [imageLoaded, setImageLoaded] = useState(false);
 	const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
 		e.stopPropagation();
 		onClick();
@@ -17,9 +19,19 @@ export default function UniversityButton({ name, img, selected, onClick }: Unive
 		<li className="my-[6px]">
 			<button
 				onClick={handleClick}
-				className={`w-full h-full p-6 flex flex-row items-center border rounded-400 ${selected ? "border-primary-400 bg-system-skyblue text-primary-500" : "border-gray-400"} `}
+				className={`w-full h-full p-6 flex flex-row items-center border rounded-400 ${
+					selected ? "border-primary-400 bg-system-skyblue text-primary-500" : "border-gray-400"
+				}`}
 			>
-				<img src={img} className="mr-4" />
+				{!imageLoaded && <div className="w-[30px] h-[30px] bg-gray-300 rounded-full  animate-pulse" />}
+				<img
+					src={img}
+					className={`mr-4 transition-opacity duration-300 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
+					alt={`${name} 로고`}
+					onLoad={() => setImageLoaded(true)}
+					onError={() => setImageLoaded(true)} // 에러 발생 시에도 로딩 완료로 간주
+				/>
+
 				<span className="text-kor-body2 font-medium leading-[140%]">{name}</span>
 			</button>
 		</li>

--- a/uniro_frontend/src/pages/landing.tsx
+++ b/uniro_frontend/src/pages/landing.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router";
 import useRoutePoint from "../hooks/useRoutePoint";
 import useUniversityInfo from "../hooks/useUniversityInfo";
 import { useEffect } from "react";
+import { motion } from "framer-motion";
 
 export default function LandingPage() {
 	const { setUniversity } = useUniversityInfo();
@@ -22,10 +23,22 @@ export default function LandingPage() {
 
 	return (
 		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center bg-[url(/public/background.png)] bg-cover">
-			<div>
-				<p className="text-kor-heading1 font-bold">어디든 갈 수 있는 캠퍼스.</p>
-				<p className="text-kor-heading1 font-bold">쉽고 빠르게 이동하세요.</p>
-			</div>
+			<motion.p
+				initial={{ opacity: 0, y: 50 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.5, delay: 0.3, ease: "easeInOut" }}
+				className="text-kor-heading1 font-bold"
+			>
+				어디든 갈 수 있는 캠퍼스.
+			</motion.p>
+			<motion.p
+				initial={{ opacity: 0, y: 50 }}
+				animate={{ opacity: 1, y: 0 }}
+				transition={{ duration: 0.5, delay: 0.8, ease: "easeInOut" }}
+				className="text-kor-heading1 font-bold"
+			>
+				쉽고 빠르게 이동하세요.
+			</motion.p>
 			<div className="w-full absolute bottom-6 left-[50%] px-[14px] translate-x-[-50%] flex flex-col items-start">
 				<div className="flex flex-row items-center space-x-[7px] mb-5">
 					<Logo />

--- a/uniro_frontend/src/pages/landing.tsx
+++ b/uniro_frontend/src/pages/landing.tsx
@@ -1,7 +1,7 @@
 import LandingButton from "../components/landingButton";
 import Logo from "../assets/logo.svg?react";
 import UNIRO from "../assets/UNIRO.svg?react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import useRoutePoint from "../hooks/useRoutePoint";
 import useUniversityInfo from "../hooks/useUniversityInfo";
 import { useEffect } from "react";
@@ -10,6 +10,7 @@ import { motion } from "framer-motion";
 export default function LandingPage() {
 	const { setUniversity } = useUniversityInfo();
 	const { setDestination, setOrigin } = useRoutePoint();
+	const navigate = useNavigate();
 
 	const initData = () => {
 		setDestination(undefined);
@@ -22,7 +23,10 @@ export default function LandingPage() {
 	}, []);
 
 	return (
-		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center bg-[url(/public/background.png)] bg-cover">
+		<div
+			className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto justify-center bg-[url(/public/background.png)] bg-cover"
+			onClick={() => navigate("/university")}
+		>
 			<motion.p
 				initial={{ opacity: 0, y: 50 }}
 				animate={{ opacity: 1, y: 0 }}

--- a/uniro_frontend/src/pages/universitySearch.tsx
+++ b/uniro_frontend/src/pages/universitySearch.tsx
@@ -35,46 +35,48 @@ export default function UniversitySearchPage() {
 	}, []);
 
 	return (
-		<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto py-5">
-			<div className="w-full px-[14px] pb-[17px] border-b-[1px] border-gray-400">
-				<Input
-					onChangeDebounce={(e) => setInput(e)}
-					placeholder="우리 학교를 검색해보세요"
-					handleVoiceInput={() => {}}
-				/>
-			</div>
-			<div className="overflow-y-scroll flex-1">
-				<ul
-					className="w-full h-full px-[14px] py-[6px]"
-					onClick={() => {
-						setSelectedUniv(undefined);
-					}}
-				>
-					{universityList &&
-						universityList.map((univ) => (
-							<UniversityButton
-								key={`university-${univ.id}`}
-								selected={selectedUniv?.id === univ.id}
-								onClick={() => {
-									if (selectedUniv?.id === univ.id) {
-										setUniversity(univ);
-										navigation("/map");
-										return;
-									}
-									setSelectedUniv(univ);
-								}}
-								name={univ.name}
-								img={univ.imageUrl}
-							/>
-						))}
-				</ul>
-			</div>
-			<div className="px-[14px]">
-				{selectedUniv && (
-					<Link to="/map" onClick={() => setUniversity(selectedUniv)}>
-						<Button variant="primary">다음</Button>
-					</Link>
-				)}
+		<div className="h-full w-full" onClick={() => setSelectedUniv(undefined)}>
+			<div className="relative flex flex-col h-dvh w-full max-w-[450px] mx-auto py-5">
+				<div className="w-full px-[14px] pb-[17px] border-b-[1px] border-gray-400">
+					<Input
+						onChangeDebounce={(e) => setInput(e)}
+						placeholder="우리 학교를 검색해보세요"
+						handleVoiceInput={() => {}}
+					/>
+				</div>
+				<div className="overflow-y-scroll flex-1">
+					<ul
+						className="w-full h-full px-[14px] py-[6px]"
+						onClick={() => {
+							setSelectedUniv(undefined);
+						}}
+					>
+						{universityList &&
+							universityList.map((univ) => (
+								<UniversityButton
+									key={`university-${univ.id}`}
+									selected={selectedUniv?.id === univ.id}
+									onClick={() => {
+										if (selectedUniv?.id === univ.id) {
+											setUniversity(univ);
+											navigation("/map");
+											return;
+										}
+										setSelectedUniv(univ);
+									}}
+									name={univ.name}
+									img={univ.imageUrl}
+								/>
+							))}
+					</ul>
+				</div>
+				<div className="px-[14px]">
+					{selectedUniv && (
+						<Link to="/map" onClick={() => setUniversity(selectedUniv)}>
+							<Button variant="primary">다음</Button>
+						</Link>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/uniro_frontend/src/pages/universitySearch.tsx
+++ b/uniro_frontend/src/pages/universitySearch.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import Input from "../components/customInput";
 import UniversityButton from "../components/universityButton";
 import Button from "../components/customButton";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import useUniversityInfo from "../hooks/useUniversityInfo";
 import { useQuery } from "@tanstack/react-query";
 import { getUniversityList } from "../api/search";
@@ -14,6 +14,7 @@ export default function UniversitySearchPage() {
 	const { university, setUniversity } = useUniversityInfo();
 	const { setDestination, setOrigin } = useRoutePoint();
 	const [input, setInput] = useState<string>("");
+	const navigation = useNavigate();
 
 	const { data: universityList } = useQuery({
 		queryKey: ["university", input],
@@ -55,6 +56,11 @@ export default function UniversitySearchPage() {
 								key={`university-${univ.id}`}
 								selected={selectedUniv?.id === univ.id}
 								onClick={() => {
+									if (selectedUniv?.id === univ.id) {
+										setUniversity(univ);
+										navigation("/map");
+										return;
+									}
 									setSelectedUniv(univ);
 								}}
 								name={univ.name}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

1. 랜딩 페이지 클릭 시 이동

div 전체에 이동을 걸어놓았습니다.

3. 랜딩 페이지 텍스트 애니메이션
```typescript
<motion.p
				initial={{ opacity: 0, y: 50 }}
				animate={{ opacity: 1, y: 0 }}
				transition={{ duration: 0.5, delay: 0.3, ease: "easeInOut" }}
				className="text-kor-heading1 font-bold"
			>
				어디든 갈 수 있는 캠퍼스.
			</motion.p>
			<motion.p
				initial={{ opacity: 0, y: 50 }}
				animate={{ opacity: 1, y: 0 }}
				transition={{ duration: 0.5, delay: 0.8, ease: "easeInOut" }}
				className="text-kor-heading1 font-bold"
			>
				쉽고 빠르게 이동하세요.
			</motion.p>
```
motion.p를 사용해, 각각 애니메이션이 올라오도록 했습니다.

5. 학교 더블 클릭시 선택
```typescript
onClick={() => {
		if (selectedUniv?.id === univ.id) {
			setUniversity(univ);
			navigation("/map");
			return;
		}
		setSelectedUniv(univ);
	}}
```
onClick코드를 수정했습니다.
7. 학교 배경 클릭 시 선택 해제
```typescript
<div className="h-full w-full" onClick={() => setSelectedUniv(undefined)}>
```
전체 컨테이너를 감싸는 div를 올려, 선택한 대학교를 해제하도록 했습니다.
9. 학교 사진 로딩 스켈레톤 교체
```typescript
<button
				onClick={handleClick}
				className={`w-full h-full p-6 border rounded-400 text-left ${
					selected ? "border-primary-400 bg-system-skyblue text-primary-500" : "border-gray-400"
				}`}
			>
				<span className="inline-block w-[30px] h-[30px] relative align-middle">
					{!imageLoaded && <div className="absolute inset-0 bg-gray-300 rounded-full animate-pulse" />}
					<img
						src={img}
						className={`absolute inset-0 w-full h-full transition-opacity duration-300 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
						alt={`${name} 로고`}
						onLoad={() => setImageLoaded(true)}
						onError={() => setImageLoaded(true)}
					/>
				</span>

				<span className="ml-4 inline-block align-middle text-kor-body2 font-medium leading-[140%]">{name}</span>
			</button>
```
flex를 사용하면, 순간 글자가 오른쪽으로 이동하는 flick 현상이 존재하였습니다. 객체의 존재 여부가 순간 달라져 그런 현상이 발생하고 있어, inline으로 위치를 조정시켜주었습니다.

스켈레톤 효과는 animate-pulse를 활용해 제작하였습니다.

## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과

### 초기 로딩 화면 애니메이션 및 스켈레톤 적용
https://github.com/user-attachments/assets/5af3178f-2110-4e95-8a9c-5586377af4ce

### 학교 두번 클릭 시 이동

https://github.com/user-attachments/assets/c92d64f7-a44f-487c-81f6-bf6b0647843e

### 학교 외부 클릭시 해제

https://github.com/user-attachments/assets/532273cc-1088-4f01-95ff-c3e5fd758312

## ✅ 반영 브랜치

fe

## 하위 이슈
UNI-306,UNI-308,UNI-309,UNI-310,UNI-311