### PR TITLE
[UNI-371] fix : 위험 주의 요소 바텀시트 레이아웃 이동 해결

### DIFF
--- a/uniro_frontend/src/components/navigation/route/routeCard.tsx
+++ b/uniro_frontend/src/components/navigation/route/routeCard.tsx
@@ -106,7 +106,7 @@ export const RouteCard = ({
 					onClick={onClick}
 					className={`grid grid-cols-10 items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
 				>
-					<div className="flex flex-col min-w-10 flex-shrink-0  items-center justify-start space-y-1 col-span-1">
+					<div className="flex flex-col min-w-10 flex-shrink-0 items-center justify-start space-y-1 col-span-1">
 						<LeftIcon />
 						<div className="text-primary-400 text-kor-body3 text-[12px]">{formattedDistance}</div>
 					</div>
@@ -154,7 +154,7 @@ export const RouteCard = ({
 					onClick={onClick}
 					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
 				>
-					<div className="flex flex-col min-w-10 flex-shrink-0 items-center justify-start space-y-1">
+					<div className="flex flex-col min-w-10 flex-shrink-0 items-center justify-start space-y-1 col-span-1">
 						<DestinationIcon />
 						<div className="text-[#5F5F5F] text-kor-body3 text-[12px]">도착</div>
 					</div>
@@ -168,13 +168,13 @@ export const RouteCard = ({
 			return (
 				<div
 					onClick={onClick}
-					className={`flex flex-row items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+					className={`grid grid-cols-10 items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
 				>
-					<div className="flex flex-col min-w-10 flex-shrink-0 items-center justify-start space-y-1 pr-1">
+					<div className="flex flex-col min-w-10 flex-shrink-0 items-center justify-center space-y-1 col-span-1">
 						<CautionText />
 						<div className="text-system-orange text-kor-body3 text-[12px]">{formattedDistance}</div>
 					</div>
-					<div className="flex flex-row items-center justify-center pl-4 space-x-[14px]">
+					<div className="flex flex-row items-center justify-start ml-4 space-x-[14px] col-span-9">
 						<NumberIcon index={index} />
 						<div className="text-left text-kor-body1 max-sm:text-[12px] text-gray-900 word-break">
 							{cautionFactors && cautionFactors.length > 0
@@ -190,13 +190,13 @@ export const RouteCard = ({
 			return (
 				<div
 					onClick={onClick}
-					className={`flex flex-row items-center min-w-10 flex-shrink-0 justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
+					className={`grid grid-cols-10 items-center justify-start pl-8 py-5 transition-colors ${currentRouteIdx === index ? "bg-primary-100" : ""}`}
 				>
-					<div className="flex flex-col items-center justify-start space-y-1 pr-1">
+					<div className="flex flex-col min-w-10 items-center justify-center space-y-1">
 						<DangerText />
 						<div className="text-system-red text-kor-body3 text-[12px]">{formattedDistance}</div>
 					</div>
-					<div className="flex flex-row items-center justify-center pl-4 space-x-[14px]">
+					<div className="flex flex-row items-center justify-start ml-4 space-x-[14px] col-span-9">
 						<NumberIcon index={index} />
 						<div className="text-left text-kor-body1 max-sm:text-[12px] text-gray-900 overflow-x-auto">
 							{dangerFactors && dangerFactors.length > 0


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

방향을 주는 카드들과 Danger, Caution 카드들이 CSS가 달라 Grid 형태로 같게 수정했습니다.

## 💡 To Reviewer

감사합니다.

## 🧪 테스트 결과
### AS IS

<img width="459" alt="image" src="https://github.com/user-attachments/assets/30bac39a-408c-44b7-8ab9-6a05e0f348fd" />

### TO BE

<img width="447" alt="image" src="https://github.com/user-attachments/assets/0c6766e8-a87f-4f9b-9cda-4aaab2e1b7e9" />

## ✅ 반영 브랜치
fe