### PR TITLE
[UNI-218] refactor : 길 찾기 상세경로 좌회전,우회전 로직 수정

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -275,23 +275,21 @@ public class RouteCalculator {
     }
 
     // 두 route 간의 각도를 통한 계산으로 방향성을 정하는 메서드
-    private DirectionType calculateDirection(Node secondNode, Route inBoundRoute, Route outBoundRoute) {
-        Node firstNode = inBoundRoute.getNode1().equals(secondNode) ? inBoundRoute.getNode2() : inBoundRoute.getNode1();
-        Node thirdNode = outBoundRoute.getNode1().equals(secondNode) ? outBoundRoute.getNode2() : outBoundRoute.getNode1();
+    private DirectionType calculateDirection(Node secondNode, List<Route> shortestRoutes, int idx) {
+        Node firstNode = shortestRoutes.get(idx).getNode1().equals(secondNode) ?
+                shortestRoutes.get(idx).getNode2() : shortestRoutes.get(idx).getNode1();
+        Node thirdNode = shortestRoutes.get(idx+1).getNode2().equals(secondNode) ?
+                shortestRoutes.get(idx+1).getNode1() : shortestRoutes.get(idx+1).getNode2();
 
-        Point p1 = firstNode.getCoordinates();
-        Point p2 = secondNode.getCoordinates();
-        Point p3 = thirdNode.getCoordinates();
+        if(idx-1 >= 0){
+            firstNode = shortestRoutes.get(idx-1).getNode1().equals(secondNode) ?
+                    shortestRoutes.get(idx-1).getNode2() : shortestRoutes.get(idx-1).getNode1();
+        }
 
-        return calculateAngle(p1, p2, p3);
-    }
-
-    private DirectionType calculateDirection(Node secondNode, Route inBoundRoute, Route beforeInBoundRoute,
-                                             Route outBoundRoute, Route afterOutBoundRoute) {
-        Node firstNode = inBoundRoute.getNode1().equals(secondNode) ? inBoundRoute.getNode2() : inBoundRoute.getNode1();
-        firstNode = beforeInBoundRoute.getNode1().equals(firstNode) ? beforeInBoundRoute.getNode2() : beforeInBoundRoute.getNode1();
-        Node thirdNode = outBoundRoute.getNode1().equals(secondNode) ? outBoundRoute.getNode2() : outBoundRoute.getNode1();
-        thirdNode = afterOutBoundRoute.getNode1().equals(thirdNode) ? afterOutBoundRoute.getNode2() : afterOutBoundRoute.getNode1();
+        if(idx+2 <= shortestRoutes.size()-1){
+            thirdNode = shortestRoutes.get(idx+2).getNode2().equals(secondNode) ?
+                    shortestRoutes.get(idx+2).getNode1() : shortestRoutes.get(idx+2).getNode2();
+        }
 
         Point p1 = firstNode.getCoordinates();
         Point p2 = secondNode.getCoordinates();
@@ -384,14 +382,7 @@ public class RouteCalculator {
                 break;
             }
             if(nxt.isCore()){
-                DirectionType directionType;
-                if(i == shortestRoutes.size()-2) {
-                    directionType = calculateDirection(nxt, nowRoute, shortestRoutes.get(i + 1));
-                }
-                else{
-                    directionType = calculateDirection(nxt, nowRoute, shortestRoutes.get(i-1),
-                            shortestRoutes.get(i+1), shortestRoutes.get(i+2));
-                }
+                DirectionType directionType = calculateDirection(nxt, shortestRoutes, i);
 
                 if(directionType == DirectionType.STRAIGHT){
                     now = nxt;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -283,6 +283,24 @@ public class RouteCalculator {
         Point p2 = secondNode.getCoordinates();
         Point p3 = thirdNode.getCoordinates();
 
+        return calculateAngle(p1, p2, p3);
+    }
+
+    private DirectionType calculateDirection(Node secondNode, Route inBoundRoute, Route beforeInBoundRoute,
+                                             Route outBoundRoute, Route afterOutBoundRoute) {
+        Node firstNode = inBoundRoute.getNode1().equals(secondNode) ? inBoundRoute.getNode2() : inBoundRoute.getNode1();
+        firstNode = beforeInBoundRoute.getNode1().equals(firstNode) ? beforeInBoundRoute.getNode2() : beforeInBoundRoute.getNode1();
+        Node thirdNode = outBoundRoute.getNode1().equals(secondNode) ? outBoundRoute.getNode2() : outBoundRoute.getNode1();
+        thirdNode = afterOutBoundRoute.getNode1().equals(thirdNode) ? afterOutBoundRoute.getNode2() : afterOutBoundRoute.getNode1();
+
+        Point p1 = firstNode.getCoordinates();
+        Point p2 = secondNode.getCoordinates();
+        Point p3 = thirdNode.getCoordinates();
+
+        return calculateAngle(p1, p2, p3);
+    }
+
+    private DirectionType calculateAngle(Point p1, Point p2, Point p3) {
         double v1x = p2.getX() - p1.getX();
         double v1y = p2.getY() - p1.getY();
 
@@ -366,7 +384,15 @@ public class RouteCalculator {
                 break;
             }
             if(nxt.isCore()){
-                DirectionType directionType = calculateDirection(nxt, nowRoute, shortestRoutes.get(i+1));
+                DirectionType directionType;
+                if(i == shortestRoutes.size()-2) {
+                    directionType = calculateDirection(nxt, nowRoute, shortestRoutes.get(i + 1));
+                }
+                else{
+                    directionType = calculateDirection(nxt, nowRoute, shortestRoutes.get(i-1),
+                            shortestRoutes.get(i+1), shortestRoutes.get(i+2));
+                }
+
                 if(directionType == DirectionType.STRAIGHT){
                     now = nxt;
                     continue;


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### 길 찾기 상세경로 좌회전,우회전 로직 수정
- 기존 길 찾기 상세경로에서 좌회전,우회전 판단은 코어노드로부터 전,후 노드였습니다.
- 이 경우 일부 경로에서 직진임에도 좌,우회전으로 판단되는 경우가 있어 로직을 수정하였습니다.
- 상세경로에서 좌,우회전 판단할 때 코어노드로부터 이전2번째 노드, 이후2번째 노드로 판단하도록 변경하였습니다.

