### PR TITLE
[FE-356] fix : 길 찾기 페이지 바텀시트 스크롤 x 차단

### DIFF
--- a/uniro_frontend/src/components/navigation/route/routeList.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeList.tsx
@@ -52,7 +52,7 @@ const RouteList = ({
 	}, [cautionRouteIdx, isDetailView]);
 
 	return (
-		<div className="w-full">
+		<div className="w-full scroll-x-hidden">
 			{routes &&
 				addOriginAndDestination(routes).map((route, index) => (
 					<Fragment key={`${route.dist}-${route.coordinates.lat}-fragment`}>


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### 길 찾기 페이지 바텀시트 스크롤 x 현상을 차단했습니다.
```typescript
	return (
		<div className="w-full scroll-x-hidden">
```
RouteList에 스크롤 제한을 걸어주었습니다.

## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과

### AS IS

https://github.com/user-attachments/assets/03f906cc-74b7-4cf6-839f-7038104a4943

### TO BE

https://github.com/user-attachments/assets/2dc803dd-9e5e-4be1-92ca-ecab6f20c060

## ✅ 반영 브랜치

fe
