### PR TITLE
[UNI-336] 제보하기 페이지 등록 이후 위치 이동 구현, 제보 취소, 제보 후 캐시 수정 구현

### DIFF
--- a/uniro_frontend/src/components/report/reportTitle.tsx
+++ b/uniro_frontend/src/components/report/reportTitle.tsx
@@ -1,10 +1,15 @@
+import { Link } from "react-router";
 import { ReportModeType } from "../../data/types/report";
+import CloseIcon from "../../assets/icon/close.svg?react";
 export const ReportTitle = ({ reportMode }: { reportMode: ReportModeType }) => {
 	const CREATE_TITLE = "불편한 길을 알려주세요.";
 	const UPDATE_TITLE = "불편한 길을 수정해주세요.";
 	return (
 		<div className="flex flex-col items-start justify-center max-w-[450px] w-full bg-gray-100 py-6 pl-6 text-left text-gray-900 text-kor-heading1 font-semibold">
 			{reportMode === "create" ? CREATE_TITLE : UPDATE_TITLE}
+			<Link to="/report/risk" className="absolute top-6 right-6">
+				<CloseIcon />
+			</Link>
 		</div>
 	);
 };

--- a/uniro_frontend/src/hooks/useReportRiskResult.tsx
+++ b/uniro_frontend/src/hooks/useReportRiskResult.tsx
@@ -1,0 +1,62 @@
+import { create } from "zustand";
+import { RouteId } from "../data/types/route";
+import { CautionFactor, DangerFactor } from "../data/types/factor";
+
+interface ReportedRiskResult {
+	reportedData: {
+		universityId: number | undefined;
+		routeId: RouteId | undefined;
+		cautionFactors: CautionFactor[];
+		dangerFactors: DangerFactor[];
+	};
+	setReportedRouteData: (params: {
+		universityId: number;
+		routeId: RouteId;
+		cautionFactors: CautionFactor[];
+		dangerFactors: DangerFactor[];
+	}) => void;
+	clearReportedRouteData: () => void;
+}
+
+const useReportedRisk = create<ReportedRiskResult>((set) => ({
+	reportedData: {
+		universityId: undefined,
+		routeId: undefined,
+		reportedCoord: undefined,
+		cautionFactors: [],
+		dangerFactors: [],
+	},
+	setReportedRouteData: ({
+		universityId,
+		routeId,
+		cautionFactors,
+		dangerFactors,
+	}: {
+		universityId: number;
+		routeId: RouteId;
+		cautionFactors: CautionFactor[];
+		dangerFactors: DangerFactor[];
+	}) =>
+		set((state) => ({
+			reportedData: {
+				...state.reportedData,
+				universityId,
+				routeId,
+				cautionFactors,
+				dangerFactors,
+			},
+		})),
+	clearReportedRouteData: () => {
+		set(() => ({
+			reportedData: {
+				universityId: undefined,
+				routeId: undefined,
+				reportedCoord: undefined,
+				cautionFactors: [],
+				dangerFactors: [],
+			},
+		}));
+	},
+}));
+
+export default useReportedRisk;

--- a/uniro_frontend/src/pages/map.tsx
+++ b/uniro_frontend/src/pages/map.tsx
@@ -128,10 +128,10 @@ export default function MapPage() {
 				queryKey: [university.id, "buildings"],
 				queryFn: () =>
 					getAllBuildings(university.id, {
-						leftUpLat: 38,
-						leftUpLng: 127,
-						rightDownLat: 37,
-						rightDownLng: 128,
+						leftUpLat: 35,
+						leftUpLng: 126,
+						rightDownLat: 38,
+						rightDownLng: 130,
 					}),
 			},
 			{

--- a/uniro_frontend/src/pages/reportForm.tsx
+++ b/uniro_frontend/src/pages/reportForm.tsx
@@ -20,6 +20,7 @@ import { useNavigate } from "react-router";
 import useReportRisk from "../hooks/useReportRisk";
 import { RouteId } from "../data/types/route";
 import useMutationError from "../hooks/useMutationError";
+import useReportedRisk from "../hooks/useReportRiskResult";
 
 const ReportForm = () => {
 	useScrollControl();
@@ -30,8 +31,6 @@ const ReportForm = () => {
 
 	const [disabled, setDisabled] = useState<boolean>(true);
 
-	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal();
-
 	const [errorTitle, setErrorTitle] = useState<string>("");
 
 	const { university } = useUniversityInfo();
@@ -39,6 +38,8 @@ const ReportForm = () => {
 
 	useRedirectUndefined<University | RouteId | undefined>([university, routeId]);
 	if (!routeId) return;
+
+	const { setReportedRouteData } = useReportedRisk();
 
 	const { data } = useSuspenseQuery({
 		queryKey: ["report", university?.id ?? 1001, routeId],
@@ -118,6 +119,12 @@ const ReportForm = () => {
 					cautionFactors: formData.cautionIssues,
 				}),
 			onSuccess: () => {
+				setReportedRouteData({
+					universityId: university!.id,
+					routeId: routeId,
+					dangerFactors: formData.dangerIssues,
+					cautionFactors: formData.cautionIssues,
+				});
 				queryClient.removeQueries({ queryKey: [university?.id ?? 1001, "risks"] });
 				openSuccess();
 			},
@@ -140,6 +147,10 @@ const ReportForm = () => {
 			onClose: redirectToMap,
 		},
 	);
+
+	const [SuccessModal, isSuccessOpen, openSuccess, closeSuccess] = useModal(() => {
+		navigate("/report/risk");
+	});
 
 	return (
 		<div className="flex flex-col h-dvh w-full max-w-[450px] mx-auto relative">

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -214,18 +214,9 @@ export default function ReportRiskPage() {
 		return undefined;
 	};
 
-	const checkTypeOfReportedData = () => {
-		const { routeId, cautionFactors, dangerFactors } = reportedData;
-		if ((routeId && cautionFactors.length > 0) || dangerFactors.length > 0)
-			return cautionFactors.length > 0 ? Markers.CAUTION : Markers.DANGER;
-		return null;
-	};
-
 	const moveToMarker = () => {
 		if (!map || !AdvancedMarker) return;
 		const { routeId } = reportedData;
-		const type = checkTypeOfReportedData();
-		if (type === null) return;
 		const route = findRouteById(routes.data, routeId!);
 		if (!route) return;
 		const node1 = route.node1;

--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -18,7 +18,7 @@ import BackButton from "../components/map/backButton";
 import useUniversityInfo from "../hooks/useUniversityInfo";
 import useRedirectUndefined from "../hooks/useRedirectUndefined";
 import { University } from "../data/types/university";
-import { useSuspenseQueries } from "@tanstack/react-query";
+import { useQueryClient, useSuspenseQueries } from "@tanstack/react-query";
 import { getAllRoutes } from "../api/route";
 import { getAllRisks } from "../api/routes";
 import useReportRisk from "../hooks/useReportRisk";
@@ -26,6 +26,8 @@ import { CautionIssueType, DangerIssueType } from "../data/types/enum";
 import { CautionIssue, DangerIssue } from "../constant/enum/reportEnum";
 import TutorialModal from "../components/map/tutorialModal";
 import createMarkerElement from "../utils/markers/createMarkerElement";
+import useReportedRisk from "../hooks/useReportRiskResult";
+import { interpolate } from "../utils/interpolate";
 
 interface reportMarkerTypes extends MarkerTypesWithElement {
 	route: RouteId;
@@ -39,9 +41,12 @@ export default function ReportRiskPage() {
 
 	const [message, setMessage] = useState<ReportRiskMessage>(ReportRiskMessage.DEFAULT);
 	const { setReportRouteId } = useReportRisk();
+	const { reportedData, clearReportedRouteData } = useReportedRisk();
 	const { university } = useUniversityInfo();
 	const [isTutorialShown, setIsTutorialShown] = useState<boolean>(true);
 	const { dangerMarkerElement, cautionMarkerElement, reportMarkerElement } = createMarkerElement();
+
+	const queryClient = useQueryClient();
 
 	useRedirectUndefined<University | undefined>([university]);
 
@@ -199,12 +204,75 @@ export default function ReportRiskPage() {
 		}
 	};
 
+	const findRouteById = (routesList: CoreRoutesList, targetRouteId: RouteId): CoreRoute | undefined => {
+		for (const coreRoutes of routesList) {
+			const foundRoute = coreRoutes.routes.find((route) => route.routeId === targetRouteId);
+			if (foundRoute) {
+				return foundRoute;
+			}
+		}
+		return undefined;
+	};
+
+	const checkTypeOfReportedData = () => {
+		const { routeId, cautionFactors, dangerFactors } = reportedData;
+		if ((routeId && cautionFactors.length > 0) || dangerFactors.length > 0)
+			return cautionFactors.length > 0 ? Markers.CAUTION : Markers.DANGER;
+		return null;
+	};
+
+	const moveToMarker = () => {
+		if (!map || !AdvancedMarker) return;
+		const { routeId } = reportedData;
+		const type = checkTypeOfReportedData();
+		if (type === null) return;
+		const route = findRouteById(routes.data, routeId!);
+		if (!route) return;
+		const node1 = route.node1;
+		const node2 = route.node2;
+		const reportedCoord = interpolate({ lat: node1.lat, lng: node1.lng }, { lat: node2.lat, lng: node2.lng }, 0.5);
+		map.setCenter(reportedCoord);
+		clearReportedRouteData();
+	};
+
 	useEffect(() => {
 		drawRoute(routes.data);
+		if (reportedData?.routeId) {
+			const foundRoute = findRouteById(routes.data, reportedData.routeId!);
+			if (!foundRoute) return;
+
+			queryClient.setQueryData(
+				[university.id, "risks"],
+				(prev: { dangerRoutes: CoreRoute[]; cautionRoutes: CoreRoute[] }) => {
+					let newDangerRoutes = prev.dangerRoutes;
+					let newCautionRoutes = prev.cautionRoutes;
+
+					if (reportedData.dangerFactors.length > 0) {
+						if (!newDangerRoutes.some((route) => route.routeId === foundRoute.routeId)) {
+							newDangerRoutes = [...newDangerRoutes, foundRoute];
+						}
+					} else {
+						newDangerRoutes = newDangerRoutes.filter((route) => route.routeId !== foundRoute.routeId);
+					}
+
+					if (reportedData.cautionFactors.length > 0) {
+						if (!newCautionRoutes.some((route) => route.routeId === foundRoute.routeId)) {
+							newCautionRoutes = [...newCautionRoutes, foundRoute];
+						}
+					} else {
+						newCautionRoutes = newCautionRoutes.filter((route) => route.routeId !== foundRoute.routeId);
+					}
+
+					return { dangerRoutes: newDangerRoutes, cautionRoutes: newCautionRoutes };
+				},
+			);
+		}
 		addRiskMarker();
 
 		if (map) {
-			map.setCenter(university.centerPoint);
+			if (reportedData) moveToMarker();
+			else map.setCenter(university.centerPoint);
+
 			map.addListener("click", () => {
 				setReportMarker((prevMarker) => {
 					if (prevMarker) {


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### 제보한 마커를 위한 store를 생성했습니다.
```typescript
import { create } from "zustand";
import { RouteId } from "../data/types/route";
import { CautionFactor, DangerFactor } from "../data/types/factor";

interface ReportedRiskResult {
	reportedData: {
		universityId: number | undefined;
		routeId: RouteId | undefined;
		cautionFactors: CautionFactor[];
		dangerFactors: DangerFactor[];
	};
	setReportedRouteData: (params: {
		universityId: number;
		routeId: RouteId;
		cautionFactors: CautionFactor[];
		dangerFactors: DangerFactor[];
	}) => void;
	clearReportedRouteData: () => void;
}

const useReportedRisk = create<ReportedRiskResult>((set) => ({
	reportedData: {
		universityId: undefined,
		routeId: undefined,
		reportedCoord: undefined,
		cautionFactors: [],
		dangerFactors: [],
	},
	setReportedRouteData: ({
		universityId,
		routeId,
		cautionFactors,
		dangerFactors,
	}: {
		universityId: number;
		routeId: RouteId;
		cautionFactors: CautionFactor[];
		dangerFactors: DangerFactor[];
	}) =>
		set((state) => ({
			reportedData: {
				...state.reportedData,
				universityId,
				routeId,
				cautionFactors,
				dangerFactors,
			},
		})),
	clearReportedRouteData: () => {
		set(() => ({
			reportedData: {
				universityId: undefined,
				routeId: undefined,
				reportedCoord: undefined,
				cautionFactors: [],
				dangerFactors: [],
			},
		}));
	},
}));

export default useReportedRisk;
```

이 스토어를 제보화면으로 돌아올 때, 넘겨주기 위해서 사용했습니다.

Form 등록시 다음과 같이 store에 정보를 넘겨줍니다.
```typescript
onSuccess: () => {
				setReportedRouteData({
					universityId: university!.id,
					routeId: routeId,
					dangerFactors: formData.dangerIssues,
					cautionFactors: formData.cautionIssues,
				});
				queryClient.removeQueries({ queryKey: [university?.id ?? 1001, "risks"] });
				openSuccess();
			},
```

다시 돌아온 후에, 존재여부를 확인하고, cache를 업데이트 합니다.
```typescript
if (reportedData?.routeId) {
			const foundRoute = findRouteById(routes.data, reportedData.routeId!);
			if (!foundRoute) return;

			queryClient.setQueryData(
				[university.id, "risks"],
				(prev: { dangerRoutes: CoreRoute[]; cautionRoutes: CoreRoute[] }) => {
					let newDangerRoutes = prev.dangerRoutes;
					let newCautionRoutes = prev.cautionRoutes;

					if (reportedData.dangerFactors.length > 0) {
						if (!newDangerRoutes.some((route) => route.routeId === foundRoute.routeId)) {
							newDangerRoutes = [...newDangerRoutes, foundRoute];
						}
					} else {
						newDangerRoutes = newDangerRoutes.filter((route) => route.routeId !== foundRoute.routeId);
					}

					if (reportedData.cautionFactors.length > 0) {
						if (!newCautionRoutes.some((route) => route.routeId === foundRoute.routeId)) {
							newCautionRoutes = [...newCautionRoutes, foundRoute];
						}
					} else {
						newCautionRoutes = newCautionRoutes.filter((route) => route.routeId !== foundRoute.routeId);
					}

					return { dangerRoutes: newDangerRoutes, cautionRoutes: newCautionRoutes };
				},
			);
		}
```

따로 함수로 빼려했으나 만드시고 계신 cache로직과 결합하기 쉽게 따로 하진 않았습니다.

이후 이동하는 메서드를 구현했습니다.
```typescript
if (map) {
			if (reportedData) moveToMarker();
			else map.setCenter(university.centerPoint);
```


#### moveToMarker
```typescript
	const moveToMarker = () => {
		if (!map || !AdvancedMarker) return;
		const { routeId } = reportedData;
		const route = findRouteById(routes.data, routeId!);
		if (!route) return;
		const node1 = route.node1;
		const node2 = route.node2;
		const reportedCoord = interpolate({ lat: node1.lat, lng: node1.lng }, { lat: node2.lat, lng: node2.lng }, 0.5);
		map.setCenter(reportedCoord);
		clearReportedRouteData();
	};
```

#### checkTypeOfReportedData
```typescript
const findRouteById = (routesList: CoreRoutesList, targetRouteId: RouteId): CoreRoute | undefined => {
		for (const coreRoutes of routesList) {
			const foundRoute = coreRoutes.routes.find((route) => route.routeId === targetRouteId);
			if (foundRoute) {
				return foundRoute;
			}
		}
		return undefined;
	};

```

checkTypeOfReportedData를 활용해, routeId로 routeCoord를 받아왔습니다.


## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과

### 뒤로가기 구현

https://github.com/user-attachments/assets/92898c1c-2d61-4e7b-bcff-d5ec72b777ea

### 찍은 위치로 이동 구현

https://github.com/user-attachments/assets/f77a5326-c728-4714-9443-c4bea5da5b85

## ✅ 반영 브랜치
fe
