### PR TITLE
[UNI-323] feat : Stream + SSE로 대용량 조회 분할처리 로직 구현

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/UniroBackendApplication.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/UniroBackendApplication.java
@@ -3,9 +3,11 @@ package com.softeer5.uniro_backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class UniroBackendApplication {
 
 	public static void main(String[] args) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/AsyncConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/AsyncConfig.java
@@ -1,0 +1,34 @@
+package com.softeer5.uniro_backend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10); //기본 스레드 개수 10개
+        executor.setMaxPoolSize(20); //20개까지 추가 생성 가능
+        executor.setQueueCapacity(100); //대기열 크기
+
+        executor.setTaskDecorator(runnable -> {
+            RequestAttributes context = RequestContextHolder.getRequestAttributes();
+            return () -> {
+                try {
+                    RequestContextHolder.setRequestAttributes(context);
+                    runnable.run();
+                } finally {
+                    RequestContextHolder.resetRequestAttributes();
+                }
+            };
+        });
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -11,4 +11,8 @@ public final class UniroConst {
 	public static final double BUILDING_ROUTE_DISTANCE = 1e8;
 	public static final int IS_SINGLE_ROUTE = 2;
 	public static final double HEURISTIC_WEIGHT_NORMALIZATION_FACTOR = 10.0;
+	public static final int STREAM_FETCH_SIZE = 2500;
+
+	//컴파일 상수를 보장하기 위한 코드
+	public static final String STREAM_FETCH_SIZE_AS_STRING = "" + STREAM_FETCH_SIZE;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -28,6 +29,13 @@ public interface MapApi {
 			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
 	ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId);
+
+	@Operation(summary = "모든 지도(노드,루트) 조회 by sse")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "모든 지도 조회 성공"),
+			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
+	})
+	SseEmitter getAllRoutes(@PathVariable("univId") Long univId);
 
 	@Operation(summary = "위험&주의 요소 조회")
 	@ApiResponses(value = {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import com.softeer5.uniro_backend.map.service.MapService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -29,6 +30,14 @@ public class MapController implements MapApi {
 	public ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId){
 		GetAllRoutesResDTO allRoutes = mapService.getAllRoutes(univId);
 		return ResponseEntity.ok().body(allRoutes);
+	}
+
+	@Override
+	@GetMapping("/{univId}/routes/sse")
+	public SseEmitter getAllRoutes(@PathVariable("univId") Long univId){
+		SseEmitter emitter = new SseEmitter(60 * 1000L); // timeout 1분
+		mapService.getAllRoutesByStream(univId, emitter);
+		return emitter;
 	}
 
 	@Override

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
@@ -3,21 +3,27 @@ package com.softeer5.uniro_backend.map.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.softeer5.uniro_backend.map.entity.Route;
+
+import static com.softeer5.uniro_backend.common.constant.UniroConst.STREAM_FETCH_SIZE_AS_STRING;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
 
     @EntityGraph(attributePaths = {"node1", "node2"})
     @Query("SELECT r FROM Route r WHERE r.univId = :univId")
     List<Route> findAllRouteByUnivIdWithNodes(Long univId);
+
+    @EntityGraph(attributePaths = {"node1", "node2"})
+    @Query("SELECT r FROM Route r WHERE r.univId = :univId")
+    @QueryHints(@QueryHint(name = "org.hibernate.fetchSize", value = STREAM_FETCH_SIZE_AS_STRING))
+    Stream<Route> findAllRouteByUnivIdWithNodesStream(Long univId);
 
     @Query(value = "SELECT r.* FROM route r " +
             "WHERE r.univ_id = :univId " +

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -1,11 +1,11 @@
 package com.softeer5.uniro_backend.map.service;
 
-import static com.softeer5.uniro_backend.common.constant.UniroConst.BUILDING_ROUTE_DISTANCE;
-import static com.softeer5.uniro_backend.common.constant.UniroConst.CORE_NODE_CONDITION;
+import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
 import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
 import static com.softeer5.uniro_backend.common.utils.GeoUtils.getInstance;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import com.softeer5.uniro_backend.admin.annotation.RevisionOperation;
 import com.softeer5.uniro_backend.admin.entity.RevInfo;
@@ -25,8 +25,11 @@ import com.softeer5.uniro_backend.building.repository.BuildingRepository;
 import com.softeer5.uniro_backend.map.repository.NodeRepository;
 import com.softeer5.uniro_backend.map.dto.request.CreateBuildingRouteReqDTO;
 import com.softeer5.uniro_backend.map.dto.response.*;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,12 +38,15 @@ import com.softeer5.uniro_backend.map.entity.Route;
 import com.softeer5.uniro_backend.map.repository.RouteRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class MapService {
 	private final RouteRepository routeRepository;
+	private final EntityManager entityManager;
 	private final NodeRepository nodeRepository;
 	private final BuildingRepository buildingRepository;
 	private final RevInfoRepository revInfoRepository;
@@ -65,6 +71,43 @@ public class MapService {
 		return GetAllRoutesResDTO.of(allRoutesInfo.getNodeInfos(), allRoutesInfo.getCoreRoutes(),
 			allRoutesInfo.getBuildingRoutes(), revInfo.getRev());
 	}
+
+	@Async
+	public void getAllRoutesByStream(Long univId, SseEmitter emitter) {
+		try (Stream<Route> routeStream = routeRepository.findAllRouteByUnivIdWithNodesStream(univId)) {
+			List<Route> batch = new ArrayList<>(STREAM_FETCH_SIZE);
+			Iterator<Route> iterator = routeStream.iterator();
+			while (iterator.hasNext()) {
+				Route route = iterator.next();
+				batch.add(route);
+				entityManager.detach(route);
+
+				if (batch.size() == STREAM_FETCH_SIZE) {
+					processBatch(batch, emitter);
+				}
+			}
+			// 남은 배치 처리
+			if (!batch.isEmpty()) {
+				processBatch(batch, emitter);
+			}
+			emitter.complete();
+			log.info("[SSE emitter complete] " + Thread.currentThread().getName());
+		}
+		catch (Exception e) {
+			emitter.completeWithError(e);
+			log.error(e.getMessage());
+		}
+	}
+
+	private void processBatch(List<Route> batch, SseEmitter emitter) throws Exception {
+		if (!batch.isEmpty()) {
+			AllRoutesInfo allRoutesInfo = routeCalculator.assembleRoutes(batch);
+			emitter.send(allRoutesInfo);
+			batch.clear();
+			entityManager.clear();
+		}
+	}
+
 
 	public List<FastestRouteResDTO> findFastestRoute(Long univId, Long startNodeId, Long endNodeId){
 


### PR DESCRIPTION
# 📝 PR 타입
- [x] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 🚀 변경 사항
##  Stream을 이용한 Route 조회 개선
- 기존에는 List<Route>로 전체 데이터를 한 번에 조회하다 보니, 한정된 EC2 인스턴스 리소스 환경에서 수만 개의 Node와 Route 데이터를 여러 쓰레드가 동시에 조회할 때 OOM(OutOfMemory) 문제가 발생했습니다.
- 이를 해결하기 위해, 전체 데이터를 한꺼번에 메모리에 적재하는 대신, Stream<Route>를 활용하여 일정 단위(예: 2500건)로 데이터를 처리하도록 변경했습니다.
- 각 배치 처리 후 entityManager.detach()와 리스트 클리어 작업을 통해 영속성 컨텍스트 및 메모리에서 불필요한 데이터를 제거하여, GC가 효과적으로 메모리를 회수할 수 있도록 구현하였습니다.

## SSE를 통한 분할 응답
- 전체 데이터를 한 번의 응답으로 전달하면 응답 데이터가 누적되어 메모리 사용량이 급증할 수 있는 문제가 있었습니다.
- 이를 개선하기 위해, Server-Sent Events(SSE)를 도입하여 데이터를 배치 단위로 분할하여 전송하도록 변경하였습니다.
- 이 방식은 클라이언트가 각 배치 데이터를 즉시 처리할 수 있게 하여, 서버 측에서는 응답 데이터를 누적하지 않고 지속적으로 메모리를 해제할 수 있도록 합니다.
- 또한, Stream과 SSE 기법을 결합하여 메모리 부담을 최소화하면서 응답 속도와 처리 효율을 극대화하였습니다.


## 힙 사용량 비교자료
조건 : 힙 메모리 500MB, 쓰레드 15개, 루프카운트 10


<img width="593" alt="image" src="https://github.com/user-attachments/assets/b6402ec6-08e8-41d1-b074-0d3ec4e909a9" />
<img width="524" alt="image" src="https://github.com/user-attachments/assets/a95c423b-1866-4d6a-9574-96b4b0c85d89" />



# 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="624" alt="image" src="https://github.com/user-attachments/assets/6e74e50a-6b36-4582-b93c-8e993021f43b" />



<!-- [UNI-324] -->


[UNI-324]: https://uniro.atlassian.net/browse/UNI-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ