### PR TITLE
[UNI-313] feat : 초기 로딩시 필요없는 화면에 대해 Lazy Loading 적용

### DIFF
--- a/.github/workflows/fe-deploy.yml
+++ b/.github/workflows/fe-deploy.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - fe
-    paths:
-      - "uniro_frontend/**"
+      - feat/UNI-313
+    # paths:
+    #   - "uniro_frontend/**"
 
 jobs:
   CI:

--- a/.github/workflows/fe-deploy.yml
+++ b/.github/workflows/fe-deploy.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - fe
-      - feat/UNI-313
-    # paths:
-    #   - "uniro_frontend/**"
+    paths:
+      - "uniro_frontend/**"
 
 jobs:
   CI:

--- a/uniro_frontend/src/App.tsx
+++ b/uniro_frontend/src/App.tsx
@@ -2,18 +2,12 @@ import { Route, Routes } from "react-router";
 import "./App.css";
 import LandingPage from "./pages/landing";
 import UniversitySearchPage from "./pages/universitySearch";
-import MapPage from "./pages/map";
-import BuildingSearchPage from "./pages/buildingSearch";
-import NavigationResultPage from "./pages/navigationResult";
-import ReportRoutePage from "./pages/reportRoute";
-import ReportForm from "./pages/reportForm";
-import ReportRiskPage from "./pages/reportRisk";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useDynamicSuspense } from "./hooks/useDynamicSuspense";
 import OfflinePage from "./pages/offline";
 import useNetworkStatus from "./hooks/useNetworkStatus";
 import ErrorPage from "./pages/error";
-import { Suspense } from "react";
+import { lazy, Suspense } from "react";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import ErrorBoundary from "./components/error/ErrorBoundary";
 import Errortest from "./pages/errorTest";
@@ -26,6 +20,13 @@ const queryClient = new QueryClient({
 		},
 	},
 });
+
+const BuildingSearchPage = lazy(() => import("./pages/buildingSearch"));
+const MapPage = lazy(() => import("./pages/map"));
+const ReportForm = lazy(() => import("./pages/reportForm"));
+const NavigationResultPage = lazy(() => import("./pages/navigationResult"));
+const ReportRoutePage = lazy(() => import("./pages/reportRoute"));
+const ReportRiskPage = lazy(() => import("./pages/reportRisk"));
 
 function App() {
 	const { location, fallback } = useDynamicSuspense();


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### Lazy Loading 적용한 코드
```typescript
const BuildingSearchPage = lazy(() => import("./pages/buildingSearch"));
const MapPage = lazy(() => import("./pages/map"));
const ReportForm = lazy(() => import("./pages/reportForm"));
const NavigationResultPage = lazy(() => import("./pages/navigationResult"));
const ReportRoutePage = lazy(() => import("./pages/reportRoute"));
const ReportRiskPage = lazy(() => import("./pages/reportRisk"));
```

#### 제외한 페이지

- 랜딩 페이지
- 대학 검색 페이지(테스트 결과 중간 로딩화면 깜빡임 발생하는 유일한 페이지)
- 에러페이지
- Not Found 페이지
- Offline 페이지
- ErrorTest 페이지

### 번들 분할

<img width="877" alt="image" src="https://github.com/user-attachments/assets/0a8cc478-8c16-494d-a96a-302b882b2576" />

번들이이 Lazy Loading에 맞게 잘 분할된 것을 볼 수 있습니다. Loading이 길어질 것으로 예상되는 Component에서 1자리 kb js를 다운로드 하기 때문에, 거의 영향이 없을 것으로 예상됩니다.

## 💡 To Reviewer

코드 결합 후 FCP랑 LightHouse 측정하면 유의미한 결과가 있을 것 같습니다.
감사합니다.

## 🧪 테스트 결과


#### 1. 초반에 다운로드 하는 데이터 차이

#### Lazy Loading 미적용 (663KB)
<img width="694" alt="스크린샷 2025-02-20 17 22 56" src="https://github.com/user-attachments/assets/826f16ed-a221-48aa-b4eb-37250a40db44" />

#### Lazy Loading 적용 (505KB)
<img width="794" alt="스크린샷 2025-02-20 17 29 41" src="https://github.com/user-attachments/assets/277e8446-a564-4c65-b7ae-d5fec4522399" />

#### 2. LightHouse(배포환경) 점수 차이

#### Lazy Loading 미적용 (78점, FCP 3.8s)

<img width="824" alt="스크린샷 2025-02-20 17 38 17" src="https://github.com/user-attachments/assets/97ee8e0a-95d9-4fd7-9226-54b2bea7c9a1" />

#### Lazy Loading 적용 (86점, FCP 3.0s)

<img width="1728" alt="스크린샷 2025-02-20 17 30 17" src="https://github.com/user-attachments/assets/4f6f62bb-4cdd-4490-8a67-904d04e2d9a0" />

## ✅ 반영 브랜치

fe