### PR TITLE
[UNI-366] fix : 휠체어, 전동휠체어가 존재하지 않을 때 상세경로 보기 비활성화

### DIFF
--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -165,7 +165,7 @@ const NavigationResultPage = () => {
 						setButtonState={setButtonState}
 					></BottomCardList>
 					<div
-						onClick={showDetailView}
+						onClick={routeList?.data[buttonState] ? showDetailView : () => {}}
 						className="w-full h-15 bg-primary-600 hover:bg-primary-700 active:bg-primary-700 transition-color duration-200 flex flex-col items-center justify-center -mb-[30px] mt-4"
 					>
 						<div className="text-white font-bold">상세경로 보기 </div>


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### 휠체어, 전동휠체어가 존재하지 않을 때 상세경로 보기 비활성화

```JSX
<div
      onClick={routeList?.data[buttonState] ? showDetailView : () => {}}
      aria-disabled={routeList?.data[buttonState] ? false : true}
      className={`w-full h-15 ${routeList?.data[buttonState] ? "bg-primary-600 hover:bg-primary-700 active:bg-primary-700" : "bg-gray-500"} transition-color duration-200 flex flex-col items-center justify-center -mb-[30px] mt-4`}
      >
      <div className="text-white font-bold">상세경로 보기 </div>
</div>
```

routeList?.data[buttonState]로 현재 길 존재 여부를 판단해서 조건에 맞게 동작하도록 했습니다.

## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과

### 버튼 비활성화

https://github.com/user-attachments/assets/198f2061-70c7-4019-9758-2ad7bc4ac183

### 버튼 클릭 시 동작

https://github.com/user-attachments/assets/93d9fc3b-ac97-4dcd-b6cb-884078b5c3c3

## ✅ 반영 브랜치
- fe