### PR TITLE
[UNI-255-v4] refactor: 스트림 기반 redis 구현 및 경량객체 조회하도록 개선 (UNI-321)

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -12,7 +12,7 @@ import com.softeer5.uniro_backend.building.repository.BuildingRepository;
 import com.softeer5.uniro_backend.common.exception.custom.AdminException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteException;
 import com.softeer5.uniro_backend.common.exception.custom.UnivException;
-import com.softeer5.uniro_backend.common.redis.RedisService;
+import com.softeer5.uniro_backend.external.redis.RedisService;
 import com.softeer5.uniro_backend.map.dto.response.AllRoutesInfo;
 import com.softeer5.uniro_backend.map.dto.response.GetChangedRoutesByRevisionResDTO;
 import com.softeer5.uniro_backend.map.dto.response.GetRiskRoutesResDTO;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.admin.service;
 
+import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
 import static com.softeer5.uniro_backend.common.error.ErrorCode.*;
 
 import com.softeer5.uniro_backend.admin.annotation.DisableAudit;
@@ -108,7 +109,8 @@ public class AdminService {
             }
         }
 
-        redisService.deleteData(univId.toString());
+        int routeCount = routes.size();
+        redisService.deleteRoutesData(univId.toString(), routeCount / STREAM_FETCH_SIZE + 1);
     }
 
     public GetAllRoutesByRevisionResDTO getAllRoutesByRevision(Long univId, Long versionId){

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/service/BuildingService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/building/service/BuildingService.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import com.softeer5.uniro_backend.admin.annotation.RevisionOperation;
 import com.softeer5.uniro_backend.admin.enums.RevisionOperationType;
-import com.softeer5.uniro_backend.external.MapClient;
+import com.softeer5.uniro_backend.external.elevation.MapClient;
 import com.softeer5.uniro_backend.building.dto.request.CreateBuildingNodeReqDTO;
 import com.softeer5.uniro_backend.building.entity.Building;
 import com.softeer5.uniro_backend.map.entity.Node;
@@ -13,7 +13,6 @@ import com.softeer5.uniro_backend.map.repository.NodeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.softeer5.uniro_backend.common.CursorPage;
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.BuildingException;
 import com.softeer5.uniro_backend.common.utils.GeoUtils;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/RedisConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/RedisConfig.java
@@ -1,8 +1,7 @@
-package com.softeer5.uniro_backend.common.redis;
+package com.softeer5.uniro_backend.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/WebMvcConfig.java
@@ -33,26 +33,26 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		this.jwtInterceptor = jwtInterceptor;
 	}
 
-	@Override
-	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-		FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
-		//custom configuration...
-		FastJsonConfig config = new FastJsonConfig();
-		config.setDateFormat("yyyy-MM-dd HH:mm:ss");
-		config.setReaderFeatures(JSONReader.Feature.FieldBased, JSONReader.Feature.SupportArrayToBean);
-		config.setWriterFeatures(JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.PrettyFormat);
-		converter.setFastJsonConfig(config);
-		converter.setDefaultCharset(StandardCharsets.UTF_8);
-
-		converter.setSupportedMediaTypes(List.of(
-			MediaType.APPLICATION_JSON, // application/json 지원
-			new MediaType("application", "json", StandardCharsets.UTF_8),
-			new MediaType("application", "openmetrics-text", StandardCharsets.UTF_8)
-		));
-
-		converters.add(0, converter);
-		converters.forEach(c -> log.info("✔ {}", c.getClass().getName()));
-	}
+	// @Override
+	// public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+	// 	FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+	// 	//custom configuration...
+	// 	FastJsonConfig config = new FastJsonConfig();
+	// 	config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+	// 	config.setReaderFeatures(JSONReader.Feature.FieldBased, JSONReader.Feature.SupportArrayToBean);
+	// 	config.setWriterFeatures(JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.PrettyFormat);
+	// 	converter.setFastJsonConfig(config);
+	// 	converter.setDefaultCharset(StandardCharsets.UTF_8);
+	//
+	// 	converter.setSupportedMediaTypes(List.of(
+	// 		MediaType.APPLICATION_JSON, // application/json 지원
+	// 		new MediaType("application", "json", StandardCharsets.UTF_8),
+	// 		new MediaType("application", "openmetrics-text", StandardCharsets.UTF_8)
+	// 	));
+	//
+	// 	converters.add(0, converter);
+	// 	converters.forEach(c -> log.info("✔ {}", c.getClass().getName()));
+	// }
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClient.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClient.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.external;
+package com.softeer5.uniro_backend.external.elevation;
 
 import com.softeer5.uniro_backend.map.entity.Node;
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClientImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/elevation/MapClientImpl.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.external;
+package com.softeer5.uniro_backend.external.elevation;
 
 import com.softeer5.uniro_backend.common.error.ErrorCode;
 import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/redis/RedisService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/redis/RedisService.java
@@ -1,4 +1,4 @@
-package com.softeer5.uniro_backend.common.redis;
+package com.softeer5.uniro_backend.external.redis;
 
 import java.time.Duration;
 import java.util.HashMap;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/redis/RedisService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/redis/RedisService.java
@@ -49,4 +49,13 @@ public class RedisService {
 		redisTemplate.delete(key);
 		cacheMap.remove(key);
 	}
+
+	public void deleteRoutesData(String key, int batchNumber) {
+		String redisKeyPrefix = key + ":";
+
+		for(int i=1; i<=batchNumber; i++){
+			redisTemplate.delete(redisKeyPrefix + i);
+		}
+		cacheMap.remove(key);
+	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/RouteRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.softeer5.uniro_backend.map.entity.Route;
+import com.softeer5.uniro_backend.map.service.vo.LightRoute;
 
 import static com.softeer5.uniro_backend.common.constant.UniroConst.STREAM_FETCH_SIZE_AS_STRING;
 
@@ -24,6 +25,17 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
     @Query("SELECT r FROM Route r WHERE r.univId = :univId")
     @QueryHints(@QueryHint(name = "org.hibernate.fetchSize", value = STREAM_FETCH_SIZE_AS_STRING))
     Stream<Route> findAllRouteByUnivIdWithNodesStream(Long univId);
+
+    @Query("""
+    SELECT new com.softeer5.uniro_backend.map.service.vo.LightRoute(r.id, r.distance, n1, n2) 
+    FROM Route r 
+    JOIN r.node1 n1 
+    JOIN r.node2 n2
+    WHERE r.univId = :univId
+""")
+    @QueryHints(@QueryHint(name = "org.hibernate.fetchSize", value = STREAM_FETCH_SIZE_AS_STRING))
+    Stream<LightRoute> findAllLightRoutesByUnivId(Long univId);
+
 
     @Query(value = "SELECT r.* FROM route r " +
             "WHERE r.univ_id = :univId " +

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -156,11 +156,10 @@ public class MapService {
 	}
 
 	private void processDatabaseData(Long univId, String redisKeyPrefix, int batchNumber, SseEmitter emitter) {
-		try (Stream<Route> routeStream = routeRepository.findAllRouteByUnivIdWithNodesStream(univId)) {
+		try (Stream<LightRoute> routeStream = routeRepository.findAllLightRoutesByUnivId(univId)) {
 			List<LightRoute> batch = new ArrayList<>(STREAM_FETCH_SIZE);
-			for (Route route : (Iterable<Route>) routeStream::iterator) {
-				batch.add(new LightRoute(route));
-				entityManager.detach(route);
+			for (LightRoute route : (Iterable<LightRoute>) routeStream::iterator) {
+				batch.add(route);
 
 				if (batch.size() == STREAM_FETCH_SIZE) {
 					saveAndSendBatch(redisKeyPrefix, batchNumber++, batch, emitter);

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -17,8 +17,8 @@ import com.softeer5.uniro_backend.common.exception.custom.BuildingException;
 import com.softeer5.uniro_backend.common.exception.custom.NodeException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteCalculationException;
 import com.softeer5.uniro_backend.common.exception.custom.RouteException;
-import com.softeer5.uniro_backend.common.redis.RedisService;
-import com.softeer5.uniro_backend.external.MapClient;
+import com.softeer5.uniro_backend.external.redis.RedisService;
+import com.softeer5.uniro_backend.external.elevation.MapClient;
 import com.softeer5.uniro_backend.map.dto.request.CreateRoutesReqDTO;
 import com.softeer5.uniro_backend.map.entity.Node;
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -308,7 +308,9 @@ public class MapService {
 		nodeRepository.saveAll(nodesForSave);
 		routeRepository.saveAll(routes);
 
-		redisService.deleteData(univId.toString());
+		int routeCount = routeRepository.countByUnivId(univId);
+
+		redisService.deleteRoutesData(univId.toString(), routeCount / STREAM_FETCH_SIZE + 1);
 
 		return routeCalculator.assembleRoutes(routes);
 	}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/MapService.java
@@ -119,37 +119,77 @@ public class MapService {
 
 	@Async
 	public void getAllRoutesByStream(Long univId, SseEmitter emitter) {
-		int batchSize = routeRepository.countByUnivId(univId);
-		batchSize = batchSize % STREAM_FETCH_SIZE == 0 ? batchSize / STREAM_FETCH_SIZE : batchSize / STREAM_FETCH_SIZE + 1;
+		String redisKeyPrefix = univId + ":";
+		int batchNumber = 1;
 
-		try (Stream<Route> routeStream = routeRepository.findAllRouteByUnivIdWithNodesStream(univId)) {
-			List<Route> batch = new ArrayList<>(STREAM_FETCH_SIZE);
-			Iterator<Route> iterator = routeStream.iterator();
-			while (iterator.hasNext()) {
-				Route route = iterator.next();
-				batch.add(route);
-				entityManager.detach(route);
+		try {
+			// 1️⃣ Redis 데이터가 있다면 우선 처리
+			if (processRedisData(redisKeyPrefix, batchNumber, emitter)) {
+				return;
+			}
 
-				if (batch.size() == STREAM_FETCH_SIZE) {
-					processBatch(batch, emitter, batchSize);
-				}
-			}
-			// 남은 배치 처리
-			if (!batch.isEmpty()) {
-				processBatch(batch, emitter, batchSize);
-			}
-			emitter.complete();
-			log.info("[SSE emitter complete] " + Thread.currentThread().getName());
-		}
-		catch (Exception e) {
+			// 2️⃣ Redis에 데이터가 없으면 기존 DB 조회 방식 사용
+			processDatabaseData(univId, redisKeyPrefix, batchNumber, emitter);
+		} catch (Exception e) {
 			emitter.completeWithError(e);
-			log.error(e.getMessage());
+			log.error("SSE error: {}", e.getMessage(), e);
 		}
 	}
 
-	private void processBatch(List<Route> batch, SseEmitter emitter, int size) throws Exception {
+	private boolean processRedisData(String redisKeyPrefix, int batchNumber, SseEmitter emitter) throws Exception {
+		while (redisService.hasData(redisKeyPrefix + batchNumber)) {
+			LightRoutes lightRoutes = (LightRoutes) redisService.getData(redisKeyPrefix + batchNumber);
+			if (lightRoutes == null) {
+				break;
+			}
+
+			processBatch(lightRoutes.getLightRoutes(), emitter, lightRoutes.getLightRoutes().size());
+			batchNumber++;
+		}
+
+		if (batchNumber > 1) {
+			emitter.complete();
+			log.info("[SSE emitter complete] Redis data used.");
+			return true;
+		}
+		return false;
+	}
+
+	private void processDatabaseData(Long univId, String redisKeyPrefix, int batchNumber, SseEmitter emitter) {
+		try (Stream<Route> routeStream = routeRepository.findAllRouteByUnivIdWithNodesStream(univId)) {
+			List<LightRoute> batch = new ArrayList<>(STREAM_FETCH_SIZE);
+			for (Route route : (Iterable<Route>) routeStream::iterator) {
+				batch.add(new LightRoute(route));
+				entityManager.detach(route);
+
+				if (batch.size() == STREAM_FETCH_SIZE) {
+					saveAndSendBatch(redisKeyPrefix, batchNumber++, batch, emitter);
+				}
+			}
+
+			// 남은 배치 처리
+			if (!batch.isEmpty()) {
+				saveAndSendBatch(redisKeyPrefix, batchNumber, batch, emitter);
+			}
+
+			emitter.complete();
+			log.info("[SSE emitter complete] DB data used.");
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private void saveAndSendBatch(String redisKeyPrefix, int batchNumber, List<LightRoute> batch, SseEmitter emitter)
+		throws Exception {
+		LightRoutes value = new LightRoutes(batch);
+		redisService.saveData(redisKeyPrefix + batchNumber, value);
+		processBatch(batch, emitter, batch.size());
+		batch.clear();
+	}
+
+	private void processBatch(List<LightRoute> batch, SseEmitter emitter, int size) throws Exception {
 		if (!batch.isEmpty()) {
-			AllRoutesInfo allRoutesInfo = routeCalculator.assembleRoutes(batch);
+			AllRoutesInfo allRoutesInfo = routeCacheCalculator.assembleRoutes(batch);
 			allRoutesInfo.setBatchSize(size);
 			emitter.send(allRoutesInfo);
 			batch.clear();
@@ -195,11 +235,11 @@ public class MapService {
 	@Transactional
 	public void updateRisk(Long univId, Long routeId, PostRiskReqDTO postRiskReqDTO) {
 		Route route = routeRepository.findByIdAndUnivId(routeId, univId)
-				.orElseThrow(() -> new RouteException("Route not Found", ROUTE_NOT_FOUND));
+			.orElseThrow(() -> new RouteException("Route not Found", ROUTE_NOT_FOUND));
 
 		if(!postRiskReqDTO.getCautionFactors().isEmpty() && !postRiskReqDTO.getDangerFactors().isEmpty()){
 			throw new RouteException("DangerFactors and CautionFactors can't exist simultaneously.",
-					ErrorCode.CAUTION_DANGER_CANT_EXIST_SIMULTANEOUSLY);
+				ErrorCode.CAUTION_DANGER_CANT_EXIST_SIMULTANEOUSLY);
 		}
 
 		route.setCautionFactorsByList(postRiskReqDTO.getCautionFactors());
@@ -218,10 +258,10 @@ public class MapService {
 		}
 
 		Node buildingNode = nodeRepository.findById(buildingNodeId)
-				.orElseThrow(()-> new NodeException("Node not found", NODE_NOT_FOUND));
+			.orElseThrow(()-> new NodeException("Node not found", NODE_NOT_FOUND));
 
 		Node connectedNode = nodeRepository.findById(nodeId)
-				.orElseThrow(()-> new NodeException("Node not found", NODE_NOT_FOUND));
+			.orElseThrow(()-> new NodeException("Node not found", NODE_NOT_FOUND));
 
 		int connectedRouteCount = routeRepository.countByUnivIdAndNodeId(univId, nodeId);
 		if(connectedRouteCount>= CORE_NODE_CONDITION - 1){
@@ -234,15 +274,15 @@ public class MapService {
 		}
 
 		Route route = Route.builder()
-				.distance(BUILDING_ROUTE_DISTANCE)
-				.path(geometryFactory.createLineString(
-						new Coordinate[] {buildingNode.getCoordinates().getCoordinate(),
-								connectedNode.getCoordinates().getCoordinate()}))
-				.node1(buildingNode)
-				.node2(connectedNode)
-				.cautionFactors(Collections.EMPTY_SET)
-				.dangerFactors(Collections.EMPTY_SET)
-				.univId(univId).build();
+			.distance(BUILDING_ROUTE_DISTANCE)
+			.path(geometryFactory.createLineString(
+				new Coordinate[] {buildingNode.getCoordinates().getCoordinate(),
+					connectedNode.getCoordinates().getCoordinate()}))
+			.node1(buildingNode)
+			.node2(connectedNode)
+			.cautionFactors(Collections.EMPTY_SET)
+			.dangerFactors(Collections.EMPTY_SET)
+			.univId(univId).build();
 
 		routeRepository.save(route);
 	}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoute.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/vo/LightRoute.java
@@ -2,6 +2,7 @@ package com.softeer5.uniro_backend.map.service.vo;
 
 import java.io.Serializable;
 
+import com.softeer5.uniro_backend.map.entity.Node;
 import com.softeer5.uniro_backend.map.entity.Route;
 
 import lombok.AllArgsConstructor;
@@ -24,5 +25,12 @@ public class LightRoute implements Serializable {
 		this.distance = route.getDistance();
 		this.node1 = new LightNode(route.getNode1());
 		this.node2 = new LightNode(route.getNode2());
+	}
+
+	public LightRoute(long id, double distance, Node node1, Node node2) {
+		this.id = id;
+		this.distance = distance;
+		this.node1 = new LightNode(node1);
+		this.node2 = new LightNode(node2);
 	}
 }

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/external/MapClientImplTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/external/MapClientImplTest.java
@@ -1,6 +1,6 @@
 package com.softeer5.uniro_backend.external;
 
-import com.softeer5.uniro_backend.external.MapClientImpl;
+import com.softeer5.uniro_backend.external.elevation.MapClientImpl;
 import com.softeer5.uniro_backend.common.exception.custom.ElevationApiException;
 import com.softeer5.uniro_backend.map.entity.Node;
 import org.junit.jupiter.api.Assertions;

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/MapServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -24,7 +23,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.softeer5.uniro_backend.common.exception.custom.RouteCalculationException;
-import com.softeer5.uniro_backend.external.MapClient;
+import com.softeer5.uniro_backend.external.elevation.MapClient;
 import com.softeer5.uniro_backend.fixture.NodeFixture;
 import com.softeer5.uniro_backend.fixture.RouteFixture;
 import com.softeer5.uniro_backend.map.dto.request.CreateRoutesReqDTO;


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
### 1. 스트림 기반 redis 구현
<img width="594" alt="스크린샷 2025-02-21 오후 12 04 34" src="https://github.com/user-attachments/assets/7a1f63df-4c2a-4ed5-879a-49842d95b3e7" />

- 기존에 부하테스트를 진행하다 힙 사용량이 높아 OOM 문제가 발생하는 것을 확인했습니다.
- 이를 개선하기 위해 redis 캐시를 사용할 때도 배치단위로 스트림 읽도록 구현하여 총 메모리 사용량을 줄였습니다.
- 길 추가 로직이나 롤백 로직에서는 해당 캐시 정보가 지워지도록 구현했습니다.

### 2. 경량 객체 조회
- DB에서 객체를 가져올 때 너무 무거워 메모리 사용량이 높다는 문제점이 있었습니다.
- 이를 해결하기 위해 프로젝션을 활용하여 필요한 데이터만 가져오도록 구현했습니다.

## 💡 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->


## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/