### PR TITLE
[UNI-367] fix : SSE 종료 시점 하드코딩 변수 제거

### DIFF
--- a/uniro_frontend/src/pages/mapSSE.tsx
+++ b/uniro_frontend/src/pages/mapSSE.tsx
@@ -762,14 +762,10 @@ export default function MapSSEPage() {
 				const routes = transformAllRoutes({ coreRoutes, nodeInfos });
 				drawRoute(routes);
 				sseCounter.current += 1;
-				if (sseCounter.current === 11) {
+				if (sseCounter.current === batchSize) {
 					eventSource.close();
 				}
 			}
-		};
-
-		eventSource.onerror = (err) => {
-			console.log("ERROR");
 		};
 
 		return () => {

--- a/uniro_frontend/src/pages/mapSSE.tsx
+++ b/uniro_frontend/src/pages/mapSSE.tsx
@@ -768,6 +768,10 @@ export default function MapSSEPage() {
 			}
 		};
 
+		eventSource.onerror = () => {
+			sseCounter.current = 0;
+		};
+
 		return () => {
 			eventSource.close();
 		};


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

### SSE 종료 시점 하드코딩 변수 제거
batchSize로 몇 번의 이벤트가 수신될 지를 받아서 종료 시점을 선택합니다.


## 🧪 동작 화면

| SSE | Non - SSE |
|----------|------------|
| <video src="https://github.com/user-attachments/assets/7df35f5d-81e2-4e71-96fc-2c21e3bc15d0"/> | <video src="https://github.com/user-attachments/assets/c5885d28-474a-4bb2-b4b5-1c29f1a886f8" />

 - 초기 로딩 시간이 매우 빨라진 것을 확인할 수 있습니다.
 - SSE 동작이 안정된다면 메인 페이지를 교체할 예정입니다.