### PR TITLE
[UNI-340] refactor : Google API 비동기 처리 최적화 & Google API 호출 최대 개수 조정

### DIFF
--- a/uniro_backend/Dockerfile
+++ b/uniro_backend/Dockerfile
@@ -8,5 +8,5 @@ COPY ${JAR_FILE} uniro-server.jar
 ENV SPRING_PROFILE=${SPRING_PROFILE}
 
 # JVM 메모리 설정 추가
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul","-Dspring.profiles.active=${SPRING_PROFILE}","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/tmp/heapdump.hprof","-jar", "uniro-server.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul","-Dspring.profiles.active=${SPRING_PROFILE}","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/tmp/heapdump.hprof", "-Xmx500m", "-jar", "uniro-server.jar"]
 

--- a/uniro_backend/build.gradle
+++ b/uniro_backend/build.gradle
@@ -88,6 +88,12 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 	implementation 'com.auth0:java-jwt:4.4.0'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate6'
+	implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.55'
 }
 
 tasks.named('test') {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -12,6 +12,7 @@ import com.softeer5.uniro_backend.building.repository.BuildingRepository;
 import com.softeer5.uniro_backend.common.exception.custom.AdminException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteException;
 import com.softeer5.uniro_backend.common.exception.custom.UnivException;
+import com.softeer5.uniro_backend.common.redis.RedisService;
 import com.softeer5.uniro_backend.map.dto.response.AllRoutesInfo;
 import com.softeer5.uniro_backend.map.dto.response.GetChangedRoutesByRevisionResDTO;
 import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;
@@ -44,6 +45,8 @@ public class AdminService {
     private final NodeAuditRepository nodeAuditRepository;
 
     private final RouteCalculator routeCalculator;
+
+    private final RedisService redisService;
 
     public List<RevInfoDTO> getAllRevInfo(Long univId){
         return revInfoRepository.findAllByUnivId(univId).stream().map(r -> RevInfoDTO.of(r.getRev(),
@@ -105,6 +108,7 @@ public class AdminService {
             }
         }
 
+        redisService.deleteData(univId.toString());
     }
 
     public GetAllRoutesByRevisionResDTO getAllRoutesByRevision(Long univId, Long versionId){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.admin.service;
 
+import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
 import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
 
 import com.softeer5.uniro_backend.admin.annotation.DisableAudit;
@@ -12,7 +13,7 @@ import com.softeer5.uniro_backend.building.repository.BuildingRepository;
 import com.softeer5.uniro_backend.common.exception.custom.AdminException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteException;
 import com.softeer5.uniro_backend.common.exception.custom.UnivException;
-import com.softeer5.uniro_backend.common.redis.RedisService;
+import com.softeer5.uniro_backend.external.redis.RedisService;
 import com.softeer5.uniro_backend.map.dto.response.AllRoutesInfo;
 import com.softeer5.uniro_backend.map.dto.response.GetChangedRoutesByRevisionResDTO;
 import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;
@@ -108,7 +109,8 @@ public class AdminService {
             }
         }
 
-        redisService.deleteData(univId.toString());
+        int routeCount = routes.size();
+        redisService.deleteRoutesData(univId.toString(), routeCount / STREAM_FETCH_SIZE + 1);
     }
 
     public GetAllRoutesByRevisionResDTO getAllRoutesByRevision(Long univId, Long versionId){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/service/BuildingService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/service/BuildingService.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import com.softeer5.uniro_backend.admin.annotation.RevisionOperation;
 import com.softeer5.uniro_backend.admin.enums.RevisionOperationType;
-import com.softeer5.uniro_backend.external.MapClient;
+import com.softeer5.uniro_backend.external.elevation.MapClient;
 import com.softeer5.uniro_backend.building.dto.request.CreateBuildingNodeReqDTO;
 import com.softeer5.uniro_backend.building.entity.Building;
 import com.softeer5.uniro_backend.map.entity.Node;
@@ -13,7 +13,6 @@ import com.softeer5.uniro_backend.map.repository.NodeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.softeer5.uniro_backend.common.CursorPage;
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.BuildingException;
 import com.softeer5.uniro_backend.common.utils.GeoUtils;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/RedisConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/RedisConfig.java
@@ -1,8 +1,7 @@
-package com.softeer5.uniro_backend.common.redis;
+package com.softeer5.uniro_backend.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/SchedulerConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/SchedulerConfig.java
@@ -1,0 +1,17 @@
+package com.softeer5.uniro_backend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
@@ -1,14 +1,29 @@
 package com.softeer5.uniro_backend.common.config;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring6.http.converter.FastJsonHttpMessageConverter;
 import com.softeer5.uniro_backend.admin.interceptor.AdminInterceptor;
 import com.softeer5.uniro_backend.admin.interceptor.JwtInterceptor;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Configuration
+@EnableWebMvc
+@Slf4j
 public class WebMvcConfig implements WebMvcConfigurer {
 	private final AdminInterceptor adminInterceptor;
 	private final JwtInterceptor jwtInterceptor; // JWT 인터셉터 추가
@@ -16,6 +31,27 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	public WebMvcConfig(AdminInterceptor adminInterceptor, JwtInterceptor jwtInterceptor) {
 		this.adminInterceptor = adminInterceptor;
 		this.jwtInterceptor = jwtInterceptor;
+	}
+
+	@Override
+	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+		FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+		//custom configuration...
+		FastJsonConfig config = new FastJsonConfig();
+		config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+		config.setReaderFeatures(JSONReader.Feature.FieldBased, JSONReader.Feature.SupportArrayToBean);
+		config.setWriterFeatures(JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.PrettyFormat);
+		converter.setFastJsonConfig(config);
+		converter.setDefaultCharset(StandardCharsets.UTF_8);
+
+		converter.setSupportedMediaTypes(List.of(
+			MediaType.APPLICATION_JSON, // application/json 지원
+			new MediaType("application", "json", StandardCharsets.UTF_8),
+			new MediaType("application", "openmetrics-text", StandardCharsets.UTF_8)
+		));
+
+		converters.add(0, converter);
+		converters.forEach(c -> log.info("✔ {}", c.getClass().getName()));
 	}
 
 	@Override

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
@@ -33,26 +33,26 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		this.jwtInterceptor = jwtInterceptor;
 	}
 
-	@Override
-	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-		FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
-		//custom configuration...
-		FastJsonConfig config = new FastJsonConfig();
-		config.setDateFormat("yyyy-MM-dd HH:mm:ss");
-		config.setReaderFeatures(JSONReader.Feature.FieldBased, JSONReader.Feature.SupportArrayToBean);
-		config.setWriterFeatures(JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.PrettyFormat);
-		converter.setFastJsonConfig(config);
-		converter.setDefaultCharset(StandardCharsets.UTF_8);
-
-		converter.setSupportedMediaTypes(List.of(
-			MediaType.APPLICATION_JSON, // application/json 지원
-			new MediaType("application", "json", StandardCharsets.UTF_8),
-			new MediaType("application", "openmetrics-text", StandardCharsets.UTF_8)
-		));
-
-		converters.add(0, converter);
-		converters.forEach(c -> log.info("✔ {}", c.getClass().getName()));
-	}
+	// @Override
+	// public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+	// 	FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+	// 	//custom configuration...
+	// 	FastJsonConfig config = new FastJsonConfig();
+	// 	config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+	// 	config.setReaderFeatures(JSONReader.Feature.FieldBased, JSONReader.Feature.SupportArrayToBean);
+	// 	config.setWriterFeatures(JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.PrettyFormat);
+	// 	converter.setFastJsonConfig(config);
+	// 	converter.setDefaultCharset(StandardCharsets.UTF_8);
+	//
+	// 	converter.setSupportedMediaTypes(List.of(
+	// 		MediaType.APPLICATION_JSON, // application/json 지원
+	// 		new MediaType("application", "json", StandardCharsets.UTF_8),
+	// 		new MediaType("application", "openmetrics-text", StandardCharsets.UTF_8)
+	// 	));
+	//
+	// 	converters.add(0, converter);
+	// 	converters.forEach(c -> log.info("✔ {}", c.getClass().getName()));
+	// }
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -12,7 +12,8 @@ public final class UniroConst {
 	public static final int IS_SINGLE_ROUTE = 2;
 	public static final double HEURISTIC_WEIGHT_NORMALIZATION_FACTOR = 10.0;
 	public static final int STREAM_FETCH_SIZE = 2500;
-
 	//컴파일 상수를 보장하기 위한 코드
 	public static final String STREAM_FETCH_SIZE_AS_STRING = "" + STREAM_FETCH_SIZE;
+
+	public static final int CREATE_ROUTE_LIMIT_COUNT = 2000;
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     ROUTE_NOT_FOUND(404, "루트를 찾을 수 없습니다."),
     CAUTION_DANGER_CANT_EXIST_SIMULTANEOUSLY(400, "위험요소와 주의요소는 동시에 존재할 수 없습니다."),
     INVALID_MAP(500,"현재 지도 데이터가 제약조건에 어긋난 상태입니다."),
+    CREATE_ROUTE_LIMIT_EXCEEDED(400, "길 추가 최대 길이를 초과하였습니다."),
 
     //길 생성
     ELEVATION_API_ERROR(500, "구글 해발고도 API에서 오류가 발생했습니다."),
@@ -34,6 +35,9 @@ public enum ErrorCode {
     // 경로 계산
     INTERSECTION_ONLY_ALLOWED_POINT(400, "기존 경로와 겹칠 수 없습니다."),
 
+    // 대학
+    UNIV_NOT_FOUND(404, "대학을 찾을 수 없습니다."),
+
     // 어드민
     ALREADY_LATEST_VERSION_ID(400, "현재 가장 최신 버전 id 입니다."),
     INVALID_VERSION_ID(400, "유효하지 않은 버전 id 입니다."),
@@ -42,6 +46,7 @@ public enum ErrorCode {
     UNAUTHORIZED_UNIV(401, "해당 대학교의 권한이 없습니다."),
     INVALID_UNIV_ID(400, "유효하지 않은 대학교 id 입니다."),
     RECENT_REVISION_NOT_FOUND(404, "최신 버전을 찾을 수 없습니다."),
+    CANT_ROLLBACK_BELOW_MINIMUM_VERSION(400, "롤백하려는 버전이 허용된 최소 버전보다 낮습니다.")
     ;
 
     private final int httpStatus;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -27,7 +27,7 @@ public class ExecutionLoggingAop {
 	private static final ThreadLocal<String> userIdThreadLocal = new ThreadLocal<>();
 
 	@Around("execution(* com.softeer5.uniro_backend..*(..)) "
-		+ "&& !within(com.softeer5.uniro_backend.common..*) "
+		+ "&& !within(com.softeer5.uniro_backend.common..*)"
 	)
 	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
 		String userId = userIdThreadLocal.get();
@@ -46,7 +46,14 @@ public class ExecutionLoggingAop {
 		if (isController) {
 			logHttpRequest(userId);
 		}
-		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+		HttpServletRequest request = null;
+		if (RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes) {
+			request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+		}
+
+		if(request==null){
+			return pjp.proceed();
+		}
 		log.info("✅ [ userId = {} Start] [Call Method] {}: {}", userId, request.getMethod(), task);
 
 		try{

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/redis/RedisConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/redis/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.softeer5.uniro_backend.common.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.alibaba.fastjson2.support.spring6.data.redis.FastJsonRedisSerializer;
+import com.softeer5.uniro_backend.map.service.vo.LightRoutes;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// 키는 String, 값은 FastJson으로 변환된 JSON 문자열 저장
+		StringRedisSerializer serializer = new StringRedisSerializer();
+		FastJsonRedisSerializer<LightRoutes> fastJsonRedisSerializer = new FastJsonRedisSerializer<>(LightRoutes.class);
+
+		template.setKeySerializer(serializer);
+		template.setValueSerializer(fastJsonRedisSerializer);
+
+		return template;
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/redis/RedisService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/redis/RedisService.java
@@ -1,0 +1,52 @@
+package com.softeer5.uniro_backend.common.redis;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisService {
+
+	private final RedisTemplate redisTemplate;
+	private final Map<String, Boolean> cacheMap = new HashMap<>();
+
+	public void saveData(String key, Object value) {
+		long startTime = System.nanoTime();
+		redisTemplate.opsForValue().set(key, value, Duration.ofMinutes(1000)); // 10분 TTL
+		long endTime = System.nanoTime();
+
+		long duration = TimeUnit.NANOSECONDS.toMicros(endTime - startTime);
+		log.info("🔴🔴🔴🔴🔴🔴🔴 Redis 직렬화 및 저장 시간: {} 마이크로초", duration);
+
+		cacheMap.put(key, true);
+	}
+
+	public Object getData(String key) {
+		long startTime = System.nanoTime();
+		Object data = redisTemplate.opsForValue().get(key);
+		long endTime = System.nanoTime();
+
+		long duration = TimeUnit.NANOSECONDS.toMicros(endTime - startTime);
+		log.info("🟢🟢🟢🟢🟢🟢🟢 Redis 역직렬화 및 조회 시간: {} 마이크로초", duration);
+		cacheMap.put(key, true);
+		return data;
+	}
+
+	public boolean hasData(String key){
+		return cacheMap.containsKey(key);
+	}
+
+	public void deleteData(String key) {
+		redisTemplate.delete(key);
+		cacheMap.remove(key);
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClient.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClient.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.external;
+package com.softeer5.uniro_backend.external.elevation;
 
 import com.softeer5.uniro_backend.map.entity.Node;
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClientImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClientImpl.java
@@ -45,13 +45,7 @@ public class MapClientImpl implements MapClient{
 
     @Override
     public void fetchHeights(List<Node> nodes) {
-        List<Node> nodesWithoutHeight = nodes.stream()
-                .filter(node -> node.getId() == null)
-                .toList();
-
-        if(nodesWithoutHeight.isEmpty()) return;
-
-        List<List<Node>> partitions = partitionNodes(nodesWithoutHeight, MAX_BATCH_SIZE);
+        List<List<Node>> partitions = partitionNodes(nodes, MAX_BATCH_SIZE);
 
         List<Mono<Void>> apiCalls = partitions.stream()
                 .map(batch -> fetchElevationAsync(batch)

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClientImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClientImpl.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.external;
+package com.softeer5.uniro_backend.external.elevation;
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteCreatedEvent.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteCreatedEvent.java
@@ -1,0 +1,5 @@
+package com.softeer5.uniro_backend.external.event;
+
+public record RouteCreatedEvent() {
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventListener.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventListener.java
@@ -1,0 +1,46 @@
+package com.softeer5.uniro_backend.external.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@Component
+public class RouteEventListener {
+    private final TaskScheduler taskScheduler;
+    private final RouteEventService routeEventService;
+    private final AtomicBoolean isScheduled = new AtomicBoolean(false);
+
+    public RouteEventListener(TaskScheduler taskScheduler, RouteEventService routeEventService) {
+        this.taskScheduler = taskScheduler;
+        this.routeEventService = routeEventService;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleRouteCreatedEvent(RouteCreatedEvent event) {
+        log.info("Routes Created Event Listen");
+
+        // 이미 스케쥴링되고있는지 판단
+        if(isScheduled.compareAndSet(false, true)) {
+            Date scheduledTime = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(30));
+
+            taskScheduler.schedule(() -> {
+                try {
+                    routeEventService.fetchHeight();
+                } finally {
+                    isScheduled.set(false);
+                }
+            }, scheduledTime.toInstant());
+
+        }
+
+    }
+
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
@@ -1,0 +1,32 @@
+package com.softeer5.uniro_backend.external.event;
+
+import com.softeer5.uniro_backend.admin.annotation.DisableAudit;
+import com.softeer5.uniro_backend.external.elevation.MapClient;
+import com.softeer5.uniro_backend.map.entity.Node;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
+import com.softeer5.uniro_backend.map.repository.NodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class RouteEventService {
+    private final MapClient mapClient;
+    private final NodeRepository nodeRepository;
+
+    @DisableAudit
+    public void fetchHeight(){
+        List<Node> readyNodes = nodeRepository.findAllByStatus(HeightStatus.READY);
+        mapClient.fetchHeights(readyNodes);
+        setStatus(readyNodes,HeightStatus.DONE);
+    }
+
+    private void setStatus(List<Node> readyNodes, HeightStatus heightStatus) {
+        readyNodes.forEach(readyNode -> readyNode.setStatus(heightStatus));
+    }
+
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/redis/RedisService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/redis/RedisService.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.common.redis;
+package com.softeer5.uniro_backend.external.redis;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -47,6 +47,15 @@ public class RedisService {
 
 	public void deleteData(String key) {
 		redisTemplate.delete(key);
+		cacheMap.remove(key);
+	}
+
+	public void deleteRoutesData(String key, int batchNumber) {
+		String redisKeyPrefix = key + ":";
+
+		for(int i=1; i<=batchNumber; i++){
+			redisTemplate.delete(redisKeyPrefix + i);
+		}
 		cacheMap.remove(key);
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapApi.java
@@ -67,7 +67,7 @@ public interface MapApi {
 			@ApiResponse(responseCode = "201", description = "길 추가 성공"),
 			@ApiResponse(responseCode = "400", description = "EXCEPTION(임시)", content = @Content),
 	})
-	ResponseEntity<Void> createRoute (@PathVariable("univId") Long univId,
+	ResponseEntity<AllRoutesInfo> createRoute (@PathVariable("univId") Long univId,
 									  @RequestBody CreateRoutesReqDTO routes);
 
 	@Operation(summary = "빠른 길 계산")

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
@@ -66,10 +66,10 @@ public class MapController implements MapApi {
 
 	@Override
 	@PostMapping("/{univId}/route")
-	public ResponseEntity<Void> createRoute (@PathVariable("univId") Long univId,
+	public ResponseEntity<AllRoutesInfo> createRoute (@PathVariable("univId") Long univId,
 											 @RequestBody @Valid CreateRoutesReqDTO routes){
-		mapService.createRoute(univId, routes);
-		return ResponseEntity.status(HttpStatus.CREATED).build();
+		AllRoutesInfo createdRoutes = mapService.createRoute(univId, routes);
+		return ResponseEntity.ok().body(createdRoutes);
 	}
 
 	@Override

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/controller/MapController.java
@@ -25,6 +25,12 @@ public class MapController implements MapApi {
 	private final MapService mapService;
 	private final AdminService adminService;
 
+	@GetMapping("/{univId}/routes-local")
+	public ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodesByLocalCache(@PathVariable("univId") Long univId){
+		GetAllRoutesResDTO allRoutes = mapService.getAllRoutesByLocalCache(univId);
+		return ResponseEntity.ok().body(allRoutes);
+	}
+
 	@Override
 	@GetMapping("/{univId}/routes")
 	public ResponseEntity<GetAllRoutesResDTO> getAllRoutesAndNodes(@PathVariable("univId") Long univId){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/AllRoutesInfo.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/AllRoutesInfo.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -18,6 +19,9 @@ public class AllRoutesInfo {
     private final List<CoreRouteResDTO> coreRoutes;
     @Schema(description = "빌딩 루트 정보 (id, startNodeId, endNodeId)", example = "")
     private final List<BuildingRouteResDTO> buildingRoutes;
+    @Setter
+    @Schema(description = "배치 사이즈", example = "1")
+    private int batchSize = 1;
 
     public static AllRoutesInfo of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
                                         List<BuildingRouteResDTO> buildingRoutes) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/FastestRouteResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/FastestRouteResDTO.java
@@ -14,8 +14,10 @@ import java.util.List;
 public class FastestRouteResDTO {
     @Schema(description = "길찾기 타입 (PEDES-도보, WHEEL_FAST-휠체어빠른, WHEEL_SAFE-휠체어안전)", example = "PEDES")
     private final RoadExclusionPolicy routeType;
-    @Schema(description = "길 찾기 결과에 위험요소가 포함되어있는지 여부", example = "true")
+    @Schema(description = "길 찾기 결과에 주의요소가 포함되어있는지 여부", example = "true")
     private final boolean hasCaution;
+    @Schema(description = "길 찾기 결과에 위험요소가 포함되어있는지 여부", example = "true")
+    private final boolean hasDanger;
     @Schema(description = "총 이동거리", example = "150.3421234")
     private final double totalDistance;
     @Schema(description = "총 걸리는 시간(초) - 도보", example = "1050.32198432")
@@ -31,6 +33,7 @@ public class FastestRouteResDTO {
 
     public static FastestRouteResDTO of(RoadExclusionPolicy routeType,
                                         boolean hasCaution,
+                                        boolean hasDanger,
                                         double totalDistance,
                                         Double pedestrianTotalCost,
                                         Double manualTotalCost,
@@ -39,6 +42,7 @@ public class FastestRouteResDTO {
                                         List<RouteDetailResDTO> routeDetails) {
         return new FastestRouteResDTO(routeType,
                 hasCaution,
+                hasDanger,
                 totalDistance,
                 pedestrianTotalCost,
                 manualTotalCost,

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetAllRoutesResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/GetAllRoutesResDTO.java
@@ -12,17 +12,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetAllRoutesResDTO {
 
-	@Schema(description = "노드 정보 (id, 좌표)", example = "")
-	private final List<NodeInfoResDTO> nodeInfos;
-	@Schema(description = "루트 정보 (id, startNodeId, endNodeId)", example = "")
-	private final List<CoreRouteResDTO> coreRoutes;
-	@Schema(description = "빌딩 루트 정보 (id, startNodeId, endNodeId)", example = "")
-	private final List<BuildingRouteResDTO> buildingRoutes;
-	@Schema(description = "버전 id", example = "230")
-	private final Long versionId;
+    @Schema(description = "노드 정보 (id, 좌표)", example = "")
+    private final List<NodeInfoResDTO> nodeInfos;
+    @Schema(description = "루트 정보 (id, startNodeId, endNodeId)", example = "")
+    private final List<CoreRouteResDTO> coreRoutes;
+    @Schema(description = "빌딩 루트 정보 (id, startNodeId, endNodeId)", example = "")
+    private final List<BuildingRouteResDTO> buildingRoutes;
+    @Schema(description = "버전 id", example = "230")
+    private final Long versionId;
 
-	public static GetAllRoutesResDTO of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
-		List<BuildingRouteResDTO> buildingRoutes, Long versionId) {
-		return new GetAllRoutesResDTO(nodeInfos, coreRoutes, buildingRoutes, versionId);
-	}
+    public static GetAllRoutesResDTO of(List<NodeInfoResDTO> nodeInfos, List<CoreRouteResDTO> coreRoutes,
+                                        List<BuildingRouteResDTO> buildingRoutes, Long versionId) {
+        return new GetAllRoutesResDTO(nodeInfos, coreRoutes, buildingRoutes, versionId);
+    }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/RouteDetailResDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/response/RouteDetailResDTO.java
@@ -1,6 +1,7 @@
 package com.softeer5.uniro_backend.map.dto.response;
 
 import com.softeer5.uniro_backend.map.enums.CautionFactor;
+import com.softeer5.uniro_backend.map.enums.DangerFactor;
 import com.softeer5.uniro_backend.map.enums.DirectionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -22,10 +23,13 @@ public class RouteDetailResDTO {
     private final Map<String, Double> coordinates;
     @Schema(description = "주의 요소 타입 리스트", example = "[\"SLOPE\", \"STAIRS\"]")
     private final List<CautionFactor> cautionFactors;
+    @Schema(description = "위험 요소 타입 리스트", example = "[\"SLOPE\", \"STAIRS\"]")
+    private final List<DangerFactor> dangerFactors;
 
     public static RouteDetailResDTO of(double dist, DirectionType directionType,
                                        Map<String, Double> coordinates,
-                                       List<CautionFactor> cautionFactors) {
-        return new RouteDetailResDTO(dist, directionType, coordinates, cautionFactors);
+                                       List<CautionFactor> cautionFactors,
+                                       List<DangerFactor> dangerFactors) {
+        return new RouteDetailResDTO(dist, directionType, coordinates, cautionFactors, dangerFactors);
     }
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Node.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Node.java
@@ -6,18 +6,14 @@ import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
 import java.time.LocalDateTime;
 import java.util.Map;
 
-import jakarta.persistence.EntityListeners;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.envers.Audited;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 
 @Entity
@@ -47,6 +43,10 @@ public class Node {
 	@CreatedDate
 	private LocalDateTime createdAt;
 
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private HeightStatus status;
+
 	public Map<String, Double> getXY(){
 		return Map.of("lat", coordinates.getY(), "lng", coordinates.getX());
 	}
@@ -61,6 +61,10 @@ public class Node {
 
 	public void setHeight(double height) {
 		this.height = height;
+	}
+
+	public void setStatus(HeightStatus status) {
+		this.status = status;
 	}
 
 	public void setCoordinates(Point coordinates) {
@@ -79,10 +83,11 @@ public class Node {
 	}
 
 	@Builder
-	private Node(Point coordinates, double height, boolean isCore, Long univId) {
+	private Node(Point coordinates, double height, boolean isCore, Long univId, HeightStatus status) {
 		this.coordinates = coordinates;
 		this.height = height;
 		this.isCore = isCore;
 		this.univId = univId;
+		this.status = status;
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/enums/DirectionType.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/enums/DirectionType.java
@@ -7,5 +7,6 @@ public enum DirectionType {
     SHARP_RIGHT, // 큰 우회전
     SHARP_LEFT, // 큰 좌회전
     FINISH, // 도착점
-    CAUTION; //위험요소
+    CAUTION, // 주의요소
+    DANGER; // 위험요소
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/enums/HeightStatus.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/enums/HeightStatus.java
@@ -1,0 +1,7 @@
+package com.softeer5.uniro_backend.map.enums;
+
+public enum HeightStatus {
+    READY,
+    PROGRESS,
+    DONE
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
@@ -1,6 +1,7 @@
 package com.softeer5.uniro_backend.map.repository;
 
 import com.softeer5.uniro_backend.map.entity.Node;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,6 @@ public interface NodeRepository extends JpaRepository<Node, Long> {
     void deleteAllByCreatedAt(Long univId, LocalDateTime versionTimeStamp);
 
     List<Node> findAllByUnivId(Long univId);
+
+    List<Node> findAllByStatus(HeightStatus status);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.softeer5.uniro_backend.map.entity.Route;
+import com.softeer5.uniro_backend.map.service.vo.LightRoute;
 
 import static com.softeer5.uniro_backend.common.constant.UniroConst.STREAM_FETCH_SIZE_AS_STRING;
 
@@ -24,6 +25,17 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     @Query("SELECT r FROM Route r WHERE r.univId = :univId")
     @QueryHints(@QueryHint(name = "org.hibernate.fetchSize", value = STREAM_FETCH_SIZE_AS_STRING))
     Stream<Route> findAllRouteByUnivIdWithNodesStream(Long univId);
+
+    @Query("""
+    SELECT new com.softeer5.uniro_backend.map.service.vo.LightRoute(r.id, r.distance, n1, n2) 
+    FROM Route r 
+    JOIN r.node1 n1 
+    JOIN r.node2 n2
+    WHERE r.univId = :univId
+""")
+    @QueryHints(@QueryHint(name = "org.hibernate.fetchSize", value = STREAM_FETCH_SIZE_AS_STRING))
+    Stream<LightRoute> findAllLightRoutesByUnivId(Long univId);
+
 
     @Query(value = "SELECT r.* FROM route r " +
             "WHERE r.univ_id = :univId " +

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
@@ -81,4 +81,5 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
             """)
     int countByUnivIdAndNodeId(Long univId, Long nodeId);
 
+    int countByUnivId(Long univId);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -206,6 +206,10 @@ public class MapService {
 	@RevisionOperation(RevisionOperationType.CREATE_ROUTE)
 	synchronized public AllRoutesInfo createRoute(Long univId, CreateRoutesReqDTO requests){
 
+		if(requests.getCoordinates().size() >= CREATE_ROUTE_LIMIT_COUNT){
+			throw new RouteException("creat route limit exceeded", CREATE_ROUTE_LIMIT_EXCEEDED);
+		}
+
 		List<Route> savedRoutes = routeRepository.findAllRouteByUnivIdWithNodes(univId);
 
 		List<Node> nodesForSave = routeCalculator.createValidRouteNodes(univId, requests.getStartNodeId(),

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -64,12 +64,12 @@ public class MapService {
 		}
 
 		RevInfo revInfo = revInfoRepository.findFirstByUnivIdOrderByRevDesc(univId)
-			.orElseThrow(() -> new RouteException("Revision not found", RECENT_REVISION_NOT_FOUND));
+				.orElseThrow(() -> new RouteException("Revision not found", RECENT_REVISION_NOT_FOUND));
 
 		AllRoutesInfo allRoutesInfo = routeCalculator.assembleRoutes(routes);
 
 		return GetAllRoutesResDTO.of(allRoutesInfo.getNodeInfos(), allRoutesInfo.getCoreRoutes(),
-			allRoutesInfo.getBuildingRoutes(), revInfo.getRev());
+				allRoutesInfo.getBuildingRoutes(), revInfo.getRev());
 	}
 
 	@Async
@@ -200,7 +200,7 @@ public class MapService {
 
 	@Transactional
 	@RevisionOperation(RevisionOperationType.CREATE_ROUTE)
-	synchronized public void createRoute(Long univId, CreateRoutesReqDTO requests){
+	synchronized public AllRoutesInfo createRoute(Long univId, CreateRoutesReqDTO requests){
 
 		List<Route> savedRoutes = routeRepository.findAllRouteByUnivIdWithNodes(univId);
 
@@ -214,5 +214,7 @@ public class MapService {
 
 		nodeRepository.saveAll(nodesForSave);
 		routeRepository.saveAll(routes);
+
+		return routeCalculator.assembleRoutes(routes);
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCacheCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCacheCalculator.java
@@ -32,6 +32,7 @@ public class RouteCacheCalculator {
 		Map<Long, List<LightRoute>> adjMap = new HashMap<>();
 		Map<Long, LightNode> nodeMap = new HashMap<>();
 		List<BuildingRouteResDTO> buildingRoutes = new ArrayList<>();
+		List<LightNode> buildingNodes = new ArrayList<>();
 
 		for (LightRoute route : routes) {
 
@@ -39,6 +40,8 @@ public class RouteCacheCalculator {
 				List<RouteCoordinatesInfoResDTO> routeCoordinates = new ArrayList<>();
 				routeCoordinates.add(RouteCoordinatesInfoResDTO.of(route.getId(), route.getNode1().getId(), route.getNode2().getId()));
 				buildingRoutes.add(BuildingRouteResDTO.of(route.getNode1().getId(), route.getNode2().getId(), routeCoordinates));
+				buildingNodes.add(route.getNode1());
+				buildingNodes.add(route.getNode2());
 				continue;
 			}
 
@@ -50,13 +53,25 @@ public class RouteCacheCalculator {
 
 		}
 
-		List<NodeInfoResDTO> nodeInfos = nodeMap.entrySet().stream()
-			.map(entry -> NodeInfoResDTO.of(entry.getKey(), entry.getValue().getLng(), entry.getValue().getLat()))
-			.toList();
+//		List<NodeInfoResDTO> nodeInfos = nodeMap.entrySet().stream()
+//				.map(entry -> NodeInfoResDTO.of(entry.getKey(), entry.getValue().getLng(), entry.getValue().getLat()))
+//				.toList();
+
+		List<NodeInfoResDTO> nodeInfos = new ArrayList<>();
+
+		for(LightNode node : nodeMap.values()) {
+			nodeInfos.add(NodeInfoResDTO.of(node.getId(), node.getLng(), node.getLat()));
+		}
 
 		List<LightNode>startNode = determineStartNodes(adjMap, nodeMap);
 
-		return AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, startNode), buildingRoutes);
+		AllRoutesInfo result = AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, startNode), buildingRoutes);
+
+		for(LightNode node : buildingNodes) {
+			nodeInfos.add(NodeInfoResDTO.of(node.getId(), node.getLng(), node.getLat()));
+		}
+
+		return result;
 	}
 
 	private boolean isBuildingRoute(LightRoute route){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCacheCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCacheCalculator.java
@@ -1,0 +1,131 @@
+package com.softeer5.uniro_backend.map.service;
+
+import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.stereotype.Component;
+
+import com.softeer5.uniro_backend.common.utils.GeoUtils;
+import com.softeer5.uniro_backend.map.dto.response.AllRoutesInfo;
+import com.softeer5.uniro_backend.map.dto.response.BuildingRouteResDTO;
+import com.softeer5.uniro_backend.map.dto.response.CoreRouteResDTO;
+import com.softeer5.uniro_backend.map.dto.response.NodeInfoResDTO;
+import com.softeer5.uniro_backend.map.dto.response.RouteCoordinatesInfoResDTO;
+import com.softeer5.uniro_backend.map.service.vo.LightNode;
+import com.softeer5.uniro_backend.map.service.vo.LightRoute;
+
+@Component
+public class RouteCacheCalculator {
+
+	private final GeometryFactory geometryFactory = GeoUtils.getInstance();
+
+	public AllRoutesInfo assembleRoutes(List<LightRoute> routes) {
+		Map<Long, List<LightRoute>> adjMap = new HashMap<>();
+		Map<Long, LightNode> nodeMap = new HashMap<>();
+		List<BuildingRouteResDTO> buildingRoutes = new ArrayList<>();
+
+		for (LightRoute route : routes) {
+
+			if (isBuildingRoute(route)) {
+				List<RouteCoordinatesInfoResDTO> routeCoordinates = new ArrayList<>();
+				routeCoordinates.add(RouteCoordinatesInfoResDTO.of(route.getId(), route.getNode1().getId(), route.getNode2().getId()));
+				buildingRoutes.add(BuildingRouteResDTO.of(route.getNode1().getId(), route.getNode2().getId(), routeCoordinates));
+				continue;
+			}
+
+			nodeMap.put(route.getNode1().getId(), route.getNode1());
+			nodeMap.put(route.getNode2().getId(), route.getNode2());
+
+			adjMap.computeIfAbsent(route.getNode1().getId(), k -> new ArrayList<>()).add(route);
+			adjMap.computeIfAbsent(route.getNode2().getId(), k -> new ArrayList<>()).add(route);
+
+		}
+
+		List<NodeInfoResDTO> nodeInfos = nodeMap.entrySet().stream()
+			.map(entry -> NodeInfoResDTO.of(entry.getKey(), entry.getValue().getLng(), entry.getValue().getLat()))
+			.toList();
+
+		List<LightNode>startNode = determineStartNodes(adjMap, nodeMap);
+
+		return AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, startNode), buildingRoutes);
+	}
+
+	private boolean isBuildingRoute(LightRoute route){
+		return route.getDistance() > BUILDING_ROUTE_DISTANCE - 1;
+	}
+
+	private List<LightNode> determineStartNodes(Map<Long, List<LightRoute>> adjMap,
+		Map<Long, LightNode> nodeMap) {
+		return nodeMap.values().stream()
+			.filter(node -> node.isCore()
+				|| (adjMap.containsKey(node.getId()) && adjMap.get(node.getId()).size() == 1))
+			.toList();
+	}
+
+	private List<CoreRouteResDTO> getCoreRoutes(Map<Long, List<LightRoute>> adjMap, List<LightNode> startNode) {
+		List<CoreRouteResDTO> result = new ArrayList<>();
+		// core node간의 BFS 할 때 방문여부를 체크하는 set
+		Set<Long> visitedCoreNodes = new HashSet<>();
+		// 길 중복을 처리하기 위한 set
+		Set<Long> routeSet = new HashSet<>();
+
+		// BFS 전처리
+		Queue<LightNode> nodeQueue = new LinkedList<>();
+		startNode.forEach(n-> {
+			nodeQueue.add(n);
+			visitedCoreNodes.add(n.getId());
+		});
+
+		// BFS
+		while(!nodeQueue.isEmpty()) {
+			// 현재 노드 (코어노드)
+			LightNode now = nodeQueue.poll();
+			for(LightRoute r : adjMap.get(now.getId())) {
+				// 만약 now-nxt를 연결하는 길이 이미 등록되어있다면, 해당 coreRoute는 이미 등록된 것이므로 continue;
+				if(routeSet.contains(r.getId())) continue;
+
+				// 다음 노드 (서브노드일수도 있고 코어노드일 수도 있음)
+				LightNode currentNode = now.getId() == r.getNode1().getId() ? r.getNode2() : r.getNode1();
+
+				// 코어루트를 이루는 node들을 List로 저장
+				List<RouteCoordinatesInfoResDTO> coreRoute = new ArrayList<>();
+				coreRoute.add(RouteCoordinatesInfoResDTO.of(r.getId(),now.getId(), currentNode.getId()));
+				routeSet.add(r.getId());
+
+				while (true) {
+					//코어노드를 만나면 queue에 넣을지 판단한 뒤 종료 (제자리로 돌아오는 경우도 포함)
+					if (currentNode.isCore() || currentNode.getId() == now.getId()) {
+						if (!visitedCoreNodes.contains(currentNode.getId())) {
+							visitedCoreNodes.add(currentNode.getId());
+							nodeQueue.add(currentNode);
+						}
+						break;
+					}
+					// 끝점인 경우 종료
+					if (adjMap.get(currentNode.getId()).size() == 1) break;
+
+					// 서브노드에 연결된 두 route 중 방문하지 않았던 route를 선택한 뒤, currentNode를 업데이트
+					for (LightRoute R : adjMap.get(currentNode.getId())) {
+						if (routeSet.contains(R.getId())) continue;
+						LightNode nextNode = R.getNode1().getId() == currentNode.getId() ? R.getNode2() : R.getNode1();
+						coreRoute.add(RouteCoordinatesInfoResDTO.of(R.getId(), currentNode.getId(), nextNode.getId()));
+						routeSet.add(R.getId());
+						currentNode = nextNode;
+					}
+				}
+				result.add(CoreRouteResDTO.of(now.getId(), currentNode.getId(), coreRoute));
+			}
+
+		}
+		return result;
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -16,6 +16,7 @@ import com.softeer5.uniro_backend.map.enums.CautionFactor;
 import com.softeer5.uniro_backend.map.enums.DangerFactor;
 import com.softeer5.uniro_backend.map.enums.DirectionType;
 import com.softeer5.uniro_backend.map.entity.Route;
+import com.softeer5.uniro_backend.map.service.vo.LightNode;
 import lombok.AllArgsConstructor;
 
 import org.locationtech.jts.geom.Coordinate;
@@ -54,6 +55,7 @@ public class RouteCalculator {
         Map<Long, List<Route>> adjMap = new HashMap<>();
         Map<Long, Node> nodeMap = new HashMap<>();
         List<BuildingRouteResDTO> buildingRoutes = new ArrayList<>();
+        List<Node> buildingNodes = new ArrayList<>();
 
         for (Route route : routes) {
 
@@ -61,6 +63,8 @@ public class RouteCalculator {
                 List<RouteCoordinatesInfoResDTO> routeCoordinates = new ArrayList<>();
                 routeCoordinates.add(RouteCoordinatesInfoResDTO.of(route.getId(), route.getNode1().getId(), route.getNode2().getId()));
                 buildingRoutes.add(BuildingRouteResDTO.of(route.getNode1().getId(), route.getNode2().getId(), routeCoordinates));
+                buildingNodes.add(route.getNode1());
+                buildingNodes.add(route.getNode2());
                 continue;
             }
 
@@ -72,13 +76,25 @@ public class RouteCalculator {
 
         }
 
-        List<NodeInfoResDTO> nodeInfos = nodeMap.entrySet().stream()
-                .map(entry -> NodeInfoResDTO.of(entry.getKey(), entry.getValue().getX(), entry.getValue().getY()))
-                .toList();
+//        List<NodeInfoResDTO> nodeInfos = nodeMap.entrySet().stream()
+//                .map(entry -> NodeInfoResDTO.of(entry.getKey(), entry.getValue().getX(), entry.getValue().getY()))
+//                .toList();
+
+        List<NodeInfoResDTO> nodeInfos = new ArrayList<>();
+
+        for(Node node : nodeMap.values()) {
+            nodeInfos.add(NodeInfoResDTO.of(node.getId(), node.getX(), node.getY()));
+        }
 
         List<Node>startNode = determineStartNodes(adjMap, nodeMap);
 
-        return AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, startNode), buildingRoutes);
+        AllRoutesInfo result = AllRoutesInfo.of(nodeInfos, getCoreRoutes(adjMap, startNode), buildingRoutes);
+
+        for(Node node : buildingNodes) {
+            nodeInfos.add(NodeInfoResDTO.of(node.getId(), node.getX(), node.getY()));
+        }
+
+        return result;
     }
 
     private List<Node> determineStartNodes(Map<Long, List<Route>> adjMap,

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -13,6 +13,7 @@ import com.softeer5.uniro_backend.map.dto.response.*;
 import com.softeer5.uniro_backend.map.entity.*;
 import com.softeer5.uniro_backend.map.dto.request.CreateRouteReqDTO;
 import com.softeer5.uniro_backend.map.enums.CautionFactor;
+import com.softeer5.uniro_backend.map.enums.DangerFactor;
 import com.softeer5.uniro_backend.map.enums.DirectionType;
 import com.softeer5.uniro_backend.map.entity.Route;
 import lombok.AllArgsConstructor;
@@ -362,6 +363,7 @@ public class RouteCalculator {
         Map<String,Double> checkPointNodeCoordinates = startNode.getXY();
         DirectionType checkPointType = DirectionType.STRAIGHT;
         List<CautionFactor> checkPointCautionFactors = new ArrayList<>();
+        List<DangerFactor> checkPointDangerFactors = new ArrayList<>();
 
         // 길찾기 결과 상세정보 정리
         for(int i=0;i<shortestRoutes.size();i++){
@@ -372,7 +374,7 @@ public class RouteCalculator {
             if(!nowRoute.getCautionFactors().isEmpty()){
                 double halfOfRouteDistance = calculateRouteDistance(nowRoute)/2;
                 details.add(RouteDetailResDTO.of(accumulatedDistance - halfOfRouteDistance,
-                        checkPointType, checkPointNodeCoordinates, checkPointCautionFactors));
+                        checkPointType, checkPointNodeCoordinates, checkPointCautionFactors, checkPointDangerFactors));
                 accumulatedDistance = halfOfRouteDistance;
                 checkPointNodeCoordinates = getCenter(now, nxt);
                 checkPointType = DirectionType.CAUTION;
@@ -382,17 +384,17 @@ public class RouteCalculator {
             if(!nowRoute.getDangerFactors().isEmpty()){
                 double halfOfRouteDistance = calculateRouteDistance(nowRoute)/2;
                 details.add(RouteDetailResDTO.of(accumulatedDistance - halfOfRouteDistance,
-                        checkPointType, checkPointNodeCoordinates, checkPointCautionFactors));
+                        checkPointType, checkPointNodeCoordinates, checkPointCautionFactors, checkPointDangerFactors));
                 accumulatedDistance = halfOfRouteDistance;
                 checkPointNodeCoordinates = getCenter(now, nxt);
                 checkPointType = DirectionType.DANGER;
-                checkPointCautionFactors = nowRoute.getCautionFactorsByList();
+                checkPointDangerFactors = nowRoute.getDangerFactorsByList();
             }
 
             if(nxt.equals(endNode)){
                 details.add(RouteDetailResDTO.of(accumulatedDistance, checkPointType,
-                        checkPointNodeCoordinates, checkPointCautionFactors));
-                details.add(RouteDetailResDTO.of(0, DirectionType.FINISH, nxt.getXY(), new ArrayList<>()));
+                        checkPointNodeCoordinates, checkPointCautionFactors, checkPointDangerFactors));
+                details.add(RouteDetailResDTO.of(0, DirectionType.FINISH, nxt.getXY(), new ArrayList<>(), new ArrayList<>()));
                 break;
             }
             if(nxt.isCore()){
@@ -403,11 +405,12 @@ public class RouteCalculator {
                     continue;
                 }
                 details.add(RouteDetailResDTO.of(accumulatedDistance, checkPointType,
-                        checkPointNodeCoordinates, checkPointCautionFactors));
+                        checkPointNodeCoordinates, checkPointCautionFactors, checkPointDangerFactors));
                 checkPointNodeCoordinates = nxt.getXY();
                 checkPointType = directionType;
                 accumulatedDistance = 0.0;
                 checkPointCautionFactors = Collections.emptyList();
+                checkPointDangerFactors = Collections.emptyList();
             }
 
             now = nxt;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -395,6 +395,7 @@ public class RouteCalculator {
                 checkPointNodeCoordinates = getCenter(now, nxt);
                 checkPointType = DirectionType.CAUTION;
                 checkPointCautionFactors = nowRoute.getCautionFactorsByList();
+                checkPointDangerFactors = Collections.emptyList();
             }
 
             if(!nowRoute.getDangerFactors().isEmpty()){
@@ -405,6 +406,7 @@ public class RouteCalculator {
                 checkPointNodeCoordinates = getCenter(now, nxt);
                 checkPointType = DirectionType.DANGER;
                 checkPointDangerFactors = nowRoute.getDangerFactorsByList();
+                checkPointCautionFactors = Collections.emptyList();
             }
 
             if(nxt.equals(endNode)){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -16,7 +16,7 @@ import com.softeer5.uniro_backend.map.enums.CautionFactor;
 import com.softeer5.uniro_backend.map.enums.DangerFactor;
 import com.softeer5.uniro_backend.map.enums.DirectionType;
 import com.softeer5.uniro_backend.map.entity.Route;
-import com.softeer5.uniro_backend.map.service.vo.LightNode;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
 import lombok.AllArgsConstructor;
 
 import org.locationtech.jts.geom.Coordinate;
@@ -587,6 +587,8 @@ public class RouteCalculator {
         }
         createdNodes.add(startNode);
 
+        double nodeHeight = startNode.getHeight();
+
         // 기존에 저장된 노드와 일치하거나 or 새로운 노드와 겹칠 경우 -> 동일한 것으로 판단
         for (int i = 1; i < requests.size(); i++) {
             CreateRouteReqDTO cur = requests.get(i);
@@ -595,6 +597,7 @@ public class RouteCalculator {
             Node curNode = nodeMap.get(getNodeKey(new Coordinate(cur.getLng(), cur.getLat())));
             if(curNode != null){
                 createdNodes.add(curNode);
+                nodeHeight = (nodeHeight + curNode.getHeight()) / 2;
                 if(i == requests.size() - 1 && endNodeCount < CORE_NODE_CONDITION - 1){  // 마지막 노드일 경우, 해당 노드가 끝점일 경우
                     continue;
                 }
@@ -606,8 +609,10 @@ public class RouteCalculator {
             Coordinate coordinate = new Coordinate(cur.getLng(), cur.getLat());
             curNode = Node.builder()
                 .coordinates(geometryFactory.createPoint(coordinate))
+                .height(nodeHeight)
                 .isCore(false)
                 .univId(univId)
+                .status(HeightStatus.READY)
                 .build();
 
             createdNodes.add(curNode);
@@ -773,6 +778,7 @@ public class RouteCalculator {
             getNodeKey(distance1 <= distance2 ? coordinates[0] : coordinates[1]),
             Node.builder().coordinates(geometryFactory.createPoint(distance1 <= distance2 ? coordinates[0] : coordinates[1]))
                 .isCore(true)
+                .status(HeightStatus.READY)
                 .build()
         );
     }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -135,6 +135,7 @@ public class RouteCalculator {
             }
 
             boolean hasCaution = false;
+            boolean hasDanger = false;
             double totalDistance = 0.0;
 
             // 결과를 DTO로 정리
@@ -145,6 +146,9 @@ public class RouteCalculator {
                 totalDistance += route.getDistance();
                 if (!route.getCautionFactors().isEmpty()) {
                     hasCaution = true;
+                }
+                if(!route.getDangerFactors().isEmpty()){
+                    hasDanger = true;
                 }
 
                 Node firstNode = route.getNode1();
@@ -164,7 +168,7 @@ public class RouteCalculator {
 
             List<RouteDetailResDTO> details = getRouteDetail(startNode, endNode, shortestRoutes);
 
-            result.add(FastestRouteResDTO.of(policy, hasCaution, totalDistance,
+            result.add(FastestRouteResDTO.of(policy, hasCaution, hasDanger, totalDistance,
                     calculateCost(policy, PEDESTRIAN_SECONDS_PER_MITER, totalDistance),
                     calculateCost(policy, MANUAL_WHEELCHAIR_SECONDS_PER_MITER,totalDistance),
                     calculateCost(policy, ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER,totalDistance),
@@ -372,6 +376,16 @@ public class RouteCalculator {
                 accumulatedDistance = halfOfRouteDistance;
                 checkPointNodeCoordinates = getCenter(now, nxt);
                 checkPointType = DirectionType.CAUTION;
+                checkPointCautionFactors = nowRoute.getCautionFactorsByList();
+            }
+
+            if(!nowRoute.getDangerFactors().isEmpty()){
+                double halfOfRouteDistance = calculateRouteDistance(nowRoute)/2;
+                details.add(RouteDetailResDTO.of(accumulatedDistance - halfOfRouteDistance,
+                        checkPointType, checkPointNodeCoordinates, checkPointCautionFactors));
+                accumulatedDistance = halfOfRouteDistance;
+                checkPointNodeCoordinates = getCenter(now, nxt);
+                checkPointType = DirectionType.DANGER;
                 checkPointCautionFactors = nowRoute.getCautionFactorsByList();
             }
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightNode.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightNode.java
@@ -1,0 +1,29 @@
+package com.softeer5.uniro_backend.map.service.vo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.softeer5.uniro_backend.map.entity.Node;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+@AllArgsConstructor
+public class LightNode {
+	private long id;
+	private double lat;
+	private double lng;
+
+	@JsonProperty("core")
+	private boolean isCore;
+
+	public LightNode(Node node) {
+		this.id = node.getId();
+		this.lat = node.getY();
+		this.lng = node.getX();
+		this.isCore = node.isCore();
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoute.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoute.java
@@ -2,6 +2,7 @@ package com.softeer5.uniro_backend.map.service.vo;
 
 import java.io.Serializable;
 
+import com.softeer5.uniro_backend.map.entity.Node;
 import com.softeer5.uniro_backend.map.entity.Route;
 
 import lombok.AllArgsConstructor;
@@ -24,5 +25,12 @@ public class LightRoute implements Serializable {
 		this.distance = route.getDistance();
 		this.node1 = new LightNode(route.getNode1());
 		this.node2 = new LightNode(route.getNode2());
+	}
+
+	public LightRoute(long id, double distance, Node node1, Node node2) {
+		this.id = id;
+		this.distance = distance;
+		this.node1 = new LightNode(node1);
+		this.node2 = new LightNode(node2);
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoute.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoute.java
@@ -1,0 +1,28 @@
+package com.softeer5.uniro_backend.map.service.vo;
+
+import java.io.Serializable;
+
+import com.softeer5.uniro_backend.map.entity.Route;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+@AllArgsConstructor
+public class LightRoute implements Serializable {
+	private long id;
+	private double distance;
+	private LightNode node1;
+	private LightNode node2;
+
+	public LightRoute(Route route) {
+		this.id = route.getId();
+		this.distance = route.getDistance();
+		this.node1 = new LightNode(route.getNode1());
+		this.node2 = new LightNode(route.getNode2());
+	}
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoutes.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoutes.java
@@ -1,0 +1,17 @@
+package com.softeer5.uniro_backend.map.service.vo;
+
+import java.io.Serializable;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+@AllArgsConstructor
+public class LightRoutes implements Serializable {
+	private List<LightRoute> lightRoutes;
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/entity/Univ.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/univ/entity/Univ.java
@@ -59,6 +59,10 @@ public class Univ {
 	@NotNull
 	private Polygon areaPolygon;
 
+	@Column(name = "limit_version")
+	@NotNull
+	private long limitVersion;
+
 	public Map<String, Double> getCenterXY(){
 		return Map.of("lat", centerPoint.getY(), "lng", centerPoint.getX());
 	}

--- a/uniro_backend/src/main/resources/application-dev.yml
+++ b/uniro_backend/src/main/resources/application-dev.yml
@@ -2,6 +2,8 @@ spring:
   config:
     import: application.properties
   datasource:
+    hikari:
+      maximum-pool-size: 30
     url: ${DB_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
@@ -16,10 +18,11 @@ spring:
         show_sql: true
     open-in-view: false
     defer-datasource-initialization: true
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  data:
+    redis:
+      host: redis
+      password: ${REDIS_PASSWORD}
+      port: 6379
 map:
   api:
     key: ${google.api.key}

--- a/uniro_backend/src/main/resources/application-local.yml
+++ b/uniro_backend/src/main/resources/application-local.yml
@@ -1,5 +1,7 @@
 spring:
   datasource:
+    hikari:
+      maximum-pool-size: 30
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/uniro?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: root
@@ -17,10 +19,11 @@ spring:
 #  sql:
 #    init:
 #      mode: always
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      password: ${REDIS_PASSWORD}
+      port: 6379
 map:
   api:
     key: ${google.api.key}

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
@@ -18,15 +18,21 @@ import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.query.AuditEntity;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlGroup;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.softeer5.uniro_backend.admin.entity.RevInfo;
@@ -55,6 +61,22 @@ import jakarta.persistence.EntityManager;
 	@Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 })
 class AdminServiceTest {
+
+	@Container
+	static final GenericContainer<?> redis = new GenericContainer<>("redis:7.0.8-alpine")
+		.withExposedPorts(6379);
+
+	@BeforeAll
+	static void setup() {
+		redis.start();
+	}
+
+	@DynamicPropertySource
+	static void configureProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.redis.host", redis::getHost);
+		registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+	}
+
 
 	@Autowired
 	private AdminService adminService;

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/admin/AdminServiceTest.java
@@ -51,6 +51,7 @@ import jakarta.persistence.EntityManager;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SqlGroup({
 	@Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
+	@Sql(value = "/sql/insert-univ-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD),
 	@Sql(value = "/sql/delete-all-data.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 })
 class AdminServiceTest {

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/external/MapClientImplTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/external/MapClientImplTest.java
@@ -1,6 +1,6 @@
 package com.softeer5.uniro_backend.external;
 
-import com.softeer5.uniro_backend.external.MapClientImpl;
+import com.softeer5.uniro_backend.external.elevation.MapClientImpl;
 import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;
 import com.softeer5.uniro_backend.map.entity.Node;
 import org.junit.jupiter.api.Assertions;

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/NodeFixture.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/NodeFixture.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.fixture;
 
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 
@@ -14,6 +15,7 @@ public class NodeFixture {
 			.univId(1001L)
 			.isCore(false)
 			.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
+			.status(HeightStatus.READY)
 			.build();
 	}
 
@@ -22,6 +24,7 @@ public class NodeFixture {
 			.univId(1001L)
 			.isCore(true)
 			.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
+			.status(HeightStatus.READY)
 			.build();
 	}
 
@@ -31,6 +34,7 @@ public class NodeFixture {
 				.isCore(false)
 				.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
 				.height(height)
+				.status(HeightStatus.READY)
 				.build();
 	}
 }

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -24,7 +23,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.softeer5.uniro_backend.common.exception.custom.RouteCalculationException;
-import com.softeer5.uniro_backend.external.MapClient;
+import com.softeer5.uniro_backend.external.elevation.MapClient;
 import com.softeer5.uniro_backend.fixture.NodeFixture;
 import com.softeer5.uniro_backend.fixture.RouteFixture;
 import com.softeer5.uniro_backend.map.dto.request.CreateRoutesReqDTO;

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,8 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.softeer5.uniro_backend.common.exception.custom.RouteCalculationException;
@@ -36,8 +41,21 @@ import com.softeer5.uniro_backend.map.repository.RouteRepository;
 @Transactional
 class MapServiceTest {
 
-	@Autowired
-	private RouteCalculator routeCalculator;
+	@Container
+	static final GenericContainer<?> redis = new GenericContainer<>("redis:7.0.8-alpine")
+		.withExposedPorts(6379);
+
+	@BeforeAll
+	static void setup() {
+		redis.start();
+	}
+
+	@DynamicPropertySource
+	static void configureProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.redis.host", redis::getHost);
+		registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+	}
+
 	@Autowired
 	private MapService mapService;
 	@Autowired

--- a/uniro_backend/src/test/resources/sql/insert-univ-data.sql
+++ b/uniro_backend/src/test/resources/sql/insert-univ-data.sql
@@ -1,0 +1,14 @@
+INSERT INTO univ
+(id, name, trimmed_name, image_url, center_point, left_top_point, right_bottom_point, area_polygon, limit_version)
+VALUES
+    (
+        1001,
+        'HYUNIV',
+        'HYUNIV',
+        'http://example.com/hanyang.jpg',
+        ST_GeomFromText('POINT(126.9780 37.5665)', 4326),
+        ST_GeomFromText('POINT(126.9720 37.5700)', 4326),
+        ST_GeomFromText('POINT(126.9850 37.5620)', 4326),
+        ST_GeomFromText('POLYGON((126.9720 37.5700, 126.9850 37.5700, 126.9850 37.5620, 126.9720 37.5620, 126.9720 37.5700))', 4326),
+        0
+    );


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [x] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### 비동기 처리 최적화
- 변경 전 : 기존에는 WebClient 호출 스트림 체인에 subscribeOn(Schedulers.boundedElastic())만 사용하고 있었습니다.
   - subscribeOn은 스트림 구독(데이터 요청)이 시작되는 업스트림 작업의 실행 스레드를 지정합니다. (우리 서비스에서는  fetchElevationAsync)
   - 그러나 WebClient 호출은 기본적으로 논블로킹 I/O 작업이기 때문에, 블로킹 I/O나 시간이 오래 걸리는 작업에 최적화된 boundedElastic 스케줄러는 적합하지 않았습니다.

- 변경 후 : 스트림 체인에 subscribeOn(Schedulers.parallel())과 publishOn(Schedulers.parallel())를 모두 포함시켰습니다.
    - publishOn은 이후의 후속 연산이 특정 스케줄러에서 수행되도록 강제합니다.
    - WebClient 호출은 논블로킹 I/O 작업으로 parallel 스케줄러와 잘 맞으며, mapElevationToNodes는 단순 계산 및 데이터 할당 작업으로 CPU 집약적이고 빠르게 처리되는 작업이므로 parallel 스케줄러를 사용하는 것이 효율적입니다.

참고자료
- https://spring.io/blog/2019/12/13/flight-of-the-flux-3-hopping-threads-and-schedulers#are-schedulers-always-backed-by-an-executorservice
- https://stackoverflow.com/questions/61304762/difference-between-boundedelastic-vs-parallel-scheduler

### Google API 호출 최대 개수 조정
구글 API 호출 횟수를 줄이기 위해 100건 -> 300건으로 최대개수를 증가시켰습니다.
