### PR TITLE
[UNI-364] refactor : 길 찾기 로직에서 cost산정방식 변경 & 로직 수정

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -4,9 +4,9 @@ public final class UniroConst {
 	public static final String NODE_KEY_DELIMITER = " ";
 	public static final int CORE_NODE_CONDITION = 3;
 	public static final int BEFORE_DEFAULT_ORDER = -1;
-	public static final double PEDESTRIAN_SECONDS_PER_MITER = 1.2;
-	public static final double MANUAL_WHEELCHAIR_SECONDS_PER_MITER = 2.5;
-	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 1.0;
+	public static final double PEDESTRIAN_SECONDS_PER_MITER = 1.0;
+	public static final double MANUAL_WHEELCHAIR_SECONDS_PER_MITER = 2.0;
+	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 0.9;
 	public static final double EARTH_RADIUS = 6378137;
 	public static final double BUILDING_ROUTE_DISTANCE = 1e8;
 	public static final int IS_SINGLE_ROUTE = 2;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -5,11 +5,11 @@ public final class UniroConst {
 	public static final int CORE_NODE_CONDITION = 3;
 	public static final int BEFORE_DEFAULT_ORDER = -1;
 	public static final double PEDESTRIAN_SECONDS_PER_MITER = 1.0;
-	public static final double MANUAL_WHEELCHAIR_SECONDS_PER_MITER = 2.0;
+	public static final double MANUAL_WHEELCHAIR_SECONDS_PER_MITER = 2.1;
 	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 0.9;
 	public static final double EARTH_RADIUS = 6378137;
 	public static final double BUILDING_ROUTE_DISTANCE = 1e8;
-	public static final int IS_SINGLE_ROUTE = 2;
+	public static final double LIMIT_RANGE = 500;
 	public static final double HEURISTIC_WEIGHT_NORMALIZATION_FACTOR = 10.0;
 	public static final int STREAM_FETCH_SIZE = 2500;
 	//컴파일 상수를 보장하기 위한 코드

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -9,7 +9,7 @@ public final class UniroConst {
 	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 0.9;
 	public static final double EARTH_RADIUS = 6378137;
 	public static final double BUILDING_ROUTE_DISTANCE = 1e8;
-	public static final double LIMIT_RANGE = 500;
+	public static final double LIMIT_RANGE = 200;
 	public static final double HEURISTIC_WEIGHT_NORMALIZATION_FACTOR = 10.0;
 	public static final int STREAM_FETCH_SIZE = 2500;
 	//컴파일 상수를 보장하기 위한 코드

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/FastestRouteDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/FastestRouteDTO.java
@@ -1,0 +1,21 @@
+package com.softeer5.uniro_backend.map.dto;
+
+import com.softeer5.uniro_backend.map.entity.Route;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class FastestRouteDTO {
+    private final Map<Long, Route> prevRoute;
+    private final double totalWeightDistance;
+
+    public static FastestRouteDTO of(Map<Long, Route> prevRoute, double totalWeightDistance) {
+        return new FastestRouteDTO(prevRoute,totalWeightDistance);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/FastestRouteResultDTO.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/dto/FastestRouteResultDTO.java
@@ -1,0 +1,35 @@
+package com.softeer5.uniro_backend.map.dto;
+
+import com.softeer5.uniro_backend.map.dto.response.RouteInfoResDTO;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class FastestRouteResultDTO {
+    private final boolean hasCaution;
+    private final boolean hasDanger;
+    private final double totalDistance;
+    private final double heightIncreaseWeight;
+    private final double heightDecreaseWeight;
+    private final List<RouteInfoResDTO> routeInfoDTOS;
+
+    public static FastestRouteResultDTO of(boolean hasCaution,
+                                           boolean hasDanger,
+                                           double totalDistance,
+                                           double heightIncreaseWeight,
+                                           double heightDecreaseWeight,
+                                           List<RouteInfoResDTO> routeInfoDTOS){
+        return new FastestRouteResultDTO(hasCaution,
+                hasDanger,
+                totalDistance,
+                heightIncreaseWeight,
+                heightDecreaseWeight,
+                routeInfoDTOS);
+    }
+}

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -167,11 +167,14 @@ public class RouteCalculator {
                     fastestRouteResult.isHasCaution(),
                     fastestRouteResult.isHasDanger(),
                     fastestRouteResult.getTotalDistance(),
-                    calculateCost(policy, PEDESTRIAN_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()
+                    calculateCost(policy, PEDESTRIAN_SECONDS_PER_MITER,
+                            fastestRouteDTO.getTotalWeightDistance() % BUILDING_ROUTE_DISTANCE
                                 + fastestRouteResult.getHeightIncreaseWeight() - fastestRouteResult.getHeightDecreaseWeight()),
-                    calculateCost(policy, MANUAL_WHEELCHAIR_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()
+                    calculateCost(policy, MANUAL_WHEELCHAIR_SECONDS_PER_MITER,
+                            fastestRouteDTO.getTotalWeightDistance() % BUILDING_ROUTE_DISTANCE
                             + fastestRouteResult.getHeightIncreaseWeight() + fastestRouteResult.getHeightDecreaseWeight()),
-                    calculateCost(policy, ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()),
+                    calculateCost(policy, ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER,
+                            fastestRouteDTO.getTotalWeightDistance() % BUILDING_ROUTE_DISTANCE),
                     fastestRouteResult.getRouteInfoDTOS(),
                     details));
         }

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -217,8 +217,7 @@ public class RouteCalculator {
 
             for(Route route : adjMap.getOrDefault(currentNode.getId(), Collections.emptyList())){
                 Node nextNode = route.getNode1().getId().equals(currentNode.getId())?route.getNode2():route.getNode1();
-                double newDistance = currentDistance + route.getDistance()
-                                                + getHeightHeuristicWeight(maxHeight,minHeight,nextNode, route.getDistance(), policy);
+                double newDistance = currentDistance + route.getDistance();
 
                 if(policy==RoadExclusionPolicy.WHEEL_FAST && !route.getCautionFactors().isEmpty()){
                     currentCautionCount++;
@@ -313,7 +312,7 @@ public class RouteCalculator {
                 heightIncreaseWeight += Math.exp(heightDiff) - 1;
             }
             else{
-                heightDecreaseWeight += Math.exp(heightDiff) - 1;
+                heightDecreaseWeight += Math.exp(-heightDiff) - 1;
             }
 
             routeInfoDTOS.add(RouteInfoResDTO.of(route, firstNode, secondNode));

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -130,6 +130,7 @@ public class RouteCalculator {
 
             //길찾기 알고리즘 수행
             FastestRouteDTO fastestRouteDTO = findFastestRoute(startNode, endNode, adjMap, policy);
+            if(fastestRouteDTO==null) continue;
             Map<Long, Route> prevRoute = fastestRouteDTO.getPrevRoute();
 
 
@@ -155,7 +156,7 @@ public class RouteCalculator {
                 shortestRoutes.remove(shortestRoutes.size() - 1);
             }
 
-            FastestRouteResultDTO fastestRouteResult = func(shortestRoutes, startNode);
+            FastestRouteResultDTO fastestRouteResult = generateResult(shortestRoutes, startNode);
 
             //처음과 마지막을 제외한 구간에서 빌딩노드를 거쳐왔다면, 이는 유효한 길이 없는 것이므로 예외처리
             if (fastestRouteResult.getTotalDistance() > BUILDING_ROUTE_DISTANCE - 1) continue;
@@ -274,7 +275,7 @@ public class RouteCalculator {
         return shortestRoutes;
     }
 
-    private FastestRouteResultDTO func(List<Route> shortestRoutes, Node startNode) {
+    private FastestRouteResultDTO generateResult(List<Route> shortestRoutes, Node startNode) {
         boolean hasCaution = false;
         boolean hasDanger = false;
         double totalDistance = 0.0;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -257,7 +257,8 @@ public class RouteCalculator {
 
     // 차이에 따른 가중치를 계산하는 메서드
     private double calculateWeight(double diff, double routeDistance){
-        return (Math.pow(diff,2) * routeDistance) / HEURISTIC_WEIGHT_NORMALIZATION_FACTOR;
+        double result = (Math.pow(diff,2) * routeDistance) / HEURISTIC_WEIGHT_NORMALIZATION_FACTOR;
+        return result > LIMIT_RANGE ? 0 : result;
     }
 
     // 길찾기 결과를 파싱하여 출발지 -> 도착지 형태로 재배열하는 메서드
@@ -317,6 +318,8 @@ public class RouteCalculator {
 
             routeInfoDTOS.add(RouteInfoResDTO.of(route, firstNode, secondNode));
         }
+        if(Math.abs(heightDecreaseWeight) > LIMIT_RANGE) heightDecreaseWeight = 0.0;
+        if(Math.abs(heightIncreaseWeight) > LIMIT_RANGE) heightIncreaseWeight = 0.0;
         return FastestRouteResultDTO.of(hasCaution,hasDanger,totalDistance,heightIncreaseWeight,heightDecreaseWeight,routeInfoDTOS);
     }
 

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -157,6 +157,8 @@ public class RouteCalculator {
             boolean hasCaution = false;
             boolean hasDanger = false;
             double totalDistance = 0.0;
+            double heightIncreaseWeight = 0.0;
+            double heightDecreaseWeight = 0.0;
 
             // 결과를 DTO로 정리
             List<RouteInfoResDTO> routeInfoDTOS = new ArrayList<>();
@@ -180,6 +182,14 @@ public class RouteCalculator {
                 }
                 currentNode = secondNode;
 
+                double heightDiff = firstNode.getHeight() - secondNode.getHeight();
+                if(heightDiff > 0){
+                    heightIncreaseWeight += Math.exp(heightDiff) - 1;
+                }
+                else{
+                    heightDecreaseWeight += Math.exp(heightDiff) - 1;
+                }
+
                 routeInfoDTOS.add(RouteInfoResDTO.of(route, firstNode, secondNode));
             }
 
@@ -189,8 +199,10 @@ public class RouteCalculator {
             List<RouteDetailResDTO> details = getRouteDetail(startNode, endNode, shortestRoutes);
 
             result.add(FastestRouteResDTO.of(policy, hasCaution, hasDanger, totalDistance,
-                    calculateCost(policy, PEDESTRIAN_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()),
-                    calculateCost(policy, MANUAL_WHEELCHAIR_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()),
+                    calculateCost(policy, PEDESTRIAN_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()
+                                + heightIncreaseWeight - heightDecreaseWeight),
+                    calculateCost(policy, MANUAL_WHEELCHAIR_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()
+                                + heightIncreaseWeight + heightDecreaseWeight),
                     calculateCost(policy, ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER, fastestRouteDTO.getTotalWeightDistance()),
                     routeInfoDTOS, details));
         }

--- a/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
+++ b/uniro_backend/src/test/java/com/softeer5/uniro_backend/map/service/RouteCalculatorTest.java
@@ -317,10 +317,6 @@ class RouteCalculatorTest {
             //a-2. distance가 정상적으로 제공되는지?
             double distance0 = fastestRoute.get(0).getTotalDistance();
             assertThat(Math.abs(distance0 - 16.0)).isLessThan(epsilon);
-            double distance1 = fastestRoute.get(1).getTotalDistance();
-            assertThat(Math.abs(distance1 - 21.0)).isLessThan(epsilon);
-            double distance2 = fastestRoute.get(2).getTotalDistance();
-            assertThat(Math.abs(distance2 - 21.0)).isLessThan(epsilon);
 
         }
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
### 길찾기 로직 수정
1. 길 찾기 로직은 cost (소요시간) 산정 시 distance에 일정 상수를 곱하여 산정하였습니다.
   - 이는 실제 소요시간과 차이가 있을 것으로 생각되어 길 찾기 도중 사용하던 weight으로 산정하도록 변경하였습니다.
2. 길 찾기 로직은 기존 출발점과 도착점 해발고도 영역을 벗어날 때에만 해발고도를 고려하였습니다.
   - 이 역시 실제 소요시간과 차이가 있을 것으로 생각되어, 모든 길의 해발고도 차이에 대해 연산하도록 구현하였습니다.
3. 위 두 가지 방식 변화로 인하여 소요시간이 급격히 증가하는 것을 방지하기 위해 상수(속력)를 수정하였습니다.
4. 잘못된 데이터로 인하여 너무 큰 영향을 끼치는 것을 방지하기 위해 LIMIT_RANGE 를 설정하였습니다.

## 🧪 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다, postman을 사용하지 않으면 관련 화면 캡쳐 -->
<img width="662" alt="image" src="https://github.com/user-attachments/assets/c7a6a633-04a9-417a-ab45-e29f2c4a17f3" />



## ✅ 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/