### PR TITLE
[UNI-373] fix : 길찾기 화면의 과도한 패딩을, 핸드폰 뷰에 맞춰서 재수정

### DIFF
--- a/uniro_frontend/src/component/NavgationMap.tsx
+++ b/uniro_frontend/src/component/NavgationMap.tsx
@@ -72,6 +72,8 @@ const NavigationMap = ({
 	const { createAdvancedMarker, createPolyline } = useContext(MapContext);
 	const { mapRef, map } = useMap();
 
+	const PADDING_FOR_MAP_BOUNDARY = window.innerWidth * 0.1;
+
 	const {
 		originMarkerElementWithName,
 		destinationMarkerElementWithName,
@@ -215,16 +217,16 @@ const NavigationMap = ({
 
 		map.fitBounds(activeBounds!, {
 			top: topPadding,
-			right: 150,
+			right: PADDING_FOR_MAP_BOUNDARY,
 			bottom: bottomPadding,
-			left: 150,
+			left: PADDING_FOR_MAP_BOUNDARY,
 		});
 		return () => {
 			map.fitBounds(activeBounds!, {
 				top: topPadding,
-				right: 150,
+				right: PADDING_FOR_MAP_BOUNDARY,
 				bottom: bottomPadding,
-				left: 150,
+				left: PADDING_FOR_MAP_BOUNDARY,
 			});
 		};
 	}, [map, bottomPadding, topPadding, currentRouteIdx, buttonState, compositeRoutes]);
@@ -453,9 +455,9 @@ const NavigationMap = ({
 		boundsRef.current = bounds;
 		map.fitBounds(bounds, {
 			top: topPadding,
-			right: 150,
+			right: PADDING_FOR_MAP_BOUNDARY,
 			bottom: bottomPadding,
-			left: 150,
+			left: PADDING_FOR_MAP_BOUNDARY,
 		});
 	}, [map, currentRouteIdx, buttonState, routeResult]);
 

--- a/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
+++ b/uniro_frontend/src/hooks/useNavigationBottomSheet.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const MAX_SHEET_HEIGHT = window.innerHeight * 0.7;
 const MIN_SHEET_HEIGHT = window.innerHeight * 0.35;
-const CLOSED_SHEET_HEIGHT = 0;
+const CLOSED_SHEET_HEIGHT = window.innerHeight * 0.2;
 const ERROR_MARGIN_OF_DRAG = 0.7;
 
 export const useNavigationBottomSheet = () => {

--- a/uniro_frontend/src/pages/navigationResult.tsx
+++ b/uniro_frontend/src/pages/navigationResult.tsx
@@ -24,9 +24,9 @@ import NavigationNavBar from "../components/navigation/navBar/navigationNavBar";
 import { useAnimationControls } from "framer-motion";
 
 const NavigationResultPage = () => {
-	const CLOSED_SHEET_HEIGHT = 0;
+	const CLOSED_SHEET_HEIGHT = window.innerHeight * 0.2;
 
-	const INITIAL_TOP_BAR_HEIGHT = 143;
+	const INITIAL_TOP_BAR_HEIGHT = 200;
 	const BOTTOM_SHEET_HANDLE_HEIGHT = 100;
 	const PADDING_FOR_MAP_BOUNDARY = 70;
 


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 구현
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 인프라, 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 변경 사항

fitBounds의 디폴트 패딩을 window width의 10%로 수정했습니다.
길 상세보기 후 다시 돌아갈 시 bottom padding이 0으로 설정되어 있을 때가 있어서, 그런 부분들을 수정했습니다.

## 💡 To Reviewer

감사합니다!

## 🧪 테스트 결과

### PC
https://github.com/user-attachments/assets/2844a8e1-b141-4f19-a366-9e1e7fff0c61

### Mobile
https://github.com/user-attachments/assets/e1611cee-4546-418d-94d8-a06234a4af67

## ✅ 반영 브랜치
fe