### PR TITLE
[UNI-53] fix : 새로운 길에 너무 많은 가중치를 부여하던 로직 변경

### DIFF
--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/common/constant/UniroConst.java
@@ -9,8 +9,7 @@ public final class UniroConst {
 	public static final double ELECTRIC_WHEELCHAIR_SECONDS_PER_MITER = 0.9;
 	public static final double EARTH_RADIUS = 6378137;
 	public static final double BUILDING_ROUTE_DISTANCE = 1e8;
-	public static final double LIMIT_RANGE = 200;
-	public static final double HEURISTIC_WEIGHT_NORMALIZATION_FACTOR = 10.0;
+	public static final double LIMIT_RANGE = 10;
 	public static final int STREAM_FETCH_SIZE = 2500;
 	//컴파일 상수를 보장하기 위한 코드
 	public static final String STREAM_FETCH_SIZE_AS_STRING = "" + STREAM_FETCH_SIZE;

--- a/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
+++ b/uniro_backend/src/main/java/com/softeer5/uniro_backend/map/service/RouteCalculator.java
@@ -244,22 +244,6 @@ public class RouteCalculator {
         return Math.pow(currentCautionCount,2);
     }
 
-    // A* 알고리즘의 휴리스틱 중 max,min 해발고도를 벗어나는 경우 가중치를 부여
-    private double getHeightHeuristicWeight(double maxHeight, double minHeight, Node nextNode, double routeDistance, RoadExclusionPolicy policy) {
-        if(policy==RoadExclusionPolicy.PEDES)return 0.0;
-        double currentHeight = nextNode.getHeight();
-        double diff = 0.0;
-        if(currentHeight > maxHeight) diff = currentHeight - maxHeight;
-        if(currentHeight < minHeight) diff = minHeight - currentHeight;
-        return calculateWeight(diff, routeDistance);
-    }
-
-    // 차이에 따른 가중치를 계산하는 메서드
-    private double calculateWeight(double diff, double routeDistance){
-        double result = (Math.pow(diff,2) * routeDistance) / HEURISTIC_WEIGHT_NORMALIZATION_FACTOR;
-        return result > LIMIT_RANGE ? 0 : result;
-    }
-
     // 길찾기 결과를 파싱하여 출발지 -> 도착지 형태로 재배열하는 메서드
     private List<Route> reorderRoute(Node startNode, Node endNode, Map<Long, Route> prevRoute){
         List<Route> shortestRoutes = new ArrayList<>();
@@ -309,16 +293,14 @@ public class RouteCalculator {
 
             double heightDiff = firstNode.getHeight() - secondNode.getHeight();
             if(heightDiff > 0){
-                heightIncreaseWeight += Math.exp(heightDiff) - 1;
+                heightIncreaseWeight += Math.max(LIMIT_RANGE ,Math.exp(heightDiff) - 1);
             }
             else{
-                heightDecreaseWeight += Math.exp(-heightDiff) - 1;
+                heightDecreaseWeight += Math.max(LIMIT_RANGE, Math.exp(-heightDiff) - 1);
             }
 
             routeInfoDTOS.add(RouteInfoResDTO.of(route, firstNode, secondNode));
         }
-        if(Math.abs(heightDecreaseWeight) > LIMIT_RANGE) heightDecreaseWeight = 0.0;
-        if(Math.abs(heightIncreaseWeight) > LIMIT_RANGE) heightIncreaseWeight = 0.0;
         return FastestRouteResultDTO.of(hasCaution,hasDanger,totalDistance,heightIncreaseWeight,heightDecreaseWeight,routeInfoDTOS);
     }
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
### 새로운 길에 높이가 바로 반영이 안되는 경우 가중치가 최대 200까지 산정될 수 있었던 문제를 해결하였습니다.