### PR TITLE
[UNI-369] fix : 바텀 시트 내린 상태에서 마커 클릭시 포지션이 밀리는 현상

### DIFF
--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -28,7 +28,7 @@ type MapProps = {
 	topPadding?: number;
 	bottomPadding?: number;
 	currentRouteIdx: number;
-	handleCautionMarkerClick: (index: number) => void;
+	handleCautionMarkerClick: (index: number, isDetailView: boolean) => void;
 	setCautionRouteIdx: Dispatch<SetStateAction<number>>;
 };
 
@@ -71,7 +71,13 @@ const NavigationMap = ({
 }: MapProps) => {
 	const { createAdvancedMarker, createPolyline } = useContext(MapContext);
 	const { mapRef, map } = useMap();
+
 	const buttonStateRef = useRef(buttonState);
+	const isDetailViewRef = useRef(isDetailView);
+
+	useEffect(() => {
+		isDetailViewRef.current = isDetailView;
+	}, [isDetailView]);
 
 	// Listener들이 항상 최신 buttonStateRef를 참조하도록 ref 사용
 	useEffect(() => {
@@ -214,7 +220,7 @@ const NavigationMap = ({
 				content: originMarkerElement,
 			},
 			() => {
-				handleCautionMarkerClick(0);
+				handleCautionMarkerClick(0, isDetailViewRef.current);
 			},
 		);
 
@@ -232,7 +238,10 @@ const NavigationMap = ({
 				content: destinationMarkerElement,
 			},
 			() => {
-				handleCautionMarkerClick(routeResult[buttonStateRef.current].routeDetails.length);
+				handleCautionMarkerClick(
+					routeResult[buttonStateRef.current].routeDetails.length,
+					isDetailViewRef.current,
+				);
 			},
 		);
 
@@ -295,7 +304,7 @@ const NavigationMap = ({
 						content: markerElement,
 					},
 					() => {
-						handleCautionMarkerClick(index + 1);
+						handleCautionMarkerClick(index + 1, isDetailViewRef.current);
 					},
 				);
 				if (marker) markers.push(marker);
@@ -348,11 +357,16 @@ const NavigationMap = ({
 					hasAnimation: true,
 				});
 
-				const marker = createAdvancedMarker({
-					map: map,
-					position: coordinates,
-					content: markerElement,
-				});
+				const marker = createAdvancedMarker(
+					{
+						map: map,
+						position: coordinates,
+						content: markerElement,
+					},
+					() => {
+						handleCautionMarkerClick(index + 1, isDetailViewRef.current);
+					},
+				);
 
 				if (marker) dyamicMarkersRef.current.push(marker);
 			});

--- a/uniro_frontend/src/container/animatedContainer.tsx
+++ b/uniro_frontend/src/container/animatedContainer.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { AnimatePresence, motion, MotionProps } from "framer-motion";
+import React, { useEffect } from "react";
+import { AnimatePresence, AnimationControls, motion, MotionProps } from "framer-motion";
 
 type Props = {
 	isVisible: boolean;
@@ -9,6 +9,7 @@ type Props = {
 	isTop?: boolean;
 	transition?: MotionProps["transition"];
 	motionProps?: MotionProps;
+	controls?: AnimationControls;
 };
 
 // default는 바텀에서 시작
@@ -20,14 +21,21 @@ const AnimatedContainer = ({
 	isTop = false,
 	transition = { duration: 0.3, type: "tween" },
 	motionProps = {},
+	controls,
 }: Props) => {
+	useEffect(() => {
+		if (isVisible) {
+			controls?.start({ y: 0, transition });
+		}
+	}, [isVisible, controls]);
+
 	return (
 		<AnimatePresence>
 			{isVisible && (
 				<motion.div
 					className={className}
 					initial={{ y: isTop ? -positionDelta : positionDelta }}
-					animate={{ y: 0 }}
+					animate={controls ?? { y: 0 }}
 					exit={{ y: isTop ? -positionDelta : positionDelta }}
 					transition={transition}
 					{...motionProps}


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### 직접 TopSheet를 올릴 수 있는 로직을 생성했습니다
```typescript
const raiseSheet = useCallback(() => {
          new Promise<void>((resolve) => {
	          controls.start({ y: 0, transition: { duration: 0.5 } });
	          resolve();
          }).then(() => {
	          setSheetHeight(MAX_SHEET_HEIGHT);
	          setTopBarHeight(PADDING_FOR_MAP_BOUNDARY);
          });
}, [controls]);

const handleCautionMarkerClick = async (index: number, isDetailView: boolean) => {
          if (isDetailView) {
	          await raiseSheet();
	          setTimeout(() => {
		          setCurrentRouteIdx(index);
		          setCautionRouteIdx(index);
	          }, 500);
	          return;
          }
          showDetailView();
          setCurrentRouteIdx(index);
          setTimeout(() => {
	          setCautionRouteIdx(index);
          }, 800);
};
```
controls가 바뀌지 않으면 동일한 함수를 참조해야 해서(handleCautionMarkerClick이 자체 클로저를 가져 controls가 바뀌면 작동하지 않음) useCallback을 걸어주었습니다.

sheet를 올리는 과정을 await로 동기적으로 처리할 수 있도록 Promise를 구현했습니다.

## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과

### AS IS

https://github.com/user-attachments/assets/2ceb6991-08d2-4c4f-ac0c-5c9fd4e3aa85

### TO BE

https://github.com/user-attachments/assets/9e4ba075-0819-4de3-a4eb-b1c3b18d2d5f

## ✅ 반영 브랜치
fe