### PR TITLE
[UNI-354] feat : 이벤트를 통한 Google API호출 + 배치로 처리하는 로직 작성

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/SchedulerConfig.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/config/SchedulerConfig.java
@@ -1,0 +1,17 @@
+package com.softeer5.uniro_backend.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/logging/ExecutionLoggingAop.java
@@ -27,7 +27,8 @@ public class ExecutionLoggingAop {
 	private static final ThreadLocal<String> userIdThreadLocal = new ThreadLocal<>();
 
 	@Around("execution(* com.softeer5.uniro_backend..*(..)) "
-		+ "&& !within(com.softeer5.uniro_backend.common..*) "
+		+ "&& !within(com.softeer5.uniro_backend.common..*)"
+			+ "&& !within(com.softeer5.uniro_backend.external..*)"
 	)
 	public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
 		String userId = userIdThreadLocal.get();
@@ -46,7 +47,14 @@ public class ExecutionLoggingAop {
 		if (isController) {
 			logHttpRequest(userId);
 		}
-		HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+		HttpServletRequest request = null;
+		if (RequestContextHolder.getRequestAttributes() instanceof ServletRequestAttributes) {
+			request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+		}
+
+		if(request==null){
+			return pjp.proceed();
+		}
 		log.info("✅ [ userId = {} Start] [Call Method] {}: {}", userId, request.getMethod(), task);
 
 		try{

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/MapClientImpl.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/MapClientImpl.java
@@ -45,13 +45,7 @@ public class MapClientImpl implements MapClient{
 
     @Override
     public void fetchHeights(List<Node> nodes) {
-        List<Node> nodesWithoutHeight = nodes.stream()
-                .filter(node -> node.getId() == null)
-                .toList();
-
-        if(nodesWithoutHeight.isEmpty()) return;
-
-        List<List<Node>> partitions = partitionNodes(nodesWithoutHeight, MAX_BATCH_SIZE);
+        List<List<Node>> partitions = partitionNodes(nodes, MAX_BATCH_SIZE);
 
         List<Mono<Void>> apiCalls = partitions.stream()
                 .map(batch -> fetchElevationAsync(batch)

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteCreatedEvent.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteCreatedEvent.java
@@ -1,0 +1,5 @@
+package com.softeer5.uniro_backend.external.event;
+
+public record RouteCreatedEvent() {
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventListener.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventListener.java
@@ -1,0 +1,46 @@
+package com.softeer5.uniro_backend.external.event;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@Component
+public class RouteEventListener {
+    private final TaskScheduler taskScheduler;
+    private final RouteEventService routeEventService;
+    private final AtomicBoolean isScheduled = new AtomicBoolean(false);
+
+    public RouteEventListener(TaskScheduler taskScheduler, RouteEventService routeEventService) {
+        this.taskScheduler = taskScheduler;
+        this.routeEventService = routeEventService;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleRouteCreatedEvent(RouteCreatedEvent event) {
+        log.info("Routes Created Event Listen");
+
+        // 이미 스케쥴링되고있는지 판단
+        if(isScheduled.compareAndSet(false, true)) {
+            Date scheduledTime = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(30));
+
+            taskScheduler.schedule(() -> {
+                try {
+                    routeEventService.fetchHeight();
+                } finally {
+                    isScheduled.set(false);
+                }
+            }, scheduledTime.toInstant());
+
+        }
+
+    }
+
+}
+

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
@@ -22,7 +22,6 @@ public class RouteEventService {
     @DisableAudit
     public void fetchHeight(){
         List<Node> readyNodes = nodeRepository.findAllByStatus(HeightStatus.READY);
-        setStatus(readyNodes,HeightStatus.PROGRESS);
         mapClient.fetchHeights(readyNodes);
         setStatus(readyNodes,HeightStatus.DONE);
     }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
@@ -1,12 +1,11 @@
 package com.softeer5.uniro_backend.external.event;
 
 import com.softeer5.uniro_backend.admin.annotation.DisableAudit;
-import com.softeer5.uniro_backend.external.MapClient;
+import com.softeer5.uniro_backend.external.elevation.MapClient;
 import com.softeer5.uniro_backend.map.entity.Node;
 import com.softeer5.uniro_backend.map.enums.HeightStatus;
 import com.softeer5.uniro_backend.map.repository.NodeRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/external/event/RouteEventService.java
@@ -1,0 +1,34 @@
+package com.softeer5.uniro_backend.external.event;
+
+import com.softeer5.uniro_backend.admin.annotation.DisableAudit;
+import com.softeer5.uniro_backend.external.MapClient;
+import com.softeer5.uniro_backend.map.entity.Node;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
+import com.softeer5.uniro_backend.map.repository.NodeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class RouteEventService {
+    private final MapClient mapClient;
+    private final NodeRepository nodeRepository;
+
+    @DisableAudit
+    public void fetchHeight(){
+        List<Node> readyNodes = nodeRepository.findAllByStatus(HeightStatus.READY);
+        setStatus(readyNodes,HeightStatus.PROGRESS);
+        mapClient.fetchHeights(readyNodes);
+        setStatus(readyNodes,HeightStatus.DONE);
+    }
+
+    private void setStatus(List<Node> readyNodes, HeightStatus heightStatus) {
+        readyNodes.forEach(readyNode -> readyNode.setStatus(heightStatus));
+    }
+
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Node.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/entity/Node.java
@@ -6,18 +6,14 @@ import static com.softeer5.uniro_backend.common.constant.UniroConst.*;
 import java.time.LocalDateTime;
 import java.util.Map;
 
-import jakarta.persistence.EntityListeners;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
+import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.envers.Audited;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 
 @Entity
@@ -47,6 +43,11 @@ public class Node {
 	@CreatedDate
 	private LocalDateTime createdAt;
 
+	@NotNull
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private HeightStatus status;
+
 	public Map<String, Double> getXY(){
 		return Map.of("lat", coordinates.getY(), "lng", coordinates.getX());
 	}
@@ -61,6 +62,10 @@ public class Node {
 
 	public void setHeight(double height) {
 		this.height = height;
+	}
+
+	public void setStatus(HeightStatus status) {
+		this.status = status;
 	}
 
 	public void setCoordinates(Point coordinates) {
@@ -79,10 +84,11 @@ public class Node {
 	}
 
 	@Builder
-	private Node(Point coordinates, double height, boolean isCore, Long univId) {
+	private Node(Point coordinates, double height, boolean isCore, Long univId, HeightStatus status) {
 		this.coordinates = coordinates;
 		this.height = height;
 		this.isCore = isCore;
 		this.univId = univId;
+		this.status = status;
 	}
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/enums/HeightStatus.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/enums/HeightStatus.java
@@ -1,0 +1,7 @@
+package com.softeer5.uniro_backend.map.enums;
+
+public enum HeightStatus {
+    READY,
+    PROGRESS,
+    DONE
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/repository/NodeRepository.java
@@ -1,6 +1,7 @@
 package com.softeer5.uniro_backend.map.repository;
 
 import com.softeer5.uniro_backend.map.entity.Node;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,6 @@ public interface NodeRepository extends JpaRepository<Node, Long> {
     void deleteAllByCreatedAt(Long univId, LocalDateTime versionTimeStamp);
 
     List<Node> findAllByUnivId(Long univId);
+
+    List<Node> findAllByStatus(HeightStatus status);
 }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -16,6 +16,7 @@ import com.softeer5.uniro_backend.map.enums.CautionFactor;
 import com.softeer5.uniro_backend.map.enums.DangerFactor;
 import com.softeer5.uniro_backend.map.enums.DirectionType;
 import com.softeer5.uniro_backend.map.entity.Route;
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
 import lombok.AllArgsConstructor;
 
 import org.locationtech.jts.geom.Coordinate;
@@ -569,6 +570,8 @@ public class RouteCalculator {
         }
         createdNodes.add(startNode);
 
+        double nodeHeight = startNode.getHeight();
+
         // 기존에 저장된 노드와 일치하거나 or 새로운 노드와 겹칠 경우 -> 동일한 것으로 판단
         for (int i = 1; i < requests.size(); i++) {
             CreateRouteReqDTO cur = requests.get(i);
@@ -577,6 +580,7 @@ public class RouteCalculator {
             Node curNode = nodeMap.get(getNodeKey(new Coordinate(cur.getLng(), cur.getLat())));
             if(curNode != null){
                 createdNodes.add(curNode);
+                nodeHeight = (nodeHeight + curNode.getHeight()) / 2;
                 if(i == requests.size() - 1 && endNodeCount < CORE_NODE_CONDITION - 1){  // 마지막 노드일 경우, 해당 노드가 끝점일 경우
                     continue;
                 }
@@ -588,8 +592,10 @@ public class RouteCalculator {
             Coordinate coordinate = new Coordinate(cur.getLng(), cur.getLat());
             curNode = Node.builder()
                 .coordinates(geometryFactory.createPoint(coordinate))
+                .height(nodeHeight)
                 .isCore(false)
                 .univId(univId)
+                .status(HeightStatus.READY)
                 .build();
 
             createdNodes.add(curNode);

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -761,6 +761,7 @@ public class RouteCalculator {
             getNodeKey(distance1 <= distance2 ? coordinates[0] : coordinates[1]),
             Node.builder().coordinates(geometryFactory.createPoint(distance1 <= distance2 ? coordinates[0] : coordinates[1]))
                 .isCore(true)
+                .status(HeightStatus.READY)
                 .build()
         );
     }

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/NodeFixture.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/fixture/NodeFixture.java
@@ -1,5 +1,6 @@
 package com.softeer5.uniro_backend.fixture;
 
+import com.softeer5.uniro_backend.map.enums.HeightStatus;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 
@@ -14,6 +15,7 @@ public class NodeFixture {
 			.univId(1001L)
 			.isCore(false)
 			.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
+			.status(HeightStatus.READY)
 			.build();
 	}
 
@@ -22,6 +24,7 @@ public class NodeFixture {
 			.univId(1001L)
 			.isCore(true)
 			.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
+			.status(HeightStatus.READY)
 			.build();
 	}
 
@@ -31,6 +34,7 @@ public class NodeFixture {
 				.isCore(false)
 				.coordinates(geometryFactory.createPoint(new Coordinate(x,y)))
 				.height(height)
+				.status(HeightStatus.READY)
 				.build();
 	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
### Google API를 동기적으로 처리하지 않고, 이벤트를 통해 비동기 및 배치로 처리하도록 개선
- 구글 API를 길 추가 요청 시 동기적으로 호출하지 않고, 이벤트 기반으로 처리하도록 변경했습니다.
- 이를 통해 API 호출로 인한 응답 지연 및 비용 부담을 줄이고, 사용자 경험을 개선했습니다.

### Google API 배치 요청
- 구글 API는 한 번의 요청으로 최대 512개의 점에 대한 해발고도를 제공하며, 호출당 비용이 발생합니다.
- 비용 절감을 위해, 첫 유저가 길 추가 요청을 시작하면 30분 동안 다른 유저들의 요청을 모은 후 배치로 처리하도록 구현했습니다.
- **구현 내용:**
  - 요청된 노드 데이터를 배치 단위(최대 300개 단위)로 분할하여 처리하도록 로직을 작성했습니다.
  - Spring WebClient와 Reactor를 활용해 Google Elevation API를 비동기 방식으로 호출, 각 배치를 병렬로 처리합니다.
  - 모든 배치 요청이 완료될 때까지 비동기 작업을 모니터링하며, 응답 결과를 매핑하여 노드에 해발고도를 적용합니다.
  - 이벤트 기반 스케줄러를 통해 30분 간격으로 모인 요청들을 한 번에 처리하도록 하여, 호출 횟수를 줄이고 비용을 최적화했습니다.
