### PR TITLE
[UNI-316] refactor : 빌딩과 연결된 간선은 길 추가 시 크로스체크 하지 않도록 변경

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -510,6 +510,7 @@ public class RouteCalculator {
         int endNodeCount = 0;
 
         for (Route route : routes) {
+            if(isBuildingRoute(route)) continue;
             Node node1 = route.getNode1();
             Node node2 = route.getNode2();
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### 빌딩과 연결된 간선은 길 추가 시 크로스체크 하지 않도록 변경
- createValidRouteNodes 에서 buildingNode일 시 nodeMap과 strTree에 포함되지 않도록 변경하였습니다.