### PR TITLE
[UNI-342] fix : 다른 학교로 이동하는 현상 해결

### DIFF
--- a/uniro_frontend/src/pages/reportRisk.tsx
+++ b/uniro_frontend/src/pages/reportRisk.tsx
@@ -228,7 +228,7 @@ export default function ReportRiskPage() {
 
 	useEffect(() => {
 		drawRoute(routes.data);
-		if (reportedData?.routeId) {
+		if (reportedData?.routeId !== undefined) {
 			const foundRoute = findRouteById(routes.data, reportedData.routeId!);
 			if (!foundRoute) return;
 
@@ -261,7 +261,7 @@ export default function ReportRiskPage() {
 		addRiskMarker();
 
 		if (map) {
-			if (reportedData) moveToMarker();
+			if (reportedData?.routeId !== undefined) moveToMarker();
 			else map.setCenter(university.centerPoint);
 
 			map.addListener("click", () => {


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### 조건문 체크를 잘못해, 빠르게 수정했습니다.
```typescript
if (reportedData?.routeId !== undefined) {
			// 기존 코드와 동일

		if (map) {
			if (reportedData?.routeId !== undefined) moveToMarker();
```
routeId를 체크해 확실하게 다른 학교로 넘어가는 것을 방지했습니다.

## 💡 To Reviewer

빠른 발견 감사합니다.

## 🧪 테스트 결과

https://github.com/user-attachments/assets/cf5fa424-002f-4d14-a5c3-87a9fb3c882a

## ✅ 반영 브랜치

fe