### PR TITLE
 [UNI-307] feat : 지도 메인 페이지 경로 노출 적용 및 길 색상 변경 및 학교 영역 폴리곤 생성

### DIFF
--- a/uniro_frontend/src/hooks/useMap.tsx
+++ b/uniro_frontend/src/hooks/useMap.tsx
@@ -7,6 +7,7 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 	const [overlay, setOverlay] = useState<google.maps.OverlayView | null>(null);
 	const [AdvancedMarker, setAdvancedMarker] = useState<typeof google.maps.marker.AdvancedMarkerElement | null>(null);
 	const [Polyline, setPolyline] = useState<typeof google.maps.Polyline | null>(null);
+	const [Polygon, setPolylgon] = useState<typeof google.maps.Polygon | null>(null);
 	const [mapLoaded, setMapLoaded] = useState<boolean>(false);
 
 	useEffect(() => {
@@ -14,7 +15,7 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 
 		const initMap = async () => {
 			try {
-				const { map, overlay, AdvancedMarkerElement, Polyline } = await initializeMap(
+				const { map, overlay, AdvancedMarkerElement, Polyline, Polygon } = await initializeMap(
 					mapRef.current,
 					mapOptions,
 				);
@@ -22,6 +23,7 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 				setOverlay(overlay);
 				setAdvancedMarker(() => AdvancedMarkerElement);
 				setPolyline(() => Polyline);
+				setPolylgon(() => Polygon);
 				setMapLoaded(true);
 			} catch (e) {
 				alert("Error while initializing map: " + e);
@@ -37,7 +39,7 @@ const useMap = (mapOptions?: google.maps.MapOptions) => {
 		};
 	}, []);
 
-	return { mapRef, map, overlay, AdvancedMarker, Polyline, mapLoaded };
+	return { mapRef, map, overlay, AdvancedMarker, Polyline, Polygon, mapLoaded };
 };
 
 export default useMap;

--- a/uniro_frontend/src/map/initializer/googleMapInitializer.ts
+++ b/uniro_frontend/src/map/initializer/googleMapInitializer.ts
@@ -7,13 +7,14 @@ interface MapWithOverlay {
 	overlay: google.maps.OverlayView | null;
 	AdvancedMarkerElement: typeof google.maps.marker.AdvancedMarkerElement;
 	Polyline: typeof google.maps.Polyline;
+	Polygon: typeof google.maps.Polygon;
 }
 
 export const initializeMap = async (
 	mapElement: HTMLElement | null,
 	mapOptions?: google.maps.MapOptions,
 ): Promise<MapWithOverlay> => {
-	const { Map, OverlayView, AdvancedMarkerElement, Polyline } = await loadGoogleMapsLibraries();
+	const { Map, OverlayView, AdvancedMarkerElement, Polyline, Polygon } = await loadGoogleMapsLibraries();
 
 	if (!mapElement) {
 		throw new Error("Map Element is not provided");
@@ -44,5 +45,5 @@ export const initializeMap = async (
 	overlay.onRemove = function () {};
 	overlay.setMap(map);
 
-	return { map, overlay, AdvancedMarkerElement, Polyline };
+	return { map, overlay, AdvancedMarkerElement, Polyline, Polygon };
 };

--- a/uniro_frontend/src/map/loader/googleMapLoader.ts
+++ b/uniro_frontend/src/map/loader/googleMapLoader.ts
@@ -7,10 +7,10 @@ const GoogleMapsLoader = new Loader({
 });
 
 const loadGoogleMapsLibraries = async () => {
-	const { Map, OverlayView, Polyline } = await GoogleMapsLoader.importLibrary("maps");
+	const { Map, OverlayView, Polyline, Polygon } = await GoogleMapsLoader.importLibrary("maps");
 	const { AdvancedMarkerElement } = await GoogleMapsLoader.importLibrary("marker");
 
-	return { Map, OverlayView, AdvancedMarkerElement, Polyline };
+	return { Map, OverlayView, AdvancedMarkerElement, Polyline, Polygon };
 };
 
 export default loadGoogleMapsLibraries;

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -30,7 +30,7 @@ const ReportForm = () => {
 
 	const [disabled, setDisabled] = useState<boolean>(true);
 
-	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal(redirectToMap);
+	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal();
 
 	const [errorTitle, setErrorTitle] = useState<string>("");
 

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -168,7 +168,7 @@ export default function ReportRiskPage() {
 				path: subNodes.map((el) => {
 					return { lat: el.lat, lng: el.lng };
 				}),
-				strokeColor: "#808080",
+				strokeColor: "#3585fc",
 			});
 
 			routePolyLine.addListener("click", (e: ClickEvent) => {
@@ -183,7 +183,7 @@ export default function ReportRiskPage() {
 					AdvancedMarker,
 					map,
 					centerCoordinate(nearestEdge.node1, nearestEdge.node2),
-					reportMarkerElement({})
+					reportMarkerElement({}),
 				);
 
 				setReportMarker((prevMarker) => {
@@ -227,19 +227,21 @@ export default function ReportRiskPage() {
 		switch (marker.type) {
 			case Markers.DANGER:
 				if (isSelect) {
-					marker.element.content = dangerMarkerElement({ factors: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]) });
+					marker.element.content = dangerMarkerElement({
+						factors: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]),
+					});
 					return;
-				}
-				else {
+				} else {
 					marker.element.content = dangerMarkerElement({});
 					return;
 				}
 			case Markers.CAUTION:
 				if (isSelect) {
-					marker.element.content = cautionMarkerElement({ factors: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]) });
+					marker.element.content = cautionMarkerElement({
+						factors: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]),
+					});
 					return;
-				}
-				else {
+				} else {
 					marker.element.content = cautionMarkerElement({});
 					return;
 				}

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -59,7 +59,7 @@ export default function ReportRoutePage() {
 
 	const [selectedMarker, setSelectedMarker] = useState<SelectedMarkerTypes>();
 	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal(() => {
-		navigate("/map");
+		// navigate("/map");
 	});
 	const [tempWaypoints, setTempWayPoints] = useState<AdvancedMarker[]>([]);
 	const [isTutorialShown, setIsTutorialShown] = useState<boolean>(true);

--- a/uniro_frontend/src/pages/reportRoute.tsx
+++ b/uniro_frontend/src/pages/reportRoute.tsx
@@ -64,7 +64,13 @@ export default function ReportRoutePage() {
 	const [tempWaypoints, setTempWayPoints] = useState<AdvancedMarker[]>([]);
 	const [isTutorialShown, setIsTutorialShown] = useState<boolean>(true);
 
-	const { cautionMarkerElement, dangerMarkerElement, waypointMarkerElement, originMarkerElement, destinationMarkerElement } = createMarkerElement();
+	const {
+		cautionMarkerElement,
+		dangerMarkerElement,
+		waypointMarkerElement,
+		originMarkerElement,
+		destinationMarkerElement,
+	} = createMarkerElement();
 
 	if (!university) return;
 
@@ -281,7 +287,7 @@ export default function ReportRoutePage() {
 				path: subNodes.map((el) => {
 					return { lat: el.lat, lng: el.lng };
 				}),
-				strokeColor: "#808080",
+				strokeColor: "#3585fc",
 			});
 
 			routePolyLine.addListener("click", (e: ClickEvent) => {
@@ -317,7 +323,7 @@ export default function ReportRoutePage() {
 								element: new AdvancedMarker({
 									map: map,
 									position: nearestPoint,
-									content: destinationMarkerElement({ hasAnimation: true })
+									content: destinationMarkerElement({ hasAnimation: true }),
 								}),
 								coords: [...prevPoints.coords, nearestPoint],
 							};
@@ -454,7 +460,7 @@ export default function ReportRoutePage() {
 								element: new AdvancedMarker({
 									map: map,
 									position: point,
-									content: destinationMarkerElement({})
+									content: destinationMarkerElement({}),
 								}),
 								coords: [...prevPoints.coords, point],
 							};
@@ -472,7 +478,9 @@ export default function ReportRoutePage() {
 		if (!map || !marker) return;
 		if (marker.type === Markers.DANGER) {
 			if (isSelect) {
-				marker.element.content = dangerMarkerElement({ factors: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]) });
+				marker.element.content = dangerMarkerElement({
+					factors: (marker.factors as DangerIssueType[]).map((key) => DangerIssue[key]),
+				});
 				return;
 			}
 
@@ -481,7 +489,9 @@ export default function ReportRoutePage() {
 		}
 		if (marker.type === Markers.CAUTION) {
 			if (isSelect) {
-				marker.element.content = cautionMarkerElement({ factors: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]) });
+				marker.element.content = cautionMarkerElement({
+					factors: (marker.factors as CautionIssueType[]).map((key) => CautionIssue[key]),
+				});
 				return;
 			}
 


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### Polygon 생성

```typescript
	const drawPolygon = () => {
		if (!Polygon) return;

		const polygonPath = university.areaPolygon;
		const areaPolygon = new Polygon({
			map: map,
			paths: polygonPath,
			fillColor: "#ff2d55",
			fillOpacity: 0.1,
			strokeColor: "#ff2d55",
			strokeOpacity: 0.5,
		});

		polygon.current = areaPolygon;
	};
```
- 대학 리스트 조회 시, 받게되는 areaPolygon 값으로 전체 Polygon을 생성합니다.

## 💡 To Reviewer
- 색상은 임의로 빨간색으로 변경하였습니다.
- 추후 길 색상과 함께 변경할 수 있습니다.
- drawRoute 같은 공통 함수를 분리할 예정입니다.


## 🧪 테스트 결과

https://github.com/user-attachments/assets/48c979ae-0045-4f05-a1f3-8fda0f0f1e53



## ✅ 연관이슈
UNI-317